### PR TITLE
Improve CI/CD pipeline with environment protection and reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     needs: ci
     runs-on: self-hosted
+    environment: prod
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,16 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  LISTEN_PORT: ${{ vars.LISTEN_PORT || '80' }}
+
 jobs:
+  # Ensure CI passes before deploying
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   deploy:
+    needs: ci
     runs-on: self-hosted
     steps:
       - name: Checkout
@@ -44,7 +52,7 @@ jobs:
         run: |
           echo "Waiting for services to be healthy..."
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:${LISTEN_PORT:-80}/health > /dev/null 2>&1; then
+            if curl -sf http://localhost:${LISTEN_PORT}/health > /dev/null 2>&1; then
               echo "Service is healthy!"
               exit 0
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
This PR enhances the deployment workflow by adding CI/CD safeguards and improving configuration management. The changes ensure that CI passes before production deployments and make the CI workflow reusable across different contexts.

## Key Changes
- **Added CI gate to production deployments**: The `deploy` job now requires the `ci` job to pass before proceeding, preventing broken code from reaching production
- **Made CI workflow reusable**: Added `workflow_call` trigger to `ci.yml` to allow it to be called from other workflows
- **Added environment protection**: Specified `environment: prod` on the deploy job to enforce environment-level protections and approval requirements
- **Centralized port configuration**: Moved `LISTEN_PORT` to workflow-level environment variables with a sensible default (port 80), eliminating the need for inline defaults
- **Updated action versions**: Bumped `actions/checkout` from v4 to v6 in the release workflow for consistency and security updates
- **Simplified health check logic**: Removed the inline default fallback in the health check curl command since the port is now defined at the workflow level

## Implementation Details
- The `LISTEN_PORT` environment variable uses GitHub's variable syntax with a fallback default, allowing it to be overridden via repository variables
- The CI job is now a reusable workflow that can be called from the deploy workflow using `uses: ./.github/workflows/ci.yml`
- The `needs: ci` dependency ensures sequential execution and prevents deployment if CI fails

https://claude.ai/code/session_015PoWGiUVWERt4uEevcxLit