### PR TITLE
fix(realtime): scope inbox events to correct workspace

### DIFF
--- a/apps/web/features/realtime/use-realtime-sync.ts
+++ b/apps/web/features/realtime/use-realtime-sync.ts
@@ -110,7 +110,10 @@ export function useRealtimeSync(ws: WSClient | null) {
 
     const unsubInboxNew = ws.on("inbox:new", (p) => {
       const { item } = p as InboxNewPayload;
-      if (item) useInboxStore.getState().addItem(item);
+      if (!item) return;
+      const currentWsId = useWorkspaceStore.getState().workspace?.id;
+      if (item.workspace_id && item.workspace_id !== currentWsId) return;
+      useInboxStore.getState().addItem(item);
     });
 
     // --- Side-effect handlers (toast, navigation) ---

--- a/server/cmd/server/listeners.go
+++ b/server/cmd/server/listeners.go
@@ -25,7 +25,7 @@ func registerListeners(bus *events.Bus, hub *realtime.Hub) {
 		protocol.EventInboxBatchArchived: true,
 	}
 
-	// Helper: marshal event and send to a specific user.
+	// Helper: marshal event and send to a specific user within the event's workspace.
 	sendToRecipient := func(hub *realtime.Hub, e events.Event, recipientID string) {
 		if recipientID == "" {
 			return
@@ -34,7 +34,11 @@ func registerListeners(bus *events.Bus, hub *realtime.Hub) {
 		if err != nil {
 			return
 		}
-		hub.SendToUser(recipientID, data)
+		if e.WorkspaceID != "" {
+			hub.SendToUserInWorkspace(recipientID, e.WorkspaceID, data)
+		} else {
+			hub.SendToUser(recipientID, data)
+		}
 	}
 
 	// inbox:new — extract recipient from nested item

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -209,6 +209,45 @@ func (h *Hub) SendToUser(userID string, message []byte, excludeWorkspace ...stri
 	}
 }
 
+// SendToUserInWorkspace sends a message to all connections belonging to a
+// specific user within a specific workspace room only.
+func (h *Hub) SendToUserInWorkspace(userID, workspaceID string, message []byte) {
+	h.mu.RLock()
+	clients := h.rooms[workspaceID]
+	var targets []*Client
+	for client := range clients {
+		if client.userID == userID {
+			targets = append(targets, client)
+		}
+	}
+	h.mu.RUnlock()
+
+	var slow []*Client
+	for _, client := range targets {
+		select {
+		case client.send <- message:
+		default:
+			slow = append(slow, client)
+		}
+	}
+
+	if len(slow) > 0 {
+		h.mu.Lock()
+		for _, client := range slow {
+			if room, ok := h.rooms[workspaceID]; ok {
+				if _, exists := room[client]; exists {
+					delete(room, client)
+					close(client.send)
+					if len(room) == 0 {
+						delete(h.rooms, workspaceID)
+					}
+				}
+			}
+		}
+		h.mu.Unlock()
+	}
+}
+
 // Broadcast sends a message to all connected clients (used for daemon events).
 func (h *Hub) Broadcast(message []byte) {
 	h.broadcast <- message

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -71,6 +71,57 @@ func totalClients(hub *Hub) int {
 	return count
 }
 
+// connectWSAs connects a WebSocket client with a specific user and workspace.
+func connectWSAs(t *testing.T, server *httptest.Server, userID, workspaceID string) *websocket.Conn {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": userID,
+	})
+	signed, err := token.SignedString(auth.JWTSecret())
+	if err != nil {
+		t.Fatalf("failed to sign test JWT: %v", err)
+	}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws?token=" + signed + "&workspace_id=" + workspaceID
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to connect WebSocket: %v", err)
+	}
+	return conn
+}
+
+func TestHub_SendToUserInWorkspace(t *testing.T) {
+	hub, server := newTestHub(t)
+	defer server.Close()
+
+	// Same user connected to two different workspaces
+	connWS1 := connectWSAs(t, server, "user-a", "workspace-1")
+	defer connWS1.Close()
+	connWS2 := connectWSAs(t, server, "user-a", "workspace-2")
+	defer connWS2.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	msg := []byte(`{"type":"inbox:new","payload":{"item":{"id":"1"}}}`)
+	hub.SendToUserInWorkspace("user-a", "workspace-1", msg)
+
+	// workspace-1 connection should receive the message
+	connWS1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, received, err := connWS1.ReadMessage()
+	if err != nil {
+		t.Fatalf("workspace-1 client should receive message: %v", err)
+	}
+	if string(received) != string(msg) {
+		t.Fatalf("workspace-1: expected %s, got %s", msg, received)
+	}
+
+	// workspace-2 connection should NOT receive the message
+	connWS2.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err = connWS2.ReadMessage()
+	if err == nil {
+		t.Fatal("workspace-2 client should NOT have received the message")
+	}
+}
+
 func TestHub_ClientRegistration(t *testing.T) {
 	hub, server := newTestHub(t)
 	defer server.Close()


### PR DESCRIPTION
## Summary
- Added SendToUserInWorkspace() to the realtime Hub for workspace-scoped inbox event delivery
- Updated listeners.go to use workspace-scoped delivery when event carries a WorkspaceID
- Added frontend defensive guard on inbox:new to ignore items from other workspaces
- Added regression test TestHub_SendToUserInWorkspace

Closes MUL-22