### PR TITLE
feat(ci): add staging environment with auto-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   workflow_call:
 
 concurrency:
@@ -72,7 +72,7 @@ jobs:
 
   # Build and push Docker images to GHCR (only on main push)
   images:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     needs: [frontend, backend]
     runs-on: ubuntu-latest
     permissions:
@@ -108,7 +108,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}/${{ matrix.name }}
           tags: |
             type=sha,prefix=
-            type=raw,value=latest
+            type=raw,value=${{ github.ref == 'refs/heads/main' && 'latest' || 'staging' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,84 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [staging]
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+env:
+  LISTEN_PORT: ${{ vars.LISTEN_PORT || '8180' }}
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  deploy:
+    needs: ci
+    runs-on: self-hosted
+    environment: staging
+    env:
+      COMPOSE_ARGS: -f docker-compose.prod.yml --project-name multica-staging --env-file .env.staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Create env file
+        run: |
+          cat > .env.staging <<'ENVEOF'
+          POSTGRES_DB=multica_staging
+          POSTGRES_USER=multica_staging
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
+          FRONTEND_ORIGIN=${{ secrets.FRONTEND_ORIGIN }}
+          CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}
+          LOG_LEVEL=${{ vars.LOG_LEVEL || 'debug' }}
+          ALLOWED_EMAILS=${{ secrets.ALLOWED_EMAILS }}
+          ALLOWED_EMAIL_DOMAINS=${{ secrets.ALLOWED_EMAIL_DOMAINS }}
+          RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+          RESEND_FROM_EMAIL=${{ secrets.RESEND_FROM_EMAIL }}
+          COOKIE_DOMAIN=${{ secrets.COOKIE_DOMAIN }}
+          S3_BUCKET=${{ secrets.S3_BUCKET }}
+          S3_REGION=${{ vars.S3_REGION || 'us-west-2' }}
+          CLOUDFRONT_DOMAIN=${{ secrets.CLOUDFRONT_DOMAIN }}
+          CLOUDFRONT_KEY_PAIR_ID=${{ secrets.CLOUDFRONT_KEY_PAIR_ID }}
+          CLOUDFRONT_PRIVATE_KEY=${{ secrets.CLOUDFRONT_PRIVATE_KEY }}
+          LISTEN_PORT=${{ vars.LISTEN_PORT || '8180' }}
+          PGDATA_DIR=${{ vars.PGDATA_DIR || './data/postgres-staging' }}
+          IMAGE_TAG=staging
+          ENVEOF
+
+      - name: Pull images
+        run: docker compose ${{ env.COMPOSE_ARGS }} pull
+
+      - name: Deploy
+        run: docker compose ${{ env.COMPOSE_ARGS }} up -d --remove-orphans
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose ${{ env.COMPOSE_ARGS }} logs --tail=100
+
+      - name: Wait for health check
+        run: |
+          LISTEN_PORT="${{ vars.LISTEN_PORT || '8180' }}"
+          echo "Waiting for staging services on port $LISTEN_PORT..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:${LISTEN_PORT}/health > /dev/null 2>&1; then
+              echo "Staging is healthy!"
+              exit 0
+            fi
+            echo "Attempt $i/30 — waiting..."
+            sleep 5
+          done
+          echo "Health check failed after 150s"
+          docker compose ${{ env.COMPOSE_ARGS }} logs --tail=100
+          exit 1
+
+      - name: Cleanup env file
+        if: always()
+        run: rm -f .env.staging


### PR DESCRIPTION
## Summary

- Add `deploy-staging.yml` workflow that auto-deploys to staging on push to `staging` branch
- Update `ci.yml` to build Docker images on staging branch (tagged `staging` instead of `latest`)
- Staging runs on the same self-hosted runner as prod, isolated via separate compose project name, ports (8180), and database (`multica_staging`)

## Manual setup required after merge

1. Create `staging` GitHub environment in repo settings
2. Configure staging secrets (`POSTGRES_PASSWORD`, `JWT_SECRET`, `FRONTEND_ORIGIN`, etc.)
3. Configure staging vars (`LISTEN_PORT=8180`, `LOG_LEVEL=debug`)
4. Create `staging` branch: `git branch staging && git push origin staging`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, create `staging` branch and push — confirm workflow triggers
- [ ] Confirm staging deploys on port 8180 with isolated containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)