### PR TITLE
docs(readme): fix self-host quickstart setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ cd multica
 cp .env.example .env
 # Edit .env — at minimum, change JWT_SECRET
 
-docker compose up -d                              # Start PostgreSQL
-cd server && go run ./cmd/migrate up && cd ..     # Run migrations
-make start                                         # Start the app
+make setup                                        # Install deps, start PostgreSQL, run migrations
+make start                                        # Start backend + frontend
 ```
 
 See the [Self-Hosting Guide](SELF_HOSTING.md) for full instructions.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,9 +59,8 @@ cd multica
 cp .env.example .env
 # 编辑 .env — 至少修改 JWT_SECRET
 
-docker compose up -d                              # 启动 PostgreSQL
-cd server && go run ./cmd/migrate up && cd ..     # 运行数据库迁移
-make start                                         # 启动应用
+make setup                                        # 安装依赖、启动 PostgreSQL 并执行迁移
+make start                                        # 启动后端和前端
 ```
 
 完整部署文档请参阅 [自部署指南](SELF_HOSTING.md)。


### PR DESCRIPTION
## Summary
- update the self-host quickstart snippet in `README.md` to run `make setup` before `make start`
- mirror the same fix in `README.zh-CN.md` to keep both language guides consistent
- clarify that `make setup` handles dependency install, PostgreSQL startup, and migrations to avoid failures on fresh clones

## Test plan
- [x] Verified `README.md` quickstart command block now includes `make setup`
- [x] Verified `README.zh-CN.md` quickstart command block now includes `make setup`
- [x] Checked branch diff only includes documentation updates


Made with [Cursor](https://cursor.com)