### PR TITLE
feat: self-hosted deployment pipeline with email access control

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+.github
+server/bin
+server/tmp
+e2e
+*.md
+!apps/web/README.md
+.env*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ MULTICA_CODEX_MODEL=
 MULTICA_CODEX_WORKDIR=
 MULTICA_CODEX_TIMEOUT=20m
 
+# Access control (leave both empty for open registration)
+ALLOWED_EMAILS=
+ALLOWED_EMAIL_DOMAINS=
+
 # Email (Resend)
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=noreply@multica.ai

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create env file
+        run: |
+          cat > .env.prod <<'ENVEOF'
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
+          FRONTEND_ORIGIN=${{ vars.FRONTEND_ORIGIN }}
+          CORS_ALLOWED_ORIGINS=${{ vars.CORS_ALLOWED_ORIGINS }}
+          LOG_LEVEL=${{ vars.LOG_LEVEL || 'info' }}
+          ALLOWED_EMAILS=${{ vars.ALLOWED_EMAILS }}
+          ALLOWED_EMAIL_DOMAINS=${{ vars.ALLOWED_EMAIL_DOMAINS }}
+          RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+          RESEND_FROM_EMAIL=${{ vars.RESEND_FROM_EMAIL || 'noreply@multica.ai' }}
+          S3_BUCKET=${{ vars.S3_BUCKET }}
+          S3_REGION=${{ vars.S3_REGION || 'us-west-2' }}
+          CLOUDFRONT_DOMAIN=${{ vars.CLOUDFRONT_DOMAIN }}
+          CLOUDFRONT_KEY_PAIR_ID=${{ vars.CLOUDFRONT_KEY_PAIR_ID }}
+          CLOUDFRONT_PRIVATE_KEY=${{ secrets.CLOUDFRONT_PRIVATE_KEY }}
+          COOKIE_DOMAIN=${{ vars.COOKIE_DOMAIN }}
+          LISTEN_PORT=${{ vars.LISTEN_PORT || '80' }}
+          PGDATA_DIR=${{ vars.PGDATA_DIR || './data/postgres' }}
+          ENVEOF
+
+      - name: Deploy
+        run: |
+          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build --remove-orphans
+
+      - name: Wait for health check
+        run: |
+          echo "Waiting for services to be healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:${LISTEN_PORT:-80}/health > /dev/null 2>&1; then
+              echo "Service is healthy!"
+              exit 0
+            fi
+            echo "Attempt $i/30 — waiting..."
+            sleep 5
+          done
+          echo "Health check failed after 150s"
+          docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=50
+          exit 1
+
+      - name: Cleanup env file
+        if: always()
+        run: rm -f .env.prod

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ _features/
 *.dmg
 *.app
 server/server
+
+# deployment data
+data/

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,49 @@
+# --- Dependencies ---
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json ./apps/web/
+
+RUN pnpm install --frozen-lockfile
+
+# --- Build ---
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/ ./apps/web/
+
+ENV NEXT_TELEMETRY_DISABLED=1
+# Same-domain: browser uses relative URLs, no NEXT_PUBLIC_* needed
+ENV NEXT_PUBLIC_API_URL=
+ENV NEXT_PUBLIC_WS_URL=
+
+RUN pnpm build
+
+# --- Runtime ---
+FROM node:22-alpine
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,7 @@ config({ path: resolve(__dirname, "../../.env") });
 const remoteApiUrl = process.env.REMOTE_API_URL || "http://localhost:8080";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   images: {
     formats: ["image/avif", "image/webp"],
     qualities: [75, 80, 85],

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,77 @@
+upstream frontend {
+    server frontend:3000;
+}
+
+upstream backend {
+    server backend:8080;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 50m;
+
+    # API and auth — route directly to Go backend
+    location /api/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /auth/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Health check
+    location = /health {
+        proxy_pass http://backend;
+    }
+
+    # WebSocket — direct to backend with upgrade support
+    location /ws {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+        proxy_send_timeout 86400;
+    }
+
+    # Everything else — Next.js frontend
+    location / {
+        proxy_pass http://frontend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# --- TLS configuration (uncomment and configure when ready) ---
+#
+# server {
+#     listen 80;
+#     server_name multica.example.com;
+#     return 301 https://$host$request_uri;
+# }
+#
+# server {
+#     listen 443 ssl http2;
+#     server_name multica.example.com;
+#
+#     ssl_certificate     /etc/nginx/ssl/cert.pem;
+#     ssl_certificate_key /etc/nginx/ssl/key.pem;
+#
+#     # ... same location blocks as above ...
+# }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,85 @@
+name: multica-prod
+
+x-database-url: &database-url
+  DATABASE_URL: postgres://${POSTGRES_USER:-multica}:${POSTGRES_PASSWORD:-multica}@postgres:5432/${POSTGRES_DB:-multica}?sslmode=disable
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-multica}
+      POSTGRES_USER: ${POSTGRES_USER:-multica}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-multica}
+    volumes:
+      - ${PGDATA_DIR:-./data/postgres}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-multica} -d ${POSTGRES_DB:-multica}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ["./migrate", "up"]
+    environment:
+      <<: *database-url
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      <<: *database-url
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      PORT: "8080"
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:?FRONTEND_ORIGIN is required}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      APP_ENV: production
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-noreply@multica.ai}
+      S3_BUCKET: ${S3_BUCKET:-}
+      S3_REGION: ${S3_REGION:-us-west-2}
+      CLOUDFRONT_DOMAIN: ${CLOUDFRONT_DOMAIN:-}
+      CLOUDFRONT_KEY_PAIR_ID: ${CLOUDFRONT_KEY_PAIR_ID:-}
+      CLOUDFRONT_PRIVATE_KEY: ${CLOUDFRONT_PRIVATE_KEY:-}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
+      ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}
+      ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  frontend:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    restart: unless-stopped
+    environment:
+      REMOTE_API_URL: http://backend:8080
+    depends_on:
+      backend:
+        condition: service_healthy
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "${LISTEN_PORT:-80}:80"
+    volumes:
+      - ./deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - frontend
+      - backend

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -202,6 +202,36 @@ func (h *Handler) findOrCreateUser(ctx context.Context, email string) (db.User, 
 	return user, nil
 }
 
