### PR TITLE
fix(web): handle GitHub App callback via frontend page

### DIFF
--- a/apps/web/app/github/callback/page.tsx
+++ b/apps/web/app/github/callback/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { api } from "@/shared/api";
+import { useWorkspaceStore } from "@/features/workspace";
+
+export default function GitHubCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+
+    const installationId = searchParams.get("installation_id");
+    const workspaceId = searchParams.get("state");
+
+    if (!installationId || !workspaceId) {
+      router.replace("/settings");
+      return;
+    }
+
+    api
+      .connectGitHub(workspaceId, Number(installationId))
+      .then((updated) => {
+        useWorkspaceStore.getState().updateWorkspace(updated);
+        router.replace("/settings");
+      })
+      .catch(() => {
+        router.replace("/settings");
+      });
+  }, [searchParams, router]);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <p className="text-sm text-muted-foreground">Connecting GitHub…</p>
+    </div>
+  );
+}

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -454,6 +454,13 @@ export class ApiClient {
     return this.fetch(`/api/workspaces/${workspaceId}/github/status`);
   }
 
+  async connectGitHub(workspaceId: string, installationId: number): Promise<Workspace> {
+    return this.fetch(`/api/workspaces/${workspaceId}/github/connect`, {
+      method: "POST",
+      body: JSON.stringify({ installation_id: installationId }),
+    });
+  }
+
   async disconnectGitHub(workspaceId: string): Promise<Workspace> {
     return this.fetch(`/api/workspaces/${workspaceId}/github`, {
       method: "DELETE",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -137,7 +137,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 				r.Post("/members", h.CreateMember)
 				r.Get("/github/install-url", h.GitHubInstallURL)
 				r.Get("/github/status", h.GitHubStatus)
-				r.Get("/github/callback", h.GitHubCallback)
+				r.Post("/github/connect", h.GitHubConnect)
 				r.Delete("/github", h.GitHubDisconnect)
 					r.Route("/members/{memberId}", func(r chi.Router) {
 						r.Patch("/", h.UpdateMember)

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1,9 +1,9 @@
 package handler
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	gh "github.com/nullne/multica/server/internal/github"
@@ -21,30 +21,28 @@ func (h *Handler) GitHubInstallURL(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"url": url})
 }
 
-// GitHubCallback handles the redirect from GitHub after a user installs the App.
-func (h *Handler) GitHubCallback(w http.ResponseWriter, r *http.Request) {
+// GitHubConnect handles the POST request from the frontend after a user
+// completes the GitHub App installation flow. The frontend page at
+// /github/callback receives the redirect from GitHub (with installation_id
+// and state query params) and calls this endpoint.
+func (h *Handler) GitHubConnect(w http.ResponseWriter, r *http.Request) {
 	if h.GitHubApp == nil {
 		writeError(w, http.StatusNotImplemented, "GitHub App not configured")
 		return
 	}
 
-	installationIDStr := r.URL.Query().Get("installation_id")
-	workspaceID := r.URL.Query().Get("state")
-
-	if installationIDStr == "" || workspaceID == "" {
-		writeError(w, http.StatusBadRequest, "missing installation_id or state")
+	var body struct {
+		InstallationID int64 `json:"installation_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.InstallationID == 0 {
+		writeError(w, http.StatusBadRequest, "missing or invalid installation_id")
 		return
 	}
 
-	installationID, err := strconv.ParseInt(installationIDStr, 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid installation_id")
-		return
-	}
-
+	workspaceID := resolveWorkspaceID(r)
 	ws, err := h.Queries.SetGitHubInstallation(r.Context(), db.SetGitHubInstallationParams{
 		ID:                   parseUUID(workspaceID),
-		GithubInstallationID: pgtype.Int8{Int64: installationID, Valid: true},
+		GithubInstallationID: pgtype.Int8{Int64: body.InstallationID, Valid: true},
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to save installation")


### PR DESCRIPTION
## Summary

- Fixes GitHub App installation callback — the old `GET /github/callback` backend route couldn't work as a GitHub redirect target because auth is token-based (no cookies) and the route required workspace ID in the URL path (GitHub's Setup URL is fixed)
- Adds a frontend page at `/github/callback` that receives the redirect from GitHub, reads `installation_id` + `state` (workspace ID) from query params, calls the backend with JWT, and redirects to `/settings`
- Replaces `GET /github/callback` with `POST /github/connect` on the backend
- Adds `connectGitHub(workspaceId, installationId)` to the API client

## GitHub App Setup URL

Configure in GitHub App settings → Post installation → Setup URL:
```
https://<domain>/github/callback
```

## Test plan

- [ ] Click "Connect GitHub" in settings → install app on GitHub → verify redirect back to settings with "Connected" status
- [ ] Verify "Disconnect" works and status reverts to "Not connected"

Made with [Cursor](https://cursor.com)