### PR TITLE
feat(agent): add Cursor Agent CLI support

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -92,8 +92,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCODE_MODEL")),
 		}
 	}
+	cursorPath := envOrDefault("MULTICA_CURSOR_PATH", "cursor-agent")
+	if _, err := exec.LookPath(cursorPath); err == nil {
+		agents["cursor"] = AgentEntry{
+			Path:  cursorPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_CURSOR_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, or opencode and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, or cursor-agent and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -14,6 +14,7 @@ import (
 // Claude:   skills → {workDir}/.claude/skills/{name}/SKILL.md  (native discovery)
 // Codex:    skills → handled separately in Prepare via codex-home
 // OpenCode: skills → {workDir}/.config/opencode/skills/{name}/SKILL.md  (native discovery)
+// Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Default:  skills → {workDir}/.agent_context/skills/{name}/SKILL.md
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv) error {
 	contextDir := filepath.Join(workDir, ".agent_context")
@@ -54,6 +55,9 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 	case "opencode":
 		// OpenCode natively discovers skills from .config/opencode/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".config", "opencode", "skills")
+	case "cursor":
+		// Cursor Agent discovers skills from .cursor/skills/ in the workdir.
+		skillsDir = filepath.Join(workDir, ".cursor", "skills")
 	default:
 		// Fallback: write to .agent_context/skills/ (referenced by meta config).
 		skillsDir = filepath.Join(workDir, ".agent_context", "skills")

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -583,6 +583,151 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 	}
 }
 
+func TestWriteContextFilesCursorNativeSkills(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID: "cursor-skill-test",
+		AgentSkills: []SkillContextForEnv{
+			{
+				Name:    "Go Conventions",
+				Content: "Follow Go conventions.",
+				Files: []SkillFileContextForEnv{
+					{Path: "templates/example.go", Content: "package main"},
+				},
+			},
+		},
+	}
+
+	if err := writeContextFiles(dir, "cursor", ctx); err != nil {
+		t.Fatalf("writeContextFiles failed: %v", err)
+	}
+
+	// Skills should be in .cursor/skills/ (native discovery).
+	skillMd, err := os.ReadFile(filepath.Join(dir, ".cursor", "skills", "go-conventions", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read .cursor/skills/go-conventions/SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
+		t.Error("SKILL.md missing content")
+	}
+
+	// Supporting files should also be under .cursor/skills/.
+	supportFile, err := os.ReadFile(filepath.Join(dir, ".cursor", "skills", "go-conventions", "templates", "example.go"))
+	if err != nil {
+		t.Fatalf("failed to read supporting file: %v", err)
+	}
+	if string(supportFile) != "package main" {
+		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
+	}
+
+	// .agent_context/skills/ should NOT exist for Cursor.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
+		t.Error("expected .agent_context/skills/ to NOT exist for Cursor provider")
+	}
+
+	// issue_context.md should still be in .agent_context/.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "issue_context.md")); os.IsNotExist(err) {
+		t.Error("expected .agent_context/issue_context.md to exist")
+	}
+}
+
+func TestInjectRuntimeConfigCursor(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID:     "test-issue-id",
+		AgentSkills: []SkillContextForEnv{{Name: "Coding", Content: "Write good code."}},
+	}
+
+	if err := InjectRuntimeConfig(dir, "cursor", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	// Cursor uses .cursor/rules/multica.md.
+	content, err := os.ReadFile(filepath.Join(dir, ".cursor", "rules", "multica.md"))
+	if err != nil {
+		t.Fatalf("failed to read .cursor/rules/multica.md: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "Multica Agent Runtime") {
+		t.Error(".cursor/rules/multica.md missing meta skill header")
+	}
+	if !strings.Contains(s, "Coding") {
+		t.Error(".cursor/rules/multica.md missing skill name")
+	}
+	if !strings.Contains(s, "discovered automatically") {
+		t.Error(".cursor/rules/multica.md missing native skill discovery hint")
+	}
+
+	// CLAUDE.md and AGENTS.md should NOT exist.
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Error("expected CLAUDE.md to NOT exist for Cursor provider")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("expected AGENTS.md to NOT exist for Cursor provider")
+	}
+}
+
+func TestPrepareWithRepoContextCursor(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	taskCtx := TaskContextForEnv{
+		IssueID: "e5f6a7b8-c9d0-1234-efab-567890123456",
+		Repos: []RepoContextForEnv{
+			{URL: "https://github.com/org/backend", Description: "Go backend"},
+		},
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-test-cursor",
+		TaskID:         "e5f6a7b8-c9d0-1234-efab-567890123456",
+		AgentName:      "Cursor Agent",
+		Provider:       "cursor",
+		Task:           taskCtx,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := InjectRuntimeConfig(env.WorkDir, "cursor", taskCtx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	// Workdir should only contain expected entries.
+	entries, err := os.ReadDir(env.WorkDir)
+	if err != nil {
+		t.Fatalf("failed to read workdir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name != ".agent_context" && name != ".cursor" {
+			t.Errorf("unexpected entry in workdir: %s", name)
+		}
+	}
+
+	// .cursor/rules/multica.md should contain repo info.
+	content, err := os.ReadFile(filepath.Join(env.WorkDir, ".cursor", "rules", "multica.md"))
+	if err != nil {
+		t.Fatalf("failed to read .cursor/rules/multica.md: %v", err)
+	}
+	s := string(content)
+	for _, want := range []string{
+		"multica repo checkout",
+		"https://github.com/org/backend",
+		"Go backend",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf(".cursor/rules/multica.md missing %q", want)
+		}
+	}
+}
+
 func TestInjectRuntimeConfigUnknownProvider(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -13,6 +13,7 @@ import (
 // For Claude:   writes {workDir}/CLAUDE.md  (skills discovered natively from .claude/skills/)
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
+// For Cursor:   writes {workDir}/.cursor/rules/multica.md  (Cursor discovers rules from .cursor/rules/)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
@@ -21,6 +22,12 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
 	case "codex", "opencode":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
+	case "cursor":
+		rulesDir := filepath.Join(workDir, ".cursor", "rules")
+		if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+			return fmt.Errorf("create .cursor/rules dir: %w", err)
+		}
+		return os.WriteFile(filepath.Join(rulesDir, "multica.md"), []byte(content), 0o644)
 	default:
 		// Unknown provider — skip config injection, prompt-only mode.
 		return nil
@@ -115,8 +122,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "opencode":
-			// Codex and OpenCode discover skills natively from their respective paths — just list names.
+		case "codex", "opencode", "cursor":
+			// Codex, OpenCode, and Cursor discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		default:
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -195,7 +195,7 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 	}
 
 	// Exclude agent context files from git tracking.
-	for _, pattern := range []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".config/opencode"} {
+	for _, pattern := range []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".config/opencode", ".cursor"} {
 		_ = excludeFromGit(worktreePath, pattern)
 	}
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -79,7 +79,7 @@ type Config struct {
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "opencode".
+// Supported types: "claude", "codex", "opencode", "cursor".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -92,8 +92,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &codexBackend{cfg: cfg}, nil
 	case "opencode":
 		return &opencodeBackend{cfg: cfg}, nil
+	case "cursor":
+		return &cursorBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, cursor)", agentType)
 	}
 }
 

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -1,0 +1,279 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// cursorBackend implements Backend by spawning the Cursor Agent CLI
+// with --output-format stream-json, similar to Claude Code.
+type cursorBackend struct {
+	cfg Config
+}
+
+func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "cursor-agent"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("cursor-agent executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--force",
+		"--trust",
+	}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	if opts.MaxTurns > 0 {
+		b.cfg.Logger.Warn("cursor-agent does not support --max-turns; ignoring", "maxTurns", opts.MaxTurns)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("cursor stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[cursor:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start cursor-agent: %w", err)
+	}
+
+	b.cfg.Logger.Info("cursor-agent started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		var output strings.Builder
+		var sessionID string
+		finalStatus := "completed"
+		var finalError string
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var msg cursorSDKMessage
+			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+				continue
+			}
+
+			switch msg.Type {
+			case "assistant":
+				b.handleAssistant(msg, msgCh, &output)
+			case "user":
+				b.handleUser(msg, msgCh)
+			case "system":
+				if msg.SessionID != "" {
+					sessionID = msg.SessionID
+				}
+				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
+			case "result":
+				sessionID = msg.SessionID
+				if msg.ResultText != "" {
+					output.Reset()
+					output.WriteString(msg.ResultText)
+				}
+				if msg.IsError {
+					finalStatus = "failed"
+					finalError = msg.ResultText
+				}
+			case "tool_call":
+				b.handleToolCall(msg, msgCh, &output)
+			}
+		}
+
+		// Wait for process exit.
+		exitErr := cmd.Wait()
+		duration := time.Since(startTime)
+
+		if runCtx.Err() == context.DeadlineExceeded {
+			finalStatus = "timeout"
+			finalError = fmt.Sprintf("cursor-agent timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			finalStatus = "aborted"
+			finalError = "execution cancelled"
+		} else if exitErr != nil && finalStatus == "completed" {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("cursor-agent exited with error: %v", exitErr)
+		}
+
+		b.cfg.Logger.Info("cursor-agent finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     output.String(),
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  sessionID,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func (b *cursorBackend) handleAssistant(msg cursorSDKMessage, ch chan<- Message, output *strings.Builder) {
+	var content cursorMessageContent
+	if err := json.Unmarshal(msg.Message, &content); err != nil {
+		return
+	}
+
+	for _, block := range content.Content {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				output.WriteString(block.Text)
+				trySend(ch, Message{Type: MessageText, Content: block.Text})
+			}
+		case "thinking":
+			if block.Text != "" {
+				trySend(ch, Message{Type: MessageThinking, Content: block.Text})
+			}
+		case "tool_use":
+			var input map[string]any
+			if block.Input != nil {
+				_ = json.Unmarshal(block.Input, &input)
+			}
+			trySend(ch, Message{
+				Type:   MessageToolUse,
+				Tool:   block.Name,
+				CallID: block.ID,
+				Input:  input,
+			})
+		}
+	}
+}
+
+func (b *cursorBackend) handleUser(msg cursorSDKMessage, ch chan<- Message) {
+	var content cursorMessageContent
+	if err := json.Unmarshal(msg.Message, &content); err != nil {
+		return
+	}
+
+	for _, block := range content.Content {
+		if block.Type == "tool_result" {
+			resultStr := ""
+			if block.Content != nil {
+				resultStr = string(block.Content)
+			}
+			trySend(ch, Message{
+				Type:   MessageToolResult,
+				CallID: block.ToolUseID,
+				Output: resultStr,
+			})
+		}
+	}
+}
+
+func (b *cursorBackend) handleToolCall(msg cursorSDKMessage, ch chan<- Message, output *strings.Builder) {
+	// Cursor emits tool_call events with subtype "started" and "completed".
+	var tc cursorToolCallEvent
+	if err := json.Unmarshal(msg.ToolCall, &tc); err != nil {
+		return
+	}
+
+	switch msg.Subtype {
+	case "started":
+		var input map[string]any
+		if tc.Input != nil {
+			_ = json.Unmarshal(tc.Input, &input)
+		}
+		trySend(ch, Message{
+			Type:   MessageToolUse,
+			Tool:   tc.ToolType,
+			CallID: tc.ID,
+			Input:  input,
+		})
+	case "completed":
+		resultStr := ""
+		if tc.Output != nil {
+			resultStr = string(tc.Output)
+		}
+		trySend(ch, Message{
+			Type:   MessageToolResult,
+			Tool:   tc.ToolType,
+			CallID: tc.ID,
+			Output: resultStr,
+		})
+	}
+}
+
+// ── Cursor SDK JSON types ──
+
+// cursorSDKMessage represents a single JSON line from cursor-agent --output-format stream-json.
+// The format closely mirrors Claude Code's stream-json output, with an additional
+// "tool_call" event type.
+type cursorSDKMessage struct {
+	Type      string          `json:"type"`
+	Subtype   string          `json:"subtype,omitempty"`
+	Message   json.RawMessage `json:"message,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
+
+	// result fields
+	ResultText string  `json:"result,omitempty"`
+	IsError    bool    `json:"is_error,omitempty"`
+	DurationMs float64 `json:"duration_ms,omitempty"`
+
+	// tool_call fields
+	ToolCall json.RawMessage `json:"tool_call,omitempty"`
+}
+
+type cursorMessageContent struct {
+	Role    string               `json:"role"`
+	Content []cursorContentBlock `json:"content"`
+}
+
+type cursorContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+}
+
+type cursorToolCallEvent struct {
+	ID       string          `json:"id,omitempty"`
+	ToolType string          `json:"tool_type,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+	Output   json.RawMessage `json:"output,omitempty"`
+}

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -1,0 +1,264 @@
+package agent
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewReturnsCursorBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("cursor", Config{ExecutablePath: "/nonexistent/cursor-agent"})
+	if err != nil {
+		t.Fatalf("New(cursor) error: %v", err)
+	}
+	if _, ok := b.(*cursorBackend); !ok {
+		t.Fatalf("expected *cursorBackend, got %T", b)
+	}
+}
+
+func TestCursorHandleAssistantText(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type: "assistant",
+		Message: mustMarshal(t, cursorMessageContent{
+			Role: "assistant",
+			Content: []cursorContentBlock{
+				{Type: "text", Text: "Hello from cursor"},
+			},
+		}),
+	}
+
+	b.handleAssistant(msg, ch, &output)
+
+	if output.String() != "Hello from cursor" {
+		t.Fatalf("expected output 'Hello from cursor', got %q", output.String())
+	}
+	select {
+	case m := <-ch:
+		if m.Type != MessageText || m.Content != "Hello from cursor" {
+			t.Fatalf("unexpected message: %+v", m)
+		}
+	default:
+		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCursorHandleAssistantToolUse(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type: "assistant",
+		Message: mustMarshal(t, cursorMessageContent{
+			Role: "assistant",
+			Content: []cursorContentBlock{
+				{
+					Type:  "tool_use",
+					ID:    "call-1",
+					Name:  "Read",
+					Input: mustMarshal(t, map[string]any{"path": "/tmp/foo"}),
+				},
+			},
+		}),
+	}
+
+	b.handleAssistant(msg, ch, &output)
+
+	if output.String() != "" {
+		t.Fatalf("tool_use should not add to output, got %q", output.String())
+	}
+	select {
+	case m := <-ch:
+		if m.Type != MessageToolUse || m.Tool != "Read" || m.CallID != "call-1" {
+			t.Fatalf("unexpected message: %+v", m)
+		}
+		if m.Input["path"] != "/tmp/foo" {
+			t.Fatalf("expected input path /tmp/foo, got %v", m.Input["path"])
+		}
+	default:
+		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCursorHandleAssistantThinking(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type: "assistant",
+		Message: mustMarshal(t, cursorMessageContent{
+			Role: "assistant",
+			Content: []cursorContentBlock{
+				{Type: "thinking", Text: "Let me think..."},
+			},
+		}),
+	}
+
+	b.handleAssistant(msg, ch, &output)
+
+	if output.String() != "" {
+		t.Fatalf("thinking should not add to output, got %q", output.String())
+	}
+	select {
+	case m := <-ch:
+		if m.Type != MessageThinking || m.Content != "Let me think..." {
+			t.Fatalf("unexpected message: %+v", m)
+		}
+	default:
+		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCursorHandleUserToolResult(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+
+	msg := cursorSDKMessage{
+		Type: "user",
+		Message: mustMarshal(t, cursorMessageContent{
+			Role: "user",
+			Content: []cursorContentBlock{
+				{
+					Type:      "tool_result",
+					ToolUseID: "call-1",
+					Content:   mustMarshal(t, "file contents here"),
+				},
+			},
+		}),
+	}
+
+	b.handleUser(msg, ch)
+
+	select {
+	case m := <-ch:
+		if m.Type != MessageToolResult || m.CallID != "call-1" {
+			t.Fatalf("unexpected message: %+v", m)
+		}
+	default:
+		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCursorHandleToolCallStarted(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type:    "tool_call",
+		Subtype: "started",
+		ToolCall: mustMarshal(t, cursorToolCallEvent{
+			ID:       "tc-1",
+			ToolType: "shellToolCall",
+			Input:    mustMarshal(t, map[string]any{"command": "ls -la"}),
+		}),
+	}
+
+	b.handleToolCall(msg, ch, &output)
+
+	select {
+	case m := <-ch:
+		if m.Type != MessageToolUse || m.Tool != "shellToolCall" || m.CallID != "tc-1" {
+			t.Fatalf("unexpected message: %+v", m)
+		}
+		if m.Input["command"] != "ls -la" {
+			t.Fatalf("expected input command 'ls -la', got %v", m.Input["command"])
+		}
+	default:
+		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCursorHandleToolCallCompleted(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type:    "tool_call",
+		Subtype: "completed",
+		ToolCall: mustMarshal(t, cursorToolCallEvent{
+			ID:       "tc-1",
+			ToolType: "shellToolCall",
+			Output:   mustMarshal(t, "total 42\ndrwxr-xr-x ..."),
+		}),
+	}
+
+	b.handleToolCall(msg, ch, &output)
+
+	select {
+	case m := <-ch:
+		if m.Type != MessageToolResult || m.Tool != "shellToolCall" || m.CallID != "tc-1" {
+			t.Fatalf("unexpected message: %+v", m)
+		}
+	default:
+		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCursorHandleAssistantInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type:    "assistant",
+		Message: json.RawMessage(`invalid json`),
+	}
+
+	// Should not panic
+	b.handleAssistant(msg, ch, &output)
+
+	if output.String() != "" {
+		t.Fatalf("expected empty output for invalid JSON, got %q", output.String())
+	}
+	select {
+	case m := <-ch:
+		t.Fatalf("expected no message, got %+v", m)
+	default:
+	}
+}
+
+func TestCursorHandleToolCallInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	var output strings.Builder
+
+	msg := cursorSDKMessage{
+		Type:     "tool_call",
+		Subtype:  "started",
+		ToolCall: json.RawMessage(`invalid json`),
+	}
+
+	// Should not panic
+	b.handleToolCall(msg, ch, &output)
+
+	select {
+	case m := <-ch:
+		t.Fatalf("expected no message, got %+v", m)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
- Add `cursor-agent` as a new code agent provider alongside `claude`, `codex`, and `opencode`
- Implement `cursorBackend` that spawns `cursor-agent -p --output-format stream-json --force --trust` and parses the streaming JSON output (assistant/user/result/tool_call events)
- Auto-detect `cursor-agent` on PATH in daemon config (`MULTICA_CURSOR_PATH`, `MULTICA_CURSOR_MODEL` env vars supported)
- Inject runtime config into `.cursor/rules/multica.md` and skills into `.cursor/skills/` for native discovery

## Changes
- `server/pkg/agent/cursor.go` — New cursor backend implementation
- `server/pkg/agent/cursor_test.go` — Unit tests for all event handlers
- `server/pkg/agent/agent.go` — Register cursor in the factory
- `server/internal/daemon/config.go` — Auto-detect cursor-agent CLI
- `server/internal/daemon/execenv/context.go` — Cursor skills directory
- `server/internal/daemon/execenv/runtime_config.go` — Cursor rules injection

## Test plan
- [x] All existing tests pass (agent + execenv packages)
- [x] New cursor-specific unit tests pass (8 tests covering text, tool_use, thinking, tool_result, tool_call started/completed, invalid JSON handling)
- [x] Full server build succeeds
- [ ] Manual test with `cursor-agent` CLI installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)