### PR TITLE
fix(docker): fix frontend image build and add local prod stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: dev daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down
+.PHONY: dev daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down docker docker-backend docker-frontend prod-local prod-local-down prod-local-logs
+
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -153,6 +154,32 @@ migrate-down:
 
 sqlc:
 	cd server && sqlc generate
+
+# Docker images (same Dockerfiles as CI)
+docker-backend:
+	docker build -t multica-backend --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -f Dockerfile .
+
+docker-frontend:
+	docker build -t multica-frontend -f apps/web/Dockerfile .
+
+docker: docker-backend docker-frontend
+
+PROD_COMPOSE := docker compose --env-file $(ENV_FILE) -f docker-compose.prod.yml
+
+# Local prod: build images, tag to match prod compose, start full stack
+prod-local: docker
+	$(REQUIRE_ENV)
+	docker tag multica-backend ghcr.io/nullne/multica/backend:latest
+	docker tag multica-frontend ghcr.io/nullne/multica/frontend:latest
+	$(PROD_COMPOSE) up -d
+	@echo ""
+	@echo "✓ Production stack running at http://localhost:$${LISTEN_PORT:-80}"
+
+prod-local-down:
+	$(PROD_COMPOSE) down
+
+prod-local-logs:
+	$(PROD_COMPOSE) logs -f
 
 # Cleanup
 clean:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
-# --- Dependencies ---
-FROM node:22-alpine AS deps
+# --- Build ---
+FROM node:22-alpine AS builder
 
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
@@ -10,21 +10,9 @@ COPY apps/web/package.json ./apps/web/
 
 RUN pnpm install --frozen-lockfile
 
-# --- Build ---
-FROM node:22-alpine AS builder
-
-RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
-
-WORKDIR /app
-
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
-
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/ ./apps/web/
 
 ENV NEXT_TELEMETRY_DISABLED=1
-# Same-domain: browser uses relative URLs, no NEXT_PUBLIC_* needed
 ENV NEXT_PUBLIC_API_URL=
 ENV NEXT_PUBLIC_WS_URL=
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "dotenv": "^17.3.1",
     "embla-carousel-react": "^8.6.0",
     "emoji-mart": "^5.6.0",
     "input-otp": "^1.4.2",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,11 +49,15 @@ services:
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}
       ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-}
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      http_proxy: ""
+      https_proxy: ""
     depends_on:
       migrate:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      test: ["CMD-SHELL", "unset http_proxy HTTP_PROXY https_proxy HTTPS_PROXY; wget -q --spider http://localhost:8080/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.3)


### PR DESCRIPTION
## Summary

- Add `dotenv` as an explicit dependency in `apps/web/package.json` to fix missing module error during Docker build
- Merge Dockerfile deps+builder into a single stage to fix pnpm symlink breakage when copying `node_modules` across Docker stages
- Add `make docker` / `make prod-local` targets for building and running the full prod stack locally
- Clear proxy env vars in backend container to prevent Docker Desktop proxy from intercepting outbound API calls (Resend, healthcheck, etc.)
- Fix healthcheck to work with BusyBox `wget` which ignores `no_proxy`

## Test plan

- [x] `make docker` builds both images successfully
- [x] `make prod-local` starts full stack (postgres, backend, frontend, nginx)
- [x] Login flow works end-to-end with Resend verification
- [ ] CI `images (frontend, apps/web/Dockerfile, .)` job passes