### PR TITLE
fix(comments): convert literal \n escape sequences in agent comments

### DIFF
--- a/apps/web/components/common/markdown-to-html.test.ts
+++ b/apps/web/components/common/markdown-to-html.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { markdownToHtml } from "./markdown-to-html";
+
+describe("markdownToHtml", () => {
+  describe("literal \\n escape sequence handling", () => {
+    it("converts literal \\n to real newlines in plain text", () => {
+      const input = "line1\\nline2\\nline3";
+      const html = markdownToHtml(input);
+      // After converting \n → real newlines, marked renders them as paragraphs or <br>
+      expect(html).not.toContain("\\n");
+      expect(html).toContain("line1");
+      expect(html).toContain("line2");
+      expect(html).toContain("line3");
+    });
+
+    it("converts literal \\n\\n to paragraph breaks", () => {
+      const input = "paragraph1\\n\\nparagraph2";
+      const html = markdownToHtml(input);
+      expect(html).not.toContain("\\n");
+      // Two newlines = two paragraphs
+      expect(html).toContain("<p>paragraph1</p>");
+      expect(html).toContain("<p>paragraph2</p>");
+    });
+
+    it("preserves \\n inside inline code", () => {
+      const input = "use `\\n` for newlines";
+      const html = markdownToHtml(input);
+      expect(html).toContain("\\n");
+    });
+
+    it("preserves \\n inside fenced code blocks", () => {
+      const input = "text before\n```\nprint(\"hello\\nworld\")\n```\ntext after";
+      const html = markdownToHtml(input);
+      // The \n inside the code block should be preserved as literal text
+      expect(html).toContain("\\n");
+    });
+
+    it("handles mixed literal \\n and real newlines", () => {
+      const input = "line1\\nline2\nline3";
+      const html = markdownToHtml(input);
+      expect(html).not.toContain("\\n");
+      expect(html).toContain("line1");
+      expect(html).toContain("line2");
+      expect(html).toContain("line3");
+    });
+
+    it("converts literal \\t to real tabs", () => {
+      const input = "col1\\tcol2";
+      const html = markdownToHtml(input);
+      expect(html).not.toContain("\\t");
+    });
+
+    it("handles agent-style output with escaped newlines", () => {
+      // Simulates what happens when an agent posts via CLI --content "..."
+      const input =
+        "结论：线上库不一致。\\n\\n对比结果：\\n- migration 最新到 000045\\n- 线上记录 version=34";
+      const html = markdownToHtml(input);
+      expect(html).not.toContain("\\n");
+      expect(html).toContain("结论");
+      expect(html).toContain("对比结果");
+      // The list items should be rendered
+      expect(html).toContain("migration");
+    });
+
+    it("does nothing when no literal \\n present", () => {
+      const input = "normal text\nwith real newlines";
+      const html = markdownToHtml(input);
+      expect(html).toContain("normal text");
+    });
+  });
+});

