### PR TITLE
fix(cli): support stdin for --content and --description flags

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -134,7 +135,7 @@ func init() {
 
 	// issue create
 	issueCreateCmd.Flags().String("title", "", "Issue title (required)")
-	issueCreateCmd.Flags().String("description", "", "Issue description")
+	issueCreateCmd.Flags().String("description", "", "Issue description (use - to read from stdin)")
 	issueCreateCmd.Flags().String("status", "", "Issue status")
 	issueCreateCmd.Flags().String("priority", "", "Issue priority")
 	issueCreateCmd.Flags().String("assignee", "", "Assignee name (member or agent)")
@@ -146,7 +147,7 @@ func init() {
 
 	// issue update
 	issueUpdateCmd.Flags().String("title", "", "New title")
-	issueUpdateCmd.Flags().String("description", "", "New description")
+	issueUpdateCmd.Flags().String("description", "", "New description (use - to read from stdin)")
 	issueUpdateCmd.Flags().String("status", "", "New status")
 	issueUpdateCmd.Flags().String("priority", "", "New priority")
 	issueUpdateCmd.Flags().String("assignee", "", "New assignee name (member or agent)")
@@ -174,7 +175,7 @@ func init() {
 	issueRunMessagesCmd.Flags().Int("since", 0, "Only return messages after this sequence number")
 
 	// issue comment add
-	issueCommentAddCmd.Flags().String("content", "", "Comment content (required)")
+	issueCommentAddCmd.Flags().String("content", "", "Comment content (required; use - to read from stdin)")
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
@@ -315,8 +316,10 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	body := map[string]any{"title": title}
-	if v, _ := cmd.Flags().GetString("description"); v != "" {
-		body["description"] = v
+	if desc, descErr := readFlagOrStdin(cmd, "description"); descErr != nil {
+		return descErr
+	} else if desc != "" {
+		body["description"] = desc
 	}
 	if v, _ := cmd.Flags().GetString("status"); v != "" {
 		body["status"] = v
@@ -395,8 +398,11 @@ func runIssueUpdate(cmd *cobra.Command, args []string) error {
 		body["title"] = v
 	}
 	if cmd.Flags().Changed("description") {
-		v, _ := cmd.Flags().GetString("description")
-		body["description"] = v
+		desc, descErr := readFlagOrStdin(cmd, "description")
+		if descErr != nil {
+			return descErr
+		}
+		body["description"] = desc
 	}
 	if cmd.Flags().Changed("status") {
 		v, _ := cmd.Flags().GetString("status")
@@ -600,9 +606,12 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 }
 
 func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
-	content, _ := cmd.Flags().GetString("content")
+	content, err := readFlagOrStdin(cmd, "content")
+	if err != nil {
+		return err
+	}
 	if content == "" {
-		return fmt.Errorf("--content is required")
+		return fmt.Errorf("--content is required (use --content - to read from stdin)")
 	}
 
 	client, err := newAPIClient(cmd)
@@ -779,6 +788,19 @@ func runIssueRunMessages(cmd *cobra.Command, args []string) error {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// readFlagOrStdin returns the flag value, reading from stdin when the value is "-".
+func readFlagOrStdin(cmd *cobra.Command, flag string) (string, error) {
+	v, _ := cmd.Flags().GetString(flag)
+	if v != "-" {
+		return v, nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin for --%s: %w", flag, err)
+	}
+	return strings.TrimRight(string(data), "\n"), nil
+}
 
 type assigneeMatch struct {
 	Type string // "member" or "agent"

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -64,6 +64,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue comment add <issue-id> --content \"...\" [--parent <comment-id>]` — Post a comment (use --parent to reply to a specific comment)\n")
 	b.WriteString("- `multica issue status <id> <status>` — Update issue status (todo, in_progress, in_review, done, blocked)\n")
 	b.WriteString("- `multica issue update <id> [--title X] [--description X] [--priority X]` — Update issue fields\n\n")
+	b.WriteString("### Escaping\n\n")
+	b.WriteString("When comment or description text contains special characters (`$`, backticks, quotes, backslashes), pass `--content -` or `--description -` to read from stdin via a heredoc to avoid shell escaping issues:\n\n")
+	b.WriteString("```\ncat <<'CONTENT_EOF' | multica issue comment add <issue-id> --content -\nYour content here — no escaping needed.\nCONTENT_EOF\n```\n\n")
 
 	// Inject available repositories section.
 	if len(ctx.Repos) > 0 {


### PR DESCRIPTION
## Summary

- CLI flags `--content` and `--description` now accept `-` as a value to read from stdin, avoiding shell escaping issues that cause text loss when content contains special characters (`$`, backticks, quotes, backslashes)
- Adds `readFlagOrStdin` helper that transparently handles the `-` convention
- Updates the agent runtime prompt template to teach agents the heredoc pattern for safe content passing

## Affected commands

| Command | Flag |
|---------|------|
| `multica issue comment add` | `--content` |
| `multica issue create` | `--description` |
| `multica issue update` | `--description` |

## Usage

```bash
# Short, simple content — unchanged
multica issue comment add <id> --content "simple text"

# Complex content with special chars — use stdin
cat <<'CONTENT_EOF' | multica issue comment add <id> --content -
Text with $variables, `backticks`, "quotes" — no escaping needed.
CONTENT_EOF
```

## Test plan

- [ ] `multica issue comment add <id> --content "hello"` still works as before
- [ ] `echo "hello" | multica issue comment add <id> --content -` reads from stdin
- [ ] Content with special characters (`$`, backticks) is preserved when using stdin mode
- [ ] `--content` without value still shows helpful error message

Made with [Cursor](https://cursor.com)