### PR TITLE
feat(runtime): add managed client upgrades and server-controlled auto…

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/workspace-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/workspace-tab.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   AlertDialog,
@@ -33,6 +34,7 @@ export function WorkspaceTab() {
   const [name, setName] = useState(workspace?.name ?? "");
   const [description, setDescription] = useState(workspace?.description ?? "");
   const [context, setContext] = useState(workspace?.context ?? "");
+  const [autoUpdateEnabled, setAutoUpdateEnabled] = useState(false);
   const [saving, setSaving] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
   const [confirmAction, setConfirmAction] = useState<{
@@ -50,6 +52,7 @@ export function WorkspaceTab() {
     setName(workspace?.name ?? "");
     setDescription(workspace?.description ?? "");
     setContext(workspace?.context ?? "");
+    setAutoUpdateEnabled(getRuntimeAutoUpdateEnabled(workspace?.settings));
   }, [workspace]);
 
   const handleSave = async () => {
@@ -60,6 +63,14 @@ export function WorkspaceTab() {
         name,
         description,
         context,
+        settings: {
+          ...(workspace.settings ?? {}),
+          runtime_auto_update: {
+            enabled: autoUpdateEnabled,
+            target_version: "latest",
+            update_clients: true,
+          },
+        },
       });
       updateWorkspace(updated);
       toast.success("Workspace settings saved");
@@ -156,6 +167,22 @@ export function WorkspaceTab() {
                 {workspace.slug}
               </div>
             </div>
+            <div className="flex items-center justify-between gap-3 rounded-md border p-3">
+              <div>
+                <Label className="text-xs text-muted-foreground">
+                  Runtime Auto Update
+                </Label>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Server controls automatic runtime updates to the latest
+                  multica CLI and managed clients.
+                </p>
+              </div>
+              <Switch
+                checked={autoUpdateEnabled}
+                onCheckedChange={setAutoUpdateEnabled}
+                disabled={!canManageWorkspace}
+              />
+            </div>
             <div className="flex items-center justify-end gap-2 pt-1">
               <Button
                 size="sm"
@@ -245,4 +272,17 @@ export function WorkspaceTab() {
       </AlertDialog>
     </div>
   );
+}
+
+function getRuntimeAutoUpdateEnabled(
+  settings: Record<string, unknown> | undefined,
+): boolean {
+  if (!settings) return false;
+  const raw = settings.runtime_auto_update;
+  if (typeof raw === "boolean") return raw;
+  if (raw && typeof raw === "object") {
+    const enabled = (raw as { enabled?: unknown }).enabled;
+    return typeof enabled === "boolean" ? enabled : true;
+  }
+  return false;
 }

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -194,6 +194,7 @@ export interface RuntimeUpdate {
   runtime_id: string;
   status: RuntimeUpdateStatus;
   target_version: string;
+  update_clients?: boolean;
   output?: string;
   error?: string;
   created_at: string;

--- a/server/cmd/multica/cmd_update.go
+++ b/server/cmd/multica/cmd_update.go
@@ -20,6 +20,7 @@ func runUpdate(_ *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "Current version: %s (commit: %s)\n", version, commit)
 
 	// Check latest version from GitHub.
+	cliUpToDate := false
 	latest, err := cli.FetchLatestRelease()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not check latest version: %v\n", err)
@@ -28,33 +29,54 @@ func runUpdate(_ *cobra.Command, _ []string) error {
 		currentVer := strings.TrimPrefix(version, "v")
 		if currentVer == latestVer {
 			fmt.Fprintln(os.Stderr, "Already up to date.")
-			return nil
+			cliUpToDate = true
 		}
-		fmt.Fprintf(os.Stderr, "Latest version:  %s\n\n", latest.TagName)
+		if !cliUpToDate {
+			fmt.Fprintf(os.Stderr, "Latest version:  %s\n\n", latest.TagName)
+		}
 	}
 
-	// Detect installation method and update accordingly.
-	if cli.IsBrewInstall() {
-		fmt.Fprintln(os.Stderr, "Updating via Homebrew...")
-		output, err := cli.UpdateViaBrew()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", output)
-			return fmt.Errorf("brew upgrade failed: %w\nYou can try manually: brew upgrade nullne/tap/multica", err)
+	if !cliUpToDate {
+		// Detect installation method and update accordingly.
+		if cli.IsBrewInstall() {
+			fmt.Fprintln(os.Stderr, "Updating via Homebrew...")
+			output, err := cli.UpdateViaBrew()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s\n", output)
+				return fmt.Errorf("brew upgrade failed: %w\nYou can try manually: brew upgrade nullne/tap/multica", err)
+			}
+			fmt.Fprintln(os.Stderr, "CLI update complete.")
+		} else {
+			// Not installed via brew — download binary directly from GitHub Releases.
+			if latest == nil {
+				return fmt.Errorf("could not determine latest version; check https://github.com/nullne/multica/releases/latest")
+			}
+			targetVersion := latest.TagName
+			fmt.Fprintf(os.Stderr, "Downloading %s from GitHub Releases...\n", targetVersion)
+			output, err := cli.UpdateViaDownload(targetVersion)
+			if err != nil {
+				return fmt.Errorf("update failed: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "%s\nCLI update complete.\n", output)
 		}
-		fmt.Fprintln(os.Stderr, "Update complete.")
-		return nil
 	}
 
-	// Not installed via brew — download binary directly from GitHub Releases.
-	if latest == nil {
-		return fmt.Errorf("could not determine latest version; check https://github.com/nullne/multica/releases/latest")
+	fmt.Fprintln(os.Stderr, "\nUpdating managed agent clients (claude, codex, cursor)...")
+	clientReport := cli.UpdateManagedAgentClients()
+	for _, result := range clientReport.Results {
+		switch {
+		case result.Err != nil:
+			fmt.Fprintf(os.Stderr, "- %s: failed (%v)\n", result.Name, result.Err)
+			if result.Output != "" {
+				fmt.Fprintf(os.Stderr, "  output: %s\n", result.Output)
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "- %s: %s\n", result.Name, result.Status)
+		}
 	}
-	targetVersion := latest.TagName
-	fmt.Fprintf(os.Stderr, "Downloading %s from GitHub Releases...\n", targetVersion)
-	output, err := cli.UpdateViaDownload(targetVersion)
-	if err != nil {
-		return fmt.Errorf("update failed: %w", err)
+	if clientReport.HasFailures() {
+		fmt.Fprintln(os.Stderr, "Some client updates failed. You can rerun `multica update` after fixing local prerequisites (npm/curl/PATH).")
 	}
-	fmt.Fprintf(os.Stderr, "%s\nUpdate complete.\n", output)
+	fmt.Fprintln(os.Stderr, "Update workflow complete.")
 	return nil
 }

--- a/server/internal/cli/update.go
+++ b/server/internal/cli/update.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,8 @@ import (
 	"strings"
 	"time"
 )
+
+const managedClientCommandTimeout = 5 * time.Minute
 
 // GitHubRelease is the subset of the GitHub releases API response we need.
 type GitHubRelease struct {
@@ -165,6 +168,163 @@ func UpdateViaDownload(targetVersion string) (string, error) {
 	return fmt.Sprintf("Downloaded %s and replaced %s", assetName, exePath), nil
 }
 
+type managedClientSpec struct {
+	Name            string
+	Binary          string
+	InstallCommands [][]string
+	UpdateCommands  [][]string
+}
+
+type ManagedClientUpdateResult struct {
+	Name   string
+	Status string // installed, updated, failed
+	Output string
+	Err    error
+}
+
+type ManagedClientUpdateReport struct {
+	Results []ManagedClientUpdateResult
+}
+
+func (r ManagedClientUpdateReport) HasFailures() bool {
+	for _, res := range r.Results {
+		if res.Err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (r ManagedClientUpdateReport) String() string {
+	if len(r.Results) == 0 {
+		return "No managed clients configured."
+	}
+	var b strings.Builder
+	for i, res := range r.Results {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(res.Name)
+		b.WriteString(": ")
+		b.WriteString(res.Status)
+		if res.Err != nil {
+			b.WriteString(" (")
+			b.WriteString(res.Err.Error())
+			b.WriteString(")")
+		}
+	}
+	return b.String()
+}
+
+// UpdateManagedAgentClients installs or upgrades managed agent CLIs that are
+// commonly used by the daemon. Failures are reported per client.
+func UpdateManagedAgentClients() ManagedClientUpdateReport {
+	specs := []managedClientSpec{
+		{
+			Name:   "claude",
+			Binary: "claude",
+			InstallCommands: [][]string{
+				{"npm", "install", "-g", "@anthropic-ai/claude-code"},
+			},
+			UpdateCommands: [][]string{
+				{"claude", "update"},
+				{"npm", "install", "-g", "@anthropic-ai/claude-code"},
+			},
+		},
+		{
+			Name:   "codex",
+			Binary: "codex",
+			InstallCommands: [][]string{
+				{"npm", "install", "-g", "@openai/codex"},
+			},
+			UpdateCommands: [][]string{
+				{"npm", "install", "-g", "@openai/codex"},
+			},
+		},
+		{
+			Name:   "cursor",
+			Binary: "cursor-agent",
+			InstallCommands: [][]string{
+				{"sh", "-c", "curl https://cursor.com/install -fsS | bash"},
+			},
+			UpdateCommands: [][]string{
+				{"sh", "-c", "curl https://cursor.com/install -fsS | bash"},
+			},
+		},
+	}
+
+	results := make([]ManagedClientUpdateResult, 0, len(specs))
+	for _, spec := range specs {
+		hasBinary := commandExists(spec.Binary)
+		status := "installed"
+		commands := spec.InstallCommands
+		if hasBinary {
+			status = "updated"
+			commands = spec.UpdateCommands
+		}
+
+		var lastErr error
+		var lastOutput string
+		for _, args := range commands {
+			output, err := runUpdateCommand(args...)
+			if err == nil {
+				results = append(results, ManagedClientUpdateResult{
+					Name:   spec.Name,
+					Status: status,
+					Output: sanitizeCommandOutput(output),
+				})
+				lastErr = nil
+				break
+			}
+			lastErr = err
+			lastOutput = output
+		}
+		if lastErr != nil {
+			results = append(results, ManagedClientUpdateResult{
+				Name:   spec.Name,
+				Status: "failed",
+				Output: sanitizeCommandOutput(lastOutput),
+				Err:    lastErr,
+			})
+		}
+	}
+
+	return ManagedClientUpdateReport{Results: results}
+}
+
+func runUpdateCommand(args ...string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("empty command")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), managedClientCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return string(out), fmt.Errorf("timed out after %s", managedClientCommandTimeout)
+	}
+	if err != nil {
+		return string(out), err
+	}
+	return string(out), nil
+}
+
+func commandExists(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func sanitizeCommandOutput(output string) string {
+	s := strings.TrimSpace(output)
+	if len(s) <= 600 {
+		return s
+	}
+	return s[:600] + "...(truncated)"
+}
+
 // extractBinaryFromTarGz reads a .tar.gz stream and returns the contents of the
 // named file entry.
 func extractBinaryFromTarGz(r io.Reader, name string) ([]byte, error) {
@@ -193,4 +353,3 @@ func extractBinaryFromTarGz(r io.Reader, name string) ([]byte, error) {
 		}
 	}
 }
-

--- a/server/internal/cli/update_test.go
+++ b/server/internal/cli/update_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestManagedClientUpdateReportHasFailures(t *testing.T) {
+	report := ManagedClientUpdateReport{
+		Results: []ManagedClientUpdateResult{
+			{Name: "claude", Status: "updated"},
+			{Name: "codex", Status: "failed", Err: errors.New("boom")},
+		},
+	}
+	if !report.HasFailures() {
+		t.Fatal("HasFailures() = false, want true")
+	}
+	if got := report.String(); !strings.Contains(got, "codex: failed") {
+		t.Fatalf("String() missing failure status: %q", got)
+	}
+}
+
+func TestSanitizeCommandOutput(t *testing.T) {
+	short := "ok"
+	if got := sanitizeCommandOutput(short); got != short {
+		t.Fatalf("sanitizeCommandOutput(short) = %q, want %q", got, short)
+	}
+
+	long := strings.Repeat("a", 900)
+	got := sanitizeCommandOutput(long)
+	if !strings.Contains(got, "...(truncated)") {
+		t.Fatalf("sanitizeCommandOutput(long) should include truncation marker: %q", got)
+	}
+	if len(got) >= len(long) {
+		t.Fatalf("sanitizeCommandOutput(long) length = %d, want < %d", len(got), len(long))
+	}
+}

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -153,6 +153,7 @@ type PendingPing struct {
 type PendingUpdate struct {
 	ID            string `json:"id"`
 	TargetVersion string `json:"target_version"`
+	UpdateClients *bool  `json:"update_clients,omitempty"`
 }
 
 func (c *Client) SendHeartbeat(ctx context.Context, runtimeID string) (*HeartbeatResponse, error) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -550,6 +550,11 @@ func (d *Daemon) handleUpdate(ctx context.Context, runtimeID string, update *Pen
 
 	d.logger.Info("CLI update requested", "runtime_id", runtimeID, "update_id", update.ID, "target_version", update.TargetVersion)
 
+	updateClients := true
+	if update.UpdateClients != nil {
+		updateClients = *update.UpdateClients
+	}
+
 	// Report running status.
 	d.client.ReportUpdateResult(ctx, runtimeID, update.ID, map[string]any{
 		"status": "running",
@@ -583,10 +588,22 @@ func (d *Daemon) handleUpdate(ctx context.Context, runtimeID string, update *Pen
 		}
 	}
 
-	d.logger.Info("CLI update completed successfully", "output", output)
+	resultSummary := fmt.Sprintf("Updated multica to %s", update.TargetVersion)
+	if updateClients {
+		d.logger.Info("updating managed clients", "runtime_id", runtimeID, "update_id", update.ID)
+		clientReport := cli.UpdateManagedAgentClients()
+		if clientReport.HasFailures() {
+			d.logger.Warn("managed client update finished with failures", "report", clientReport.String())
+		}
+		if len(clientReport.Results) > 0 {
+			resultSummary = resultSummary + "\n" + clientReport.String()
+		}
+	}
+
+	d.logger.Info("CLI update completed successfully", "output", output, "summary", resultSummary)
 	d.client.ReportUpdateResult(ctx, runtimeID, update.ID, map[string]any{
 		"status": "completed",
-		"output": fmt.Sprintf("Updated to %s", update.TargetVersion),
+		"output": resultSummary,
 	})
 
 	// Trigger daemon restart with the new binary.

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -191,7 +191,7 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err := h.Queries.UpdateAgentRuntimeHeartbeat(r.Context(), parseUUID(req.RuntimeID))
+	rt, err := h.Queries.UpdateAgentRuntimeHeartbeat(r.Context(), parseUUID(req.RuntimeID))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "heartbeat failed")
 		return
@@ -208,9 +208,16 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 
 	// Check for pending update requests for this runtime.
 	if pending := h.UpdateStore.PopPending(req.RuntimeID); pending != nil {
-		resp["pending_update"] = map[string]string{
+		resp["pending_update"] = map[string]any{
 			"id":             pending.ID,
 			"target_version": pending.TargetVersion,
+			"update_clients": pending.UpdateClients,
+		}
+	} else if auto := h.maybeCreateAutoUpdate(r, rt); auto != nil {
+		resp["pending_update"] = map[string]any{
+			"id":             auto.ID,
+			"target_version": auto.TargetVersion,
+			"update_clients": auto.UpdateClients,
 		}
 	}
 

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -2,11 +2,17 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	internalcli "github.com/nullne/multica/server/internal/cli"
+	db "github.com/nullne/multica/server/pkg/db/generated"
 )
 
 // ---------------------------------------------------------------------------
@@ -29,6 +35,7 @@ type UpdateRequest struct {
 	RuntimeID     string       `json:"runtime_id"`
 	Status        UpdateStatus `json:"status"`
 	TargetVersion string       `json:"target_version"`
+	UpdateClients bool         `json:"update_clients"`
 	Output        string       `json:"output,omitempty"`
 	Error         string       `json:"error,omitempty"`
 	CreatedAt     time.Time    `json:"created_at"`
@@ -37,43 +44,48 @@ type UpdateRequest struct {
 
 // UpdateStore is a thread-safe in-memory store for CLI update requests.
 type UpdateStore struct {
-	mu       sync.Mutex
-	requests map[string]*UpdateRequest // keyed by update ID
+	mu              sync.Mutex
+	requests        map[string]*UpdateRequest // keyed by update ID
+	autoAttempts    map[string]time.Time      // runtimeID::targetVersion -> attempt time
+	latestVersion   string
+	latestVersionAt time.Time
 }
 
 func NewUpdateStore() *UpdateStore {
 	return &UpdateStore{
-		requests: make(map[string]*UpdateRequest),
+		requests:     make(map[string]*UpdateRequest),
+		autoAttempts: make(map[string]time.Time),
 	}
 }
 
-func (s *UpdateStore) Create(runtimeID, targetVersion string) (*UpdateRequest, error) {
+func (s *UpdateStore) Create(runtimeID, targetVersion string, updateClients bool) (*UpdateRequest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Clean up old requests (>5 minutes).
-	for id, req := range s.requests {
-		if time.Since(req.CreatedAt) > 5*time.Minute {
-			delete(s.requests, id)
-		}
+	s.cleanupLocked()
+	if s.hasInProgressLocked(runtimeID) {
+		return nil, errUpdateInProgress
 	}
+	req := s.createLocked(runtimeID, targetVersion, updateClients)
+	return req, nil
+}
 
-	// Reject if there is already a pending or running update for this runtime.
-	for _, req := range s.requests {
-		if req.RuntimeID == runtimeID && (req.Status == UpdatePending || req.Status == UpdateRunning) {
-			return nil, errUpdateInProgress
-		}
-	}
+// CreateAuto creates an automatic update request and throttles repeated
+// attempts for the same runtime/version pair.
+func (s *UpdateStore) CreateAuto(runtimeID, targetVersion string, updateClients bool) (*UpdateRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	req := &UpdateRequest{
-		ID:            randomID(),
-		RuntimeID:     runtimeID,
-		Status:        UpdatePending,
-		TargetVersion: targetVersion,
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
+	s.cleanupLocked()
+	if s.hasInProgressLocked(runtimeID) {
+		return nil, errUpdateInProgress
 	}
-	s.requests[req.ID] = req
+	key := runtimeID + "::" + targetVersion
+	if last, ok := s.autoAttempts[key]; ok && time.Since(last) < 30*time.Minute {
+		return nil, nil
+	}
+	req := s.createLocked(runtimeID, targetVersion, updateClients)
+	s.autoAttempts[key] = time.Now()
 	return req, nil
 }
 
@@ -82,6 +94,63 @@ var errUpdateInProgress = &updateError{msg: "an update is already in progress fo
 type updateError struct{ msg string }
 
 func (e *updateError) Error() string { return e.msg }
+
+func (s *UpdateStore) cleanupLocked() {
+	for id, req := range s.requests {
+		if time.Since(req.CreatedAt) > 5*time.Minute {
+			delete(s.requests, id)
+		}
+	}
+	for key, at := range s.autoAttempts {
+		if time.Since(at) > 30*time.Minute {
+			delete(s.autoAttempts, key)
+		}
+	}
+}
+
+func (s *UpdateStore) hasInProgressLocked(runtimeID string) bool {
+	for _, req := range s.requests {
+		if req.RuntimeID == runtimeID && (req.Status == UpdatePending || req.Status == UpdateRunning) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *UpdateStore) createLocked(runtimeID, targetVersion string, updateClients bool) *UpdateRequest {
+	req := &UpdateRequest{
+		ID:            randomID(),
+		RuntimeID:     runtimeID,
+		Status:        UpdatePending,
+		TargetVersion: targetVersion,
+		UpdateClients: updateClients,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	s.requests[req.ID] = req
+	return req
+}
+
+func (s *UpdateStore) ResolveLatestVersion(fetch func() (string, error)) (string, error) {
+	s.mu.Lock()
+	if s.latestVersion != "" && time.Since(s.latestVersionAt) < 10*time.Minute {
+		tag := s.latestVersion
+		s.mu.Unlock()
+		return tag, nil
+	}
+	s.mu.Unlock()
+
+	tag, err := fetch()
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	s.latestVersion = tag
+	s.latestVersionAt = time.Now()
+	s.mu.Unlock()
+	return tag, nil
+}
 
 func (s *UpdateStore) Get(id string) *UpdateRequest {
 	s.mu.Lock()
@@ -137,6 +206,189 @@ func (s *UpdateStore) Fail(id string, errMsg string) {
 	}
 }
 
+type runtimeAutoUpdateSettings struct {
+	Enabled       bool
+	TargetVersion string
+	UpdateClients bool
+}
+
+func parseRuntimeAutoUpdateSettings(rawSettings []byte) runtimeAutoUpdateSettings {
+	settings := runtimeAutoUpdateSettings{
+		Enabled:       false,
+		TargetVersion: "latest",
+		UpdateClients: true,
+	}
+	if len(rawSettings) == 0 {
+		return settings
+	}
+	var root map[string]any
+	if err := json.Unmarshal(rawSettings, &root); err != nil {
+		return settings
+	}
+	val, ok := root["runtime_auto_update"]
+	if !ok {
+		return settings
+	}
+	switch typed := val.(type) {
+	case bool:
+		settings.Enabled = typed
+	case map[string]any:
+		settings.Enabled = true
+		if v, ok := boolSetting(typed["enabled"]); ok {
+			settings.Enabled = v
+		}
+		if v, ok := stringSetting(typed["target_version"]); ok && strings.TrimSpace(v) != "" {
+			settings.TargetVersion = strings.TrimSpace(v)
+		}
+		if v, ok := boolSetting(typed["update_clients"]); ok {
+			settings.UpdateClients = v
+		}
+	}
+	return settings
+}
+
+func boolSetting(v any) (bool, bool) {
+	switch typed := v.(type) {
+	case bool:
+		return typed, true
+	case string:
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(typed)); err == nil {
+			return parsed, true
+		}
+	}
+	return false, false
+}
+
+func stringSetting(v any) (string, bool) {
+	s, ok := v.(string)
+	return s, ok
+}
+
+func runtimeCLIVersion(metadata []byte) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(metadata, &payload); err != nil {
+		return ""
+	}
+	raw, ok := payload["cli_version"].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(raw)
+}
+
+func shouldAutoUpdate(currentVersion, targetVersion string) bool {
+	current := parseVersion(currentVersion)
+	target := parseVersion(targetVersion)
+	if len(target) == 0 {
+		return false
+	}
+	if len(current) == 0 {
+		return true
+	}
+	maxLen := len(current)
+	if len(target) > maxLen {
+		maxLen = len(target)
+	}
+	for i := 0; i < maxLen; i++ {
+		cur := 0
+		if i < len(current) {
+			cur = current[i]
+		}
+		tar := 0
+		if i < len(target) {
+			tar = target[i]
+		}
+		if tar > cur {
+			return true
+		}
+		if tar < cur {
+			return false
+		}
+	}
+	return false
+}
+
+func parseVersion(raw string) []int {
+	s := strings.TrimSpace(strings.TrimPrefix(raw, "v"))
+	if s == "" {
+		return nil
+	}
+	if idx := strings.IndexByte(s, '-'); idx >= 0 {
+		s = s[:idx]
+	}
+	parts := strings.Split(s, ".")
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		out = append(out, leadingDigits(part))
+	}
+	return out
+}
+
+func leadingDigits(part string) int {
+	part = strings.TrimSpace(part)
+	if part == "" {
+		return 0
+	}
+	n := 0
+	for _, r := range part {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+func (h *Handler) maybeCreateAutoUpdate(r *http.Request, rt db.AgentRuntime) *UpdateRequest {
+	ws, err := h.Queries.GetWorkspace(r.Context(), rt.WorkspaceID)
+	if err != nil {
+		return nil
+	}
+	cfg := parseRuntimeAutoUpdateSettings(ws.Settings)
+	if !cfg.Enabled {
+		return nil
+	}
+
+	targetVersion := strings.TrimSpace(cfg.TargetVersion)
+	if targetVersion == "" || strings.EqualFold(targetVersion, "latest") {
+		resolved, err := h.UpdateStore.ResolveLatestVersion(func() (string, error) {
+			latest, err := internalcli.FetchLatestRelease()
+			if err != nil {
+				return "", err
+			}
+			if latest == nil || strings.TrimSpace(latest.TagName) == "" {
+				return "", fmt.Errorf("latest release tag is empty")
+			}
+			return latest.TagName, nil
+		})
+		if err != nil {
+			slog.Warn("auto update: failed to resolve latest version", "runtime_id", uuidToString(rt.ID), "error", err)
+			return nil
+		}
+		targetVersion = resolved
+	}
+
+	currentVersion := runtimeCLIVersion(rt.Metadata)
+	if !shouldAutoUpdate(currentVersion, targetVersion) {
+		return nil
+	}
+
+	update, err := h.UpdateStore.CreateAuto(uuidToString(rt.ID), targetVersion, cfg.UpdateClients)
+	if err != nil {
+		if err != errUpdateInProgress {
+			slog.Warn("auto update: failed to create request", "runtime_id", uuidToString(rt.ID), "error", err)
+		}
+		return nil
+	}
+	if update != nil {
+		slog.Info("auto update queued", "runtime_id", uuidToString(rt.ID), "current_version", currentVersion, "target_version", targetVersion, "update_clients", cfg.UpdateClients)
+	}
+	return update
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -157,6 +409,7 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 
 	var req struct {
 		TargetVersion string `json:"target_version"`
+		UpdateClients *bool  `json:"update_clients"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -167,7 +420,11 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	update, err := h.UpdateStore.Create(runtimeID, req.TargetVersion)
+	updateClients := true
+	if req.UpdateClients != nil {
+		updateClients = *req.UpdateClients
+	}
+	update, err := h.UpdateStore.Create(runtimeID, req.TargetVersion, updateClients)
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return

--- a/server/internal/handler/runtime_update_test.go
+++ b/server/internal/handler/runtime_update_test.go
@@ -1,0 +1,111 @@
+package handler
+
+import "testing"
+
+func TestParseRuntimeAutoUpdateSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         []byte
+		wantEnabled bool
+		wantTarget  string
+		wantClients bool
+	}{
+		{
+			name:        "empty settings",
+			raw:         nil,
+			wantEnabled: false,
+			wantTarget:  "latest",
+			wantClients: true,
+		},
+		{
+			name:        "boolean enabled",
+			raw:         []byte(`{"runtime_auto_update": true}`),
+			wantEnabled: true,
+			wantTarget:  "latest",
+			wantClients: true,
+		},
+		{
+			name:        "object custom values",
+			raw:         []byte(`{"runtime_auto_update": {"enabled": false, "target_version": "v1.2.3", "update_clients": false}}`),
+			wantEnabled: false,
+			wantTarget:  "v1.2.3",
+			wantClients: false,
+		},
+		{
+			name:        "object defaults enabled",
+			raw:         []byte(`{"runtime_auto_update": {"target_version": "v2.0.0"}}`),
+			wantEnabled: true,
+			wantTarget:  "v2.0.0",
+			wantClients: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRuntimeAutoUpdateSettings(tc.raw)
+			if got.Enabled != tc.wantEnabled {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, tc.wantEnabled)
+			}
+			if got.TargetVersion != tc.wantTarget {
+				t.Fatalf("TargetVersion = %q, want %q", got.TargetVersion, tc.wantTarget)
+			}
+			if got.UpdateClients != tc.wantClients {
+				t.Fatalf("UpdateClients = %v, want %v", got.UpdateClients, tc.wantClients)
+			}
+		})
+	}
+}
+
+func TestShouldAutoUpdate(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		target  string
+		want    bool
+	}{
+		{name: "target newer", current: "0.1.0", target: "0.2.0", want: true},
+		{name: "same version", current: "v0.2.0", target: "0.2.0", want: false},
+		{name: "target older", current: "0.3.0", target: "0.2.9", want: false},
+		{name: "no current version", current: "", target: "1.0.0", want: true},
+		{name: "invalid target", current: "1.0.0", target: "latest", want: false},
+		{name: "prerelease target", current: "1.2.3", target: "1.2.4-beta.1", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldAutoUpdate(tc.current, tc.target); got != tc.want {
+				t.Fatalf("shouldAutoUpdate(%q, %q) = %v, want %v", tc.current, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateStoreCreateAutoThrottle(t *testing.T) {
+	store := NewUpdateStore()
+
+	first, err := store.CreateAuto("runtime-1", "v1.2.3", true)
+	if err != nil {
+		t.Fatalf("CreateAuto first call error: %v", err)
+	}
+	if first == nil {
+		t.Fatal("CreateAuto first call returned nil request")
+	}
+
+	store.Complete(first.ID, "ok")
+
+	second, err := store.CreateAuto("runtime-1", "v1.2.3", true)
+	if err != nil {
+		t.Fatalf("CreateAuto second call error: %v", err)
+	}
+	if second != nil {
+		t.Fatal("CreateAuto second call should be throttled and return nil")
+	}
+
+	third, err := store.CreateAuto("runtime-1", "v1.2.4", true)
+	if err != nil {
+		t.Fatalf("CreateAuto third call error: %v", err)
+	}
+	if third == nil {
+		t.Fatal("CreateAuto third call should allow a new target version")
+	}
+}


### PR DESCRIPTION
… update

Make `multica update` upgrade managed agent clients (Claude, Codex, Cursor) alongside the CLI so local runtimes stay compatible. Add workspace-controlled runtime auto-update settings and heartbeat-triggered update dispatch so the server can roll out latest versions automatically.

Made-with: Cursor