--- a/apps/web/components/common/markdown-to-html.ts
+++ b/apps/web/components/common/markdown-to-html.ts
@@ -81,7 +81,7 @@ function preprocessMentionShortcodes(text: string): string {
  * avoid breaking intentional \n references in code.
  */
 function unescapeLiteralNewlines(text: string): string {
-  if (!text.includes("\\n")) return text;
+  if (!text.includes("\\n") && !text.includes("\\t")) return text;
 
   // Split into fenced code blocks, inline code, and plain text.
   // Fenced blocks: ```...``` (possibly with language tag)

--- a/apps/web/components/common/markdown-to-html.ts
+++ b/apps/web/components/common/markdown-to-html.ts
@@ -67,6 +67,39 @@ function preprocessMentionShortcodes(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Escape sequence preprocessing
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert literal \n escape sequences to actual newlines.
+ *
+ * Agent output (from CLI --content flags or SDK result text) sometimes
+ * contains literal backslash-n instead of real newlines. This makes the
+ * content render as a single unformatted line with visible \n characters.
+ *
+ * We only convert outside fenced code blocks and inline code spans to
+ * avoid breaking intentional \n references in code.
+ */
+function unescapeLiteralNewlines(text: string): string {
+  if (!text.includes("\\n")) return text;
+
+  // Split into fenced code blocks, inline code, and plain text.
+  // Fenced blocks: ```...``` (possibly with language tag)
+  // Inline code:   `...`
+  const codePattern = /(```[\s\S]*?```|`[^`\n]+`)/g;
+  const parts = text.split(codePattern);
+
+  return parts
+    .map((part, i) => {
+      // Odd-indexed parts are code spans/blocks — leave unchanged.
+      if (i % 2 === 1) return part;
+      // Convert literal \n and \t to real whitespace in plain text.
+      return part.replace(/\\n/g, "\n").replace(/\\t/g, "\t");
+    })
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -74,6 +107,7 @@ function preprocessMentionShortcodes(text: string): string {
  * Convert a markdown string to Tiptap-compatible HTML.
  *
  * Pipeline:
+ *   0. Literal \n / \t escape sequences → real whitespace (agent output fix)
  *   1. Legacy mention shortcodes → standard mention links
  *   2. Raw URLs → markdown links (linkify)
  *   3. Mention links → <span data-type="mention" ...> HTML
@@ -86,7 +120,8 @@ function preprocessMentionShortcodes(text: string): string {
  */
 export function markdownToHtml(markdown: string): string {
   if (!markdown) return "";
-  const step1 = preprocessMentionShortcodes(markdown);
+  const step0 = unescapeLiteralNewlines(markdown);
+  const step1 = preprocessMentionShortcodes(step0);
   const step2 = preprocessLinks(step1);
   const step3 = mentionsToHtml(step2);
   return tiptapMarked.parse(step3) as string;

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -604,6 +604,9 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	if content == "" {
 		return fmt.Errorf("--content is required")
 	}
+	// Process common escape sequences so agents and shell users can include
+	// newlines via \n in --content without needing ANSI-C quoting ($'...').
+	content = unescapeContent(content)
 
 	client, err := newAPIClient(cmd)
 	if err != nil {
@@ -867,6 +870,14 @@ func formatAssignee(issue map[string]any) string {
 		return ""
 	}
 	return aType + ":" + truncateID(aID)
+}
+
+// unescapeContent interprets C-style escape sequences in a string.
+// This lets CLI users and agents write newlines as \n in --content flags
+// without needing shell-specific quoting like $'...\n...'.
+func unescapeContent(s string) string {
+	r := strings.NewReplacer(`\n`, "\n", `\t`, "\t")
+	return r.Replace(s)
 }
 
 func truncateID(id string) string {

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -137,6 +137,30 @@ func TestResolveAssignee(t *testing.T) {
 	})
 }
 
+func TestUnescapeContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"literal newline", `line1\nline2`, "line1\nline2"},
+		{"literal tab", `col1\tcol2`, "col1\tcol2"},
+		{"multiple newlines", `a\n\nb`, "a\n\nb"},
+		{"mixed", `first\nsecond\tthird`, "first\nsecond\tthird"},
+		{"no escapes", "already fine\nwith real newlines", "already fine\nwith real newlines"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unescapeContent(tt.input)
+			if got != tt.want {
+				t.Errorf("unescapeContent(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidIssueStatuses(t *testing.T) {
 	expected := map[string]bool{
 		"backlog":     true,


### PR DESCRIPTION
## Summary

- Agent comments sometimes contain literal `\n` (backslash + n) instead of actual newlines, causing text to render as a single unformatted line with visible `\n` characters
- Frontend `markdownToHtml` now preprocesses literal `\n`/`\t` escape sequences → real whitespace (outside code blocks/inline code)
- CLI `multica issue comment add --content` now interprets `\n` and `\t` escape sequences so agents can include newlines without ANSI-C quoting

## Test plan

- [x] TypeScript typecheck passes
- [x] All 43 TS tests pass
- [x] Go CLI builds successfully
- [ ] Verify agent comments with `\n` now render with proper line breaks
- [ ] Verify content inside code blocks preserves literal `\n`

Closes MUL-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)