### PR TITLE
feat(agent): add per-agent model selection

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -125,6 +125,7 @@ function CreateAgentDialog({
 }) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [model, setModel] = useState("");
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(runtimes[0]?.id ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
   const [creating, setCreating] = useState(false);
@@ -146,6 +147,7 @@ function CreateAgentDialog({
         name: name.trim(),
         description: description.trim(),
         runtime_id: selectedRuntime.id,
+        runtime_config: model.trim() ? { model: model.trim() } : undefined,
         visibility,
         triggers: [
           { id: generateId(), type: "on_assign", enabled: true, config: {} },
@@ -190,6 +192,17 @@ function CreateAgentDialog({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What does this agent do?"
+              className="mt-1"
+            />
+          </div>
+
+          <div>
+            <Label className="text-xs text-muted-foreground">Model</Label>
+            <Input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="e.g. claude-sonnet-4-20250514 (optional, uses daemon default)"
               className="mt-1"
             />
           </div>
@@ -1190,6 +1203,7 @@ function SettingsTab({
 }) {
   const [name, setName] = useState(agent.name);
   const [description, setDescription] = useState(agent.description ?? "");
+  const [model, setModel] = useState((agent.runtime_config?.model as string) ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>(agent.visibility);
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
   const [saving, setSaving] = useState(false);
@@ -1213,6 +1227,7 @@ function SettingsTab({
   const dirty =
     name !== agent.name ||
     description !== (agent.description ?? "") ||
+    model !== ((agent.runtime_config?.model as string) ?? "") ||
     visibility !== agent.visibility ||
     maxTasks !== agent.max_concurrent_tasks;
 
@@ -1223,7 +1238,8 @@ function SettingsTab({
     }
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks });
+      const rc = { ...agent.runtime_config, model: model.trim() || undefined };
+      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks, runtime_config: rc });
       toast.success("Settings saved");
     } catch {
       toast.error("Failed to save settings");
@@ -1284,6 +1300,19 @@ function SettingsTab({
           placeholder="What does this agent do?"
           className="mt-1"
         />
+      </div>
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Model</Label>
+        <Input
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder="e.g. claude-sonnet-4-20250514 (optional, uses daemon default)"
+          className="mt-1"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Override the default model for this agent. Leave empty to use daemon default.
+        </p>
       </div>
 
       <div>

--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -115,6 +115,11 @@ const MODEL_SUGGESTIONS = [
   { group: "OpenAI", models: ["o3", "gpt-4.1", "gpt-4.1-mini", "codex-mini-latest", "o4-mini"] },
 ];
 
+function defaultModelLabel(runtime: RuntimeDevice | null | undefined): string {
+  const dm = runtime?.metadata?.default_model;
+  return dm ? `Default (${dm})` : "Default (from daemon config)";
+}
+
 function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
@@ -216,7 +221,7 @@ function CreateAgentDialog({
             <Popover open={modelOpen} onOpenChange={setModelOpen}>
               <PopoverTrigger className="flex w-full items-center justify-between rounded-lg border border-border bg-background px-3 py-2 mt-1.5 text-left text-sm transition-colors hover:bg-muted">
                 <span className={model ? "text-foreground" : "text-muted-foreground"}>
-                  {model || "Default (from daemon config)"}
+                  {model || defaultModelLabel(selectedRuntime)}
                 </span>
                 <ChevronDown className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${modelOpen ? "rotate-180" : ""}`} />
               </PopoverTrigger>
@@ -246,7 +251,7 @@ function CreateAgentDialog({
                         data-checked={!model}
                         onSelect={() => { setModel(""); setModelSearch(""); setModelOpen(false); }}
                       >
-                        Default (from daemon config)
+                        {defaultModelLabel(selectedRuntime)}
                       </CommandItem>
                     </CommandGroup>
                     {MODEL_SUGGESTIONS.map((group) => (
@@ -1370,7 +1375,7 @@ function SettingsTab({
         <Popover open={modelOpen} onOpenChange={setModelOpen}>
           <PopoverTrigger className="flex w-full items-center justify-between rounded-lg border border-border bg-background px-3 py-2 mt-1.5 text-left text-sm transition-colors hover:bg-muted">
             <span className={model ? "text-foreground" : "text-muted-foreground"}>
-              {model || "Default (from daemon config)"}
+              {model || defaultModelLabel(runtimeDevice)}
             </span>
             <ChevronDown className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${modelOpen ? "rotate-180" : ""}`} />
           </PopoverTrigger>
@@ -1400,7 +1405,7 @@ function SettingsTab({
                     data-checked={!model}
                     onSelect={() => { setModel(""); setModelSearch(""); setModelOpen(false); }}
                   >
-                    Default (from daemon config)
+                    {defaultModelLabel(runtimeDevice)}
                   </CommandItem>
                 </CommandGroup>
                 {MODEL_SUGGESTIONS.map((group) => (

--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -67,6 +67,14 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
@@ -102,6 +110,11 @@ const taskStatusConfig: Record<string, { label: string; icon: typeof CheckCircle
 };
 
 
+const MODEL_SUGGESTIONS = [
+  { group: "Claude", models: ["claude-sonnet-4-20250514", "claude-opus-4-20250514", "claude-haiku-4-20250506"] },
+  { group: "OpenAI", models: ["o3", "gpt-4.1", "gpt-4.1-mini", "codex-mini-latest", "o4-mini"] },
+];
+
 function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
@@ -126,6 +139,8 @@ function CreateAgentDialog({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [model, setModel] = useState("");
+  const [modelOpen, setModelOpen] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(runtimes[0]?.id ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
   const [creating, setCreating] = useState(false);
@@ -198,13 +213,59 @@ function CreateAgentDialog({
 
           <div>
             <Label className="text-xs text-muted-foreground">Model</Label>
-            <Input
-              type="text"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder="e.g. claude-sonnet-4-20250514 (optional, uses daemon default)"
-              className="mt-1"
-            />
+            <Popover open={modelOpen} onOpenChange={setModelOpen}>
+              <PopoverTrigger className="flex w-full items-center justify-between rounded-lg border border-border bg-background px-3 py-2 mt-1.5 text-left text-sm transition-colors hover:bg-muted">
+                <span className={model ? "text-foreground" : "text-muted-foreground"}>
+                  {model || "Default (from daemon config)"}
+                </span>
+                <ChevronDown className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${modelOpen ? "rotate-180" : ""}`} />
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-[var(--anchor-width)] p-0">
+                <Command shouldFilter={true}>
+                  <CommandInput
+                    placeholder="Search or type a model name..."
+                    value={modelSearch}
+                    onValueChange={setModelSearch}
+                  />
+                  <CommandList>
+                    <CommandEmpty>
+                      {modelSearch.trim() ? (
+                        <button
+                          type="button"
+                          className="text-primary hover:underline"
+                          onClick={() => { setModel(modelSearch.trim()); setModelSearch(""); setModelOpen(false); }}
+                        >
+                          Use &quot;{modelSearch.trim()}&quot;
+                        </button>
+                      ) : (
+                        <span className="text-muted-foreground">Type a model name</span>
+                      )}
+                    </CommandEmpty>
+                    <CommandGroup heading="Default">
+                      <CommandItem
+                        data-checked={!model}
+                        onSelect={() => { setModel(""); setModelSearch(""); setModelOpen(false); }}
+                      >
+                        Default (from daemon config)
+                      </CommandItem>
+                    </CommandGroup>
+                    {MODEL_SUGGESTIONS.map((group) => (
+                      <CommandGroup key={group.group} heading={group.group}>
+                        {group.models.map((m) => (
+                          <CommandItem
+                            key={m}
+                            data-checked={model === m}
+                            onSelect={() => { setModel(m); setModelSearch(""); setModelOpen(false); }}
+                          >
+                            {m}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    ))}
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
           </div>
 
           <div>
@@ -1204,6 +1265,8 @@ function SettingsTab({
   const [name, setName] = useState(agent.name);
   const [description, setDescription] = useState(agent.description ?? "");
   const [model, setModel] = useState((agent.runtime_config?.model as string) ?? "");
+  const [modelOpen, setModelOpen] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
   const [visibility, setVisibility] = useState<AgentVisibility>(agent.visibility);
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
   const [saving, setSaving] = useState(false);
@@ -1304,12 +1367,59 @@ function SettingsTab({
 
       <div>
         <Label className="text-xs text-muted-foreground">Model</Label>
-        <Input
-          value={model}
-          onChange={(e) => setModel(e.target.value)}
-          placeholder="e.g. claude-sonnet-4-20250514 (optional, uses daemon default)"
-          className="mt-1"
-        />
+        <Popover open={modelOpen} onOpenChange={setModelOpen}>
+          <PopoverTrigger className="flex w-full items-center justify-between rounded-lg border border-border bg-background px-3 py-2 mt-1.5 text-left text-sm transition-colors hover:bg-muted">
+            <span className={model ? "text-foreground" : "text-muted-foreground"}>
+              {model || "Default (from daemon config)"}
+            </span>
+            <ChevronDown className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${modelOpen ? "rotate-180" : ""}`} />
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-[var(--anchor-width)] p-0">
+            <Command shouldFilter={true}>
+              <CommandInput
+                placeholder="Search or type a model name..."
+                value={modelSearch}
+                onValueChange={setModelSearch}
+              />
+              <CommandList>
+                <CommandEmpty>
+                  {modelSearch.trim() ? (
+                    <button
+                      type="button"
+                      className="text-primary hover:underline"
+                      onClick={() => { setModel(modelSearch.trim()); setModelSearch(""); setModelOpen(false); }}
+                    >
+                      Use &quot;{modelSearch.trim()}&quot;
+                    </button>
+                  ) : (
+                    <span className="text-muted-foreground">Type a model name</span>
+                  )}
+                </CommandEmpty>
+                <CommandGroup heading="Default">
+                  <CommandItem
+                    data-checked={!model}
+                    onSelect={() => { setModel(""); setModelSearch(""); setModelOpen(false); }}
+                  >
+                    Default (from daemon config)
+                  </CommandItem>
+                </CommandGroup>
+                {MODEL_SUGGESTIONS.map((group) => (
+                  <CommandGroup key={group.group} heading={group.group}>
+                    {group.models.map((m) => (
+                      <CommandItem
+                        key={m}
+                        data-checked={model === m}
+                        onSelect={() => { setModel(m); setModelSearch(""); setModelOpen(false); }}
+                      >
+                        {m}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ))}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
         <p className="text-xs text-muted-foreground mt-1">
           Override the default model for this agent. Leave empty to use daemon default.
         </p>

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -239,12 +239,16 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 		if d.cfg.DeviceName != "" {
 			displayName = fmt.Sprintf("%s (%s)", displayName, d.cfg.DeviceName)
 		}
-		runtimes = append(runtimes, map[string]string{
+		rt := map[string]string{
 			"name":    displayName,
 			"type":    name,
 			"version": version,
 			"status":  "online",
-		})
+		}
+		if entry.Model != "" {
+			rt["default_model"] = entry.Model
+		}
+		runtimes = append(runtimes, rt)
 	}
 	if len(runtimes) == 0 {
 		return nil, fmt.Errorf("no agent runtimes could be registered")

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -868,6 +868,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		instructions = task.Agent.Instructions
 	}
 
+	// Model priority: agent runtime_config.model > daemon env var default
+	model := entry.Model
+	if task.Agent != nil && task.Agent.RuntimeConfig != nil {
+		if m, ok := task.Agent.RuntimeConfig["model"].(string); ok && m != "" {
+			model = m
+		}
+	}
+
 	// Prepare isolated execution environment.
 	// Repos are passed as metadata only — the agent checks them out on demand
 	// via `multica repo checkout <url>`.
@@ -939,7 +947,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	taskLog.Info("starting agent",
 		"provider", provider,
 		"workdir", env.WorkDir,
-		"model", entry.Model,
+		"model", model,
 		"reused", reused,
 	)
 	if task.PriorSessionID != "" {
@@ -950,7 +958,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 
 	session, err := backend.Execute(ctx, prompt, agent.ExecOptions{
 		Cwd:             env.WorkDir,
-		Model:           entry.Model,
+		Model:           model,
 		Timeout:         d.cfg.AgentTimeout,
 		ResumeSessionID: task.PriorSessionID,
 	})

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -37,10 +37,11 @@ type Task struct {
 
 // AgentData holds agent details returned by the claim endpoint.
 type AgentData struct {
-	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	Instructions string      `json:"instructions"`
-	Skills       []SkillData `json:"skills"`
+	ID            string                 `json:"id"`
+	Name          string                 `json:"name"`
+	Instructions  string                 `json:"instructions"`
+	RuntimeConfig map[string]interface{} `json:"runtime_config,omitempty"`
+	Skills        []SkillData            `json:"skills"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -116,10 +116,11 @@ type AgentTaskResponse struct {
 // TaskAgentData holds agent info included in claim responses so the daemon
 // can set up the execution environment (branch naming, skill files, instructions).
 type TaskAgentData struct {
-	ID           string                   `json:"id"`
-	Name         string                   `json:"name"`
-	Instructions string                   `json:"instructions"`
-	Skills       []service.AgentSkillData `json:"skills,omitempty"`
+	ID            string                   `json:"id"`
+	Name          string                   `json:"name"`
+	Instructions  string                   `json:"instructions"`
+	RuntimeConfig json.RawMessage          `json:"runtime_config,omitempty"`
+	Skills        []service.AgentSkillData `json:"skills,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -25,10 +25,11 @@ type DaemonRegisterRequest struct {
 	DeviceName  string `json:"device_name"`
 	CLIVersion  string `json:"cli_version"` // multica CLI version
 	Runtimes    []struct {
-		Name    string `json:"name"`
-		Type    string `json:"type"`
-		Version string `json:"version"` // agent CLI version (claude/codex)
-		Status  string `json:"status"`
+		Name         string `json:"name"`
+		Type         string `json:"type"`
+		Version      string `json:"version"`       // agent CLI version (claude/codex)
+		Status       string `json:"status"`
+		DefaultModel string `json:"default_model"` // model configured via env var (optional)
 	} `json:"runtimes"`
 }
 
@@ -90,10 +91,14 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		if runtime.Status == "offline" {
 			status = "offline"
 		}
-		metadata, _ := json.Marshal(map[string]any{
+		meta := map[string]any{
 			"version":     runtime.Version,
 			"cli_version": req.CLIVersion,
-		})
+		}
+		if runtime.DefaultModel != "" {
+			meta["default_model"] = runtime.DefaultModel
+		}
+		metadata, _ := json.Marshal(meta)
 
 		registered, err := h.Queries.UpsertAgentRuntime(r.Context(), db.UpsertAgentRuntimeParams{
 			WorkspaceID: parseUUID(req.WorkspaceID),

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -239,10 +239,11 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	if agent, err := h.Queries.GetAgent(r.Context(), task.AgentID); err == nil {
 		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
 		resp.Agent = &TaskAgentData{
-			ID:           uuidToString(agent.ID),
-			Name:         agent.Name,
-			Instructions: agent.Instructions,
-			Skills:       skills,
+			ID:            uuidToString(agent.ID),
+			Name:          agent.Name,
+			Instructions:  agent.Instructions,
+			RuntimeConfig: agent.RuntimeConfig,
+			Skills:        skills,
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds model selection to the agent creation dialog and settings tab in the UI
- Stores model in the existing `runtime_config` JSONB column (`runtime_config.model`)
- Passes `runtime_config` from the claim endpoint to the daemon via `TaskAgentData`
- Daemon uses per-agent model with priority over the global `MULTICA_*_MODEL` env var default

No database migration needed — uses the existing `runtime_config` JSONB field.

**Model priority**: `agent.runtime_config.model` > `MULTICA_CLAUDE_MODEL` env var

Closes MUL-4

## Test plan
- [ ] Create a new agent with a model specified — verify `runtime_config.model` is saved
- [ ] Edit an existing agent's model in Settings tab — verify it persists
- [ ] Assign an issue to an agent with a custom model — verify the daemon uses the agent's model
- [ ] Assign an issue to an agent without a model set — verify it falls back to daemon env var