+func isEmailAllowed(email string) bool {
+	allowedEmails := os.Getenv("ALLOWED_EMAILS")
+	allowedDomains := os.Getenv("ALLOWED_EMAIL_DOMAINS")
+
+	if allowedEmails == "" && allowedDomains == "" {
+		return true
+	}
+
+	if allowedEmails != "" {
+		for _, e := range strings.Split(allowedEmails, ",") {
+			if strings.TrimSpace(e) == email {
+				return true
+			}
+		}
+	}
+
+	if allowedDomains != "" {
+		if at := strings.LastIndex(email, "@"); at >= 0 {
+			domain := email[at+1:]
+			for _, d := range strings.Split(allowedDomains, ",") {
+				if strings.TrimSpace(d) == domain {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
 func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 	var req SendCodeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -212,6 +242,11 @@ func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 	email := strings.ToLower(strings.TrimSpace(req.Email))
 	if email == "" {
 		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	if !isEmailAllowed(email) {
+		writeError(w, http.StatusForbidden, "email not allowed")
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Add complete Docker-based deployment stack for self-hosting: frontend Dockerfile (Next.js standalone), `docker-compose.prod.yml` (postgres + backend + frontend + nginx), and nginx config for same-domain routing
- Add GitHub Actions deploy workflow with `workflow_dispatch` (manual trigger) targeting a self-hosted runner
- Add email access control via `ALLOWED_EMAILS` and `ALLOWED_EMAIL_DOMAINS` env vars to restrict who can register — checked at the `SendCode` entry point

## Architecture

```
Nginx (:80)
├── /api/*, /auth/*  → backend:8080 (direct)
├── /ws              → backend:8080 (WebSocket upgrade)
└── /*               → frontend:3000 (Next.js)
```

Same-domain deployment: browser uses relative URLs, no CORS needed. PostgreSQL data stored on the host filesystem (`./data/postgres` by default). `DATABASE_URL` auto-composed internally from postgres credentials.

## New files

| File | Purpose |
|------|---------|
| `apps/web/Dockerfile` | Multi-stage Next.js standalone build |
| `docker-compose.prod.yml` | Full stack with health checks and dependency ordering |
| `deploy/nginx.conf` | Same-domain reverse proxy with WebSocket support |
| `.github/workflows/deploy.yml` | Manual deploy to self-hosted runner |
| `.dockerignore` | Speed up Docker builds |

## Config changes

| File | Change |
|------|--------|
| `apps/web/next.config.ts` | Added `output: "standalone"` |
| `server/internal/handler/auth.go` | Added `isEmailAllowed()` check in `SendCode` |
| `.env.example` | Added `ALLOWED_EMAILS`, `ALLOWED_EMAIL_DOMAINS` |
| `.gitignore` | Added `data/` |

## Test plan

- [ ] `go vet ./...` passes (verified locally)
- [ ] Docker build for backend: `docker build -f Dockerfile .`
- [ ] Docker build for frontend: `docker build -f apps/web/Dockerfile .`
- [ ] `docker compose -f docker-compose.prod.yml up` starts all services
- [ ] Health check at `/health` returns `{"status":"ok"}`
- [ ] With `ALLOWED_EMAILS` set, non-listed emails get 403 on send-code
- [ ] With both env vars empty, open registration works as before


Made with [Cursor](https://cursor.com)