### PR TITLE
fix(dev): fix seed agent creation and daemon startup without providers

### DIFF
--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -33,7 +33,7 @@ create_agent() {
     --arg name "$name" \
     --arg desc "$description" \
     --arg inst "$instructions" \
-    '{name:$name, description:$desc, instructions:$inst, visibility:"workspace", max_concurrent_tasks:1}')
+    '{name:$name, description:$desc, instructions:$inst, providers:["claude"], visibility:"workspace", max_concurrent_tasks:1}')
   RESP=$(api POST /api/agents -d "$BODY")
   ANAME=$(echo "$RESP" | jq -r '.name // empty')
   if [ -z "$ANAME" ]; then

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -91,13 +91,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return err
 	}
 
-	runtimeIDs := d.allRuntimeIDs()
-	if len(runtimeIDs) == 0 {
-		return fmt.Errorf("no runtimes registered")
-	}
-
 	// Deregister runtimes on shutdown (uses a fresh context since ctx will be cancelled).
 	defer d.deregisterRuntimes()
+
+	if len(d.allRuntimeIDs()) == 0 {
+		d.logger.Warn("no runtimes registered — daemon will wait for providers to become available via heartbeat")
+	}
 
 	// Start config watcher for hot-reload.
 	go d.configWatchLoop(ctx)
@@ -177,11 +176,16 @@ func (d *Daemon) loadWatchedWorkspaces(ctx context.Context) error {
 		return fmt.Errorf("no watched workspaces configured: run 'multica workspace watch <id>' to add one")
 	}
 
-	var registered int
 	for _, ws := range cfg.WatchedWorkspaces {
 		resp, err := d.registerRuntimesForWorkspace(ctx, ws.ID)
 		if err != nil {
-			d.logger.Error("failed to register runtimes", "workspace_id", ws.ID, "name", ws.Name, "error", err)
+			d.logger.Warn("failed to register runtimes", "workspace_id", ws.ID, "name", ws.Name, "error", err)
+			// Still track the workspace so heartbeat/reconcile can register runtimes later.
+			d.mu.Lock()
+			if _, ok := d.workspaces[ws.ID]; !ok {
+				d.workspaces[ws.ID] = &workspaceState{workspaceID: ws.ID}
+			}
+			d.mu.Unlock()
 			continue
 		}
 		runtimeIDs := make([]string, len(resp.Runtimes))
@@ -204,11 +208,6 @@ func (d *Daemon) loadWatchedWorkspaces(ctx context.Context) error {
 		}
 
 		d.logger.Info("watching workspace", "workspace_id", ws.ID, "name", ws.Name, "runtimes", len(resp.Runtimes), "repos", len(resp.Repos))
-		registered++
-	}
-
-	if registered == 0 {
-		return fmt.Errorf("failed to register runtimes for any of the %d watched workspace(s)", len(cfg.WatchedWorkspaces))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **Seed script**: Added missing `providers: ["claude"]` to agent creation request body — the backend requires this field but the seed script never included it, causing `make dev` to fail with `"providers is required"`.
- **Daemon startup**: Made the daemon start gracefully when no agent CLIs (`claude`, `codex`) are available. Instead of crashing, it now logs a warning and waits for providers to become available via heartbeat reconciliation. The `pollLoop` already handles zero runtimes correctly.

## Test plan

- [ ] Run `make dev` and verify seed completes without errors
- [ ] Verify daemon container stays running (logs warning instead of crashing)
- [ ] Verify the rest of the dev environment (frontend, backend) works normally


Made with [Cursor](https://cursor.com)