### PR TITLE
fix(deploy): write GitHub App PEM key to file instead of .env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,11 +51,16 @@ jobs:
           CLOUDFRONT_PRIVATE_KEY=${{ secrets.CLOUDFRONT_PRIVATE_KEY }}
           MULTICA_GITHUB_APP_ID=${{ vars.MULTICA_GITHUB_APP_ID }}
           MULTICA_GITHUB_APP_SLUG=${{ vars.MULTICA_GITHUB_APP_SLUG }}
-          MULTICA_GITHUB_APP_PRIVATE_KEY=${{ secrets.MULTICA_GITHUB_APP_PRIVATE_KEY }}
           LISTEN_PORT=${{ vars.LISTEN_PORT || '80' }}
           PGDATA_DIR=${{ vars.PGDATA_DIR || './data/postgres' }}
           IMAGE_TAG=${{ inputs.image_tag || 'latest' }}
           ENVEOF
+
+      - name: Write GitHub App private key file
+        run: |
+          mkdir -p secrets
+          printf '%s' '${{ secrets.MULTICA_GITHUB_APP_PRIVATE_KEY }}' > secrets/github-app-key.pem
+          chmod 600 secrets/github-app-key.pem
 
       - name: Clean existing data
         if: inputs.clean
@@ -94,6 +99,8 @@ jobs:
           docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=100
           exit 1
 
-      - name: Cleanup env file
+      - name: Cleanup secrets
         if: always()
-        run: rm -f .env.prod
+        run: |
+          rm -f .env.prod
+          rm -rf secrets/

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ server/server
 
 # deployment data
 data/
+secrets/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,10 +49,15 @@ services:
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}
       ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-}
+      MULTICA_GITHUB_APP_ID: ${MULTICA_GITHUB_APP_ID:-}
+      MULTICA_GITHUB_APP_SLUG: ${MULTICA_GITHUB_APP_SLUG:-}
+      MULTICA_GITHUB_APP_PRIVATE_KEY_FILE: /run/secrets/github-app-key.pem
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       http_proxy: ""
       https_proxy: ""
+    volumes:
+      - ./secrets/github-app-key.pem:/run/secrets/github-app-key.pem:ro
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary

- Fixes deploy failure ([Deploy #12](https://github.com/nullne/multica/actions/runs/24165863218)) caused by the multi-line GitHub App PEM private key breaking `.env.prod` file parsing
- Writes the PEM key to a separate file (`secrets/github-app-key.pem`) and mounts it into the backend container via `MULTICA_GITHUB_APP_PRIVATE_KEY_FILE`
- Adds the missing `MULTICA_GITHUB_APP_ID` and `MULTICA_GITHUB_APP_SLUG` env vars to `docker-compose.prod.yml`

## Test plan

- [ ] Re-run the deploy workflow and confirm `Pull images` step passes
- [ ] Verify backend starts and reads the GitHub App key from the mounted file

Made with [Cursor](https://cursor.com)