### PR TITLE
Fix blank issue activity entries

### DIFF
--- a/apps/web/app/(dashboard)/issues/[id]/page.test.tsx
+++ b/apps/web/app/(dashboard)/issues/[id]/page.test.tsx
@@ -276,6 +276,27 @@ describe("IssueDetailPage", () => {
     expect(screen.getAllByText("Activity").length).toBeGreaterThanOrEqual(1);
   });
 
+  it("renders a readable fallback for unknown activity actions", async () => {
+    mockGetIssue.mockResolvedValueOnce(mockIssue);
+    mockListTimeline.mockResolvedValueOnce([
+      {
+        type: "activity",
+        id: "activity-1",
+        actor_type: "agent",
+        actor_id: "agent-1",
+        action: "agent_waiting_for_input",
+        details: {},
+        created_at: "2026-01-18T00:00:00Z",
+      },
+    ] satisfies TimelineEntry[]);
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("agent waiting for input")).toBeInTheDocument();
+    });
+  });
+
   it("shows 'Issue not found' for missing issue", async () => {
     // issue-detail fetches getIssue, useIssueReactions also fetches getIssue
     mockGetIssue.mockRejectedValue(new Error("Not found"));

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -91,6 +91,11 @@ function priorityLabel(priority: string): string {
   return PRIORITY_CONFIG[priority as IssuePriority]?.label ?? priority;
 }
 
+function humanizeActivityAction(action?: string): string {
+  if (!action) return "updated this issue";
+  return action.replace(/_/g, " ");
+}
+
 function formatActivity(
   entry: TimelineEntry,
   resolveActorName?: (type: string, id: string) => string,
@@ -127,7 +132,7 @@ function formatActivity(
     case "task_failed":
       return "task failed";
     default:
-      return entry.action ?? "";
+      return humanizeActivityAction(entry.action);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a readable fallback for unknown issue activity actions instead of rendering blank text
- keep issue activity rows visible even when backend introduces new action names
- add a regression test covering unknown activity actions in the issue detail page

## Testing
- pnpm --dir repo/apps/web test -- 'app/(dashboard)/issues/[id]/page.test.tsx'