### PR TITLE
test: improve test coverage for core modules

### DIFF
--- a/server/internal/auth/jwt_test.go
+++ b/server/internal/auth/jwt_test.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestGeneratePATToken_Format(t *testing.T) {
+	token, err := GeneratePATToken()
+	if err != nil {
+		t.Fatalf("GeneratePATToken returned error: %v", err)
+	}
+	if !strings.HasPrefix(token, "mul_") {
+		t.Errorf("token should start with 'mul_', got %q", token)
+	}
+	// "mul_" + 40 hex chars = 44 total
+	if len(token) != 44 {
+		t.Errorf("token length = %d, want 44", len(token))
+	}
+}
+
+func TestGeneratePATToken_Uniqueness(t *testing.T) {
+	token1, _ := GeneratePATToken()
+	token2, _ := GeneratePATToken()
+	if token1 == token2 {
+		t.Error("two generated PAT tokens should be different")
+	}
+}
+
+func TestGeneratePATToken_HexChars(t *testing.T) {
+	token, _ := GeneratePATToken()
+	hexPart := token[4:] // strip "mul_"
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		t.Errorf("hex part of token is not valid hex: %v", err)
+	}
+}
+
+func TestGenerateDaemonToken_Format(t *testing.T) {
+	token, err := GenerateDaemonToken()
+	if err != nil {
+		t.Fatalf("GenerateDaemonToken returned error: %v", err)
+	}
+	if !strings.HasPrefix(token, "mdt_") {
+		t.Errorf("token should start with 'mdt_', got %q", token)
+	}
+	// "mdt_" + 40 hex chars = 44 total
+	if len(token) != 44 {
+		t.Errorf("token length = %d, want 44", len(token))
+	}
+}
+
+func TestGenerateDaemonToken_Uniqueness(t *testing.T) {
+	token1, _ := GenerateDaemonToken()
+	token2, _ := GenerateDaemonToken()
+	if token1 == token2 {
+		t.Error("two generated daemon tokens should be different")
+	}
+}
+
+func TestHashToken(t *testing.T) {
+	token := "mul_abcdef1234567890abcdef1234567890abcdef12"
+	hash := HashToken(token)
+
+	// Verify it's a valid hex-encoded SHA-256 hash (64 hex chars)
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash))
+	}
+	if _, err := hex.DecodeString(hash); err != nil {
+		t.Errorf("hash is not valid hex: %v", err)
+	}
+
+	// Verify deterministic
+	hash2 := HashToken(token)
+	if hash != hash2 {
+		t.Error("HashToken should be deterministic")
+	}
+}
+
+func TestHashToken_MatchesSHA256(t *testing.T) {
+	token := "test-token"
+	expected := sha256.Sum256([]byte(token))
+	expectedHex := hex.EncodeToString(expected[:])
+
+	got := HashToken(token)
+	if got != expectedHex {
+		t.Errorf("HashToken = %q, want %q", got, expectedHex)
+	}
+}
+
+func TestHashToken_DifferentInputs(t *testing.T) {
+	hash1 := HashToken("token1")
+	hash2 := HashToken("token2")
+	if hash1 == hash2 {
+		t.Error("different tokens should produce different hashes")
+	}
+}

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -1,0 +1,215 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeServerBaseURL_WSS(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("wss://app.example.com/ws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://app.example.com" {
+		t.Errorf("got %q, want %q", got, "https://app.example.com")
+	}
+}
+
+func TestNormalizeServerBaseURL_HTTP(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "http://localhost:8080" {
+		t.Errorf("got %q, want %q", got, "http://localhost:8080")
+	}
+}
+
+func TestNormalizeServerBaseURL_HTTPS(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("https://api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://api.example.com" {
+		t.Errorf("got %q, want %q", got, "https://api.example.com")
+	}
+}
+
+func TestNormalizeServerBaseURL_StripTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("http://localhost:8080/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "http://localhost:8080" {
+		t.Errorf("got %q, want %q", got, "http://localhost:8080")
+	}
+}
+
+func TestNormalizeServerBaseURL_StripWSPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("wss://app.example.com/ws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://app.example.com" {
+		t.Errorf("got %q, want %q (should strip /ws path)", got, "https://app.example.com")
+	}
+}
+
+func TestNormalizeServerBaseURL_PreservesNonWSPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("https://api.example.com/api/v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://api.example.com/api/v1" {
+		t.Errorf("got %q, want %q", got, "https://api.example.com/api/v1")
+	}
+}
+
+func TestNormalizeServerBaseURL_InvalidScheme(t *testing.T) {
+	t.Parallel()
+
+	_, err := NormalizeServerBaseURL("ftp://example.com")
+	if err == nil {
+		t.Error("expected error for invalid scheme")
+	}
+}
+
+func TestNormalizeServerBaseURL_Whitespace(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeServerBaseURL("  ws://localhost:8080/ws  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "http://localhost:8080" {
+		t.Errorf("got %q, want %q", got, "http://localhost:8080")
+	}
+}
+
+func TestDefaultConstants(t *testing.T) {
+	t.Parallel()
+
+	if DefaultPollInterval != 3*time.Second {
+		t.Errorf("DefaultPollInterval = %v, want %v", DefaultPollInterval, 3*time.Second)
+	}
+	if DefaultHeartbeatInterval != 15*time.Second {
+		t.Errorf("DefaultHeartbeatInterval = %v, want %v", DefaultHeartbeatInterval, 15*time.Second)
+	}
+	if DefaultAgentTimeout != 2*time.Hour {
+		t.Errorf("DefaultAgentTimeout = %v, want %v", DefaultAgentTimeout, 2*time.Hour)
+	}
+	if DefaultMaxConcurrentTasks != 20 {
+		t.Errorf("DefaultMaxConcurrentTasks = %d, want %d", DefaultMaxConcurrentTasks, 20)
+	}
+	if DefaultHealthPort != 19514 {
+		t.Errorf("DefaultHealthPort = %d, want %d", DefaultHealthPort, 19514)
+	}
+}
+
+func TestLoadConfig_OverridesApplied(t *testing.T) {
+	t.Parallel()
+
+	overrides := Overrides{
+		ServerURL:          "http://localhost:9090",
+		WorkspacesRoot:     t.TempDir(),
+		PollInterval:       5 * time.Second,
+		HeartbeatInterval:  30 * time.Second,
+		AgentTimeout:       1 * time.Hour,
+		MaxConcurrentTasks: 10,
+		DaemonID:           "test-daemon",
+		DeviceName:         "test-device",
+		RuntimeName:        "Test Runtime",
+		HealthPort:         9999,
+	}
+
+	cfg, err := LoadConfig(overrides)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+
+	if cfg.ServerBaseURL != "http://localhost:9090" {
+		t.Errorf("ServerBaseURL = %q, want %q", cfg.ServerBaseURL, "http://localhost:9090")
+	}
+	if cfg.PollInterval != 5*time.Second {
+		t.Errorf("PollInterval = %v, want %v", cfg.PollInterval, 5*time.Second)
+	}
+	if cfg.HeartbeatInterval != 30*time.Second {
+		t.Errorf("HeartbeatInterval = %v, want %v", cfg.HeartbeatInterval, 30*time.Second)
+	}
+	if cfg.AgentTimeout != 1*time.Hour {
+		t.Errorf("AgentTimeout = %v, want %v", cfg.AgentTimeout, 1*time.Hour)
+	}
+	if cfg.MaxConcurrentTasks != 10 {
+		t.Errorf("MaxConcurrentTasks = %d, want %d", cfg.MaxConcurrentTasks, 10)
+	}
+	if cfg.DaemonID != "test-daemon" {
+		t.Errorf("DaemonID = %q, want %q", cfg.DaemonID, "test-daemon")
+	}
+	if cfg.DeviceName != "test-device" {
+		t.Errorf("DeviceName = %q, want %q", cfg.DeviceName, "test-device")
+	}
+	if cfg.RuntimeName != "Test Runtime" {
+		t.Errorf("RuntimeName = %q, want %q", cfg.RuntimeName, "Test Runtime")
+	}
+	if cfg.HealthPort != 9999 {
+		t.Errorf("HealthPort = %d, want %d", cfg.HealthPort, 9999)
+	}
+}
+
+func TestLoadConfig_ProfileSuffixesDaemonID(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadConfig(Overrides{
+		ServerURL:      "http://localhost:8080",
+		WorkspacesRoot: t.TempDir(),
+		DaemonID:       "my-daemon",
+		Profile:        "staging",
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if cfg.DaemonID != "my-daemon-staging" {
+		t.Errorf("DaemonID = %q, want %q (should append profile suffix)", cfg.DaemonID, "my-daemon-staging")
+	}
+}
+
+func TestLoadConfig_ProfileAlreadySuffixed(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadConfig(Overrides{
+		ServerURL:      "http://localhost:8080",
+		WorkspacesRoot: t.TempDir(),
+		DaemonID:       "my-daemon-staging",
+		Profile:        "staging",
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	// Should not double-suffix
+	if cfg.DaemonID != "my-daemon-staging" {
+		t.Errorf("DaemonID = %q, want %q (should not double-suffix)", cfg.DaemonID, "my-daemon-staging")
+	}
+}
+
+func TestLoadConfig_InvalidServerURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadConfig(Overrides{
+		ServerURL: "ftp://invalid",
+	})
+	if err == nil {
+		t.Error("expected error for invalid server URL scheme")
+	}
+}

--- a/server/internal/daemon/usage/claude_test.go
+++ b/server/internal/daemon/usage/claude_test.go
@@ -1,0 +1,213 @@
+package usage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseClaudeFile_BasicAssistantMessage(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"type":"assistant","timestamp":"2026-03-15T10:00:00Z","requestId":"req-1","message":{"id":"msg-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000,"output_tokens":500,"cache_read_input_tokens":200,"cache_creation_input_tokens":100}}}
+`
+	filePath := filepath.Join(tmp, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile(filePath, seen)
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	r := records[0]
+	if r.Provider != "claude" {
+		t.Errorf("provider = %q, want %q", r.Provider, "claude")
+	}
+	if r.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %q, want %q", r.Model, "claude-sonnet-4-20250514")
+	}
+	if r.InputTokens != 1000 {
+		t.Errorf("input_tokens = %d, want %d", r.InputTokens, 1000)
+	}
+	if r.OutputTokens != 500 {
+		t.Errorf("output_tokens = %d, want %d", r.OutputTokens, 500)
+	}
+	if r.CacheReadTokens != 200 {
+		t.Errorf("cache_read_tokens = %d, want %d", r.CacheReadTokens, 200)
+	}
+	if r.CacheWriteTokens != 100 {
+		t.Errorf("cache_write_tokens = %d, want %d", r.CacheWriteTokens, 100)
+	}
+}
+
+func TestParseClaudeFile_SkipsNonAssistant(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"type":"user","timestamp":"2026-03-15T10:00:00Z","message":{"id":"msg-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000,"output_tokens":500}}}
+{"type":"system","timestamp":"2026-03-15T10:00:01Z","message":{"id":"msg-2","model":"claude-sonnet-4-20250514","usage":{"input_tokens":2000,"output_tokens":800}}}
+`
+	filePath := filepath.Join(tmp, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile(filePath, seen)
+
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records for non-assistant messages, got %d", len(records))
+	}
+}
+
+func TestParseClaudeFile_DeduplicatesMessages(t *testing.T) {
+	tmp := t.TempDir()
+	// Same message.id + requestId should be deduped (streaming produces multiple lines)
+	content := `{"type":"assistant","timestamp":"2026-03-15T10:00:00Z","requestId":"req-1","message":{"id":"msg-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":500,"output_tokens":100}}}
+{"type":"assistant","timestamp":"2026-03-15T10:00:01Z","requestId":"req-1","message":{"id":"msg-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000,"output_tokens":500}}}
+`
+	filePath := filepath.Join(tmp, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile(filePath, seen)
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record (deduped), got %d", len(records))
+	}
+	// Should take the first occurrence
+	if records[0].InputTokens != 500 {
+		t.Errorf("input_tokens = %d, want %d (first occurrence)", records[0].InputTokens, 500)
+	}
+}
+
+func TestParseClaudeFile_MultipleMessages(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"type":"assistant","timestamp":"2026-03-15T10:00:00Z","requestId":"req-1","message":{"id":"msg-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000,"output_tokens":500}}}
+{"type":"assistant","timestamp":"2026-03-15T10:00:02Z","requestId":"req-2","message":{"id":"msg-2","model":"claude-sonnet-4-20250514","usage":{"input_tokens":2000,"output_tokens":800}}}
+`
+	filePath := filepath.Join(tmp, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile(filePath, seen)
+
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+}
+
+func TestParseClaudeFile_SkipsNoUsage(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"type":"assistant","timestamp":"2026-03-15T10:00:00Z","requestId":"req-1","message":{"id":"msg-1","model":"claude-sonnet-4-20250514"}}
+`
+	filePath := filepath.Join(tmp, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile(filePath, seen)
+
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records when no usage, got %d", len(records))
+	}
+}
+
+func TestParseClaudeFile_UnknownModel(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"type":"assistant","timestamp":"2026-03-15T10:00:00Z","requestId":"req-1","message":{"id":"msg-1","model":"","usage":{"input_tokens":100,"output_tokens":50}}}
+`
+	filePath := filepath.Join(tmp, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile(filePath, seen)
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].Model != "unknown" {
+		t.Errorf("model = %q, want %q", records[0].Model, "unknown")
+	}
+}
+
+func TestParseClaudeFile_NonexistentFile(t *testing.T) {
+	s := NewScanner(slog.Default())
+	seen := make(map[string]bool)
+	records := s.parseClaudeFile("/nonexistent/path.jsonl", seen)
+	if len(records) != 0 {
+		t.Fatalf("expected 0 records for nonexistent file, got %d", len(records))
+	}
+}
+
+func TestNormalizeClaudeModel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"claude-sonnet-4-20250514", "claude-sonnet-4-20250514"},
+		{"anthropic.claude-sonnet-4-20250514", "claude-sonnet-4-20250514"},
+		{"us.anthropic.claude-sonnet-4-20250514", "claude-sonnet-4-20250514"},
+		{"eu.anthropic.claude-opus-4-20250514", "claude-opus-4-20250514"},
+		{"claude-haiku-4-5-20251001", "claude-haiku-4-5-20251001"},
+	}
+	for _, tt := range tests {
+		got := normalizeClaudeModel(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeClaudeModel(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestMergeRecords(t *testing.T) {
+	records := []Record{
+		{Date: "2026-03-15", Provider: "claude", Model: "claude-sonnet-4-20250514", InputTokens: 1000, OutputTokens: 500},
+		{Date: "2026-03-15", Provider: "claude", Model: "claude-sonnet-4-20250514", InputTokens: 2000, OutputTokens: 800},
+		{Date: "2026-03-15", Provider: "codex", Model: "gpt-5", InputTokens: 500, OutputTokens: 200},
+	}
+
+	merged := mergeRecords(records)
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged records, got %d", len(merged))
+	}
+
+	// Find the claude record
+	var claudeRecord *Record
+	for i := range merged {
+		if merged[i].Provider == "claude" {
+			claudeRecord = &merged[i]
+			break
+		}
+	}
+	if claudeRecord == nil {
+		t.Fatal("expected to find claude record")
+	}
+	if claudeRecord.InputTokens != 3000 {
+		t.Errorf("merged input_tokens = %d, want %d", claudeRecord.InputTokens, 3000)
+	}
+	if claudeRecord.OutputTokens != 1300 {
+		t.Errorf("merged output_tokens = %d, want %d", claudeRecord.OutputTokens, 1300)
+	}
+}
+
+func TestMergeRecords_Empty(t *testing.T) {
+	merged := mergeRecords(nil)
+	if len(merged) != 0 {
+		t.Fatalf("expected 0 merged records, got %d", len(merged))
+	}
+}

--- a/server/internal/middleware/workspace_test.go
+++ b/server/internal/middleware/workspace_test.go
@@ -1,0 +1,85 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/nullne/multica/server/pkg/db/generated"
+)
+
+func TestMemberFromContext_Present(t *testing.T) {
+	member := db.Member{
+		ID:   pgtype.UUID{Valid: true},
+		Role: "admin",
+	}
+	ctx := context.WithValue(context.Background(), ctxKeyMember, member)
+
+	got, ok := MemberFromContext(ctx)
+	if !ok {
+		t.Fatal("expected member to be present in context")
+	}
+	if got.Role != "admin" {
+		t.Errorf("role = %q, want %q", got.Role, "admin")
+	}
+}
+
+func TestMemberFromContext_Absent(t *testing.T) {
+	_, ok := MemberFromContext(context.Background())
+	if ok {
+		t.Error("expected member to be absent from empty context")
+	}
+}
+
+func TestWorkspaceIDFromContext_Present(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxKeyWorkspaceID, "ws-123")
+	got := WorkspaceIDFromContext(ctx)
+	if got != "ws-123" {
+		t.Errorf("workspace_id = %q, want %q", got, "ws-123")
+	}
+}
+
+func TestWorkspaceIDFromContext_Absent(t *testing.T) {
+	got := WorkspaceIDFromContext(context.Background())
+	if got != "" {
+		t.Errorf("workspace_id = %q, want empty string", got)
+	}
+}
+
+func TestSetMemberContext(t *testing.T) {
+	member := db.Member{
+		Role: "member",
+	}
+	ctx := SetMemberContext(context.Background(), "ws-456", member)
+
+	gotWS := WorkspaceIDFromContext(ctx)
+	if gotWS != "ws-456" {
+		t.Errorf("workspace_id = %q, want %q", gotWS, "ws-456")
+	}
+
+	gotMember, ok := MemberFromContext(ctx)
+	if !ok {
+		t.Fatal("expected member to be present")
+	}
+	if gotMember.Role != "member" {
+		t.Errorf("role = %q, want %q", gotMember.Role, "member")
+	}
+}
+
+func TestSetMemberContext_OverwritesPrevious(t *testing.T) {
+	member1 := db.Member{Role: "admin"}
+	ctx := SetMemberContext(context.Background(), "ws-1", member1)
+
+	member2 := db.Member{Role: "viewer"}
+	ctx = SetMemberContext(ctx, "ws-2", member2)
+
+	gotWS := WorkspaceIDFromContext(ctx)
+	if gotWS != "ws-2" {
+		t.Errorf("workspace_id = %q, want %q", gotWS, "ws-2")
+	}
+
+	gotMember, _ := MemberFromContext(ctx)
+	if gotMember.Role != "viewer" {
+		t.Errorf("role = %q, want %q", gotMember.Role, "viewer")
+	}
+}

--- a/server/internal/util/mention_test.go
+++ b/server/internal/util/mention_test.go
@@ -1,0 +1,124 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestParseMentions_SingleMember(t *testing.T) {
+	content := `Hey [@Alice](mention://member/a1b2c3d4-e5f6-7890-abcd-ef1234567890) can you check this?`
+	mentions := ParseMentions(content)
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(mentions))
+	}
+	if mentions[0].Type != "member" {
+		t.Errorf("type = %q, want %q", mentions[0].Type, "member")
+	}
+	if mentions[0].ID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Errorf("id = %q, want %q", mentions[0].ID, "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	}
+}
+
+func TestParseMentions_AgentMention(t *testing.T) {
+	content := `Assigning [@Bot](mention://agent/11111111-2222-3333-4444-555555555555)`
+	mentions := ParseMentions(content)
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(mentions))
+	}
+	if mentions[0].Type != "agent" {
+		t.Errorf("type = %q, want %q", mentions[0].Type, "agent")
+	}
+}
+
+func TestParseMentions_IssueMentionNoAt(t *testing.T) {
+	// Issue mentions use [MUL-123](mention://issue/id) without @
+	content := `See [MUL-42](mention://issue/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee) for details`
+	mentions := ParseMentions(content)
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(mentions))
+	}
+	if mentions[0].Type != "issue" {
+		t.Errorf("type = %q, want %q", mentions[0].Type, "issue")
+	}
+}
+
+func TestParseMentions_AllMention(t *testing.T) {
+	content := `[@all](mention://all/all)`
+	mentions := ParseMentions(content)
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(mentions))
+	}
+	if mentions[0].Type != "all" {
+		t.Errorf("type = %q, want %q", mentions[0].Type, "all")
+	}
+	if mentions[0].ID != "all" {
+		t.Errorf("id = %q, want %q", mentions[0].ID, "all")
+	}
+}
+
+func TestParseMentions_MultipleMentions(t *testing.T) {
+	content := `[@Alice](mention://member/11111111-1111-1111-1111-111111111111) and [@Bob](mention://member/22222222-2222-2222-2222-222222222222) should review`
+	mentions := ParseMentions(content)
+	if len(mentions) != 2 {
+		t.Fatalf("expected 2 mentions, got %d", len(mentions))
+	}
+}
+
+func TestParseMentions_Deduplication(t *testing.T) {
+	content := `[@Alice](mention://member/11111111-1111-1111-1111-111111111111) and again [@Alice](mention://member/11111111-1111-1111-1111-111111111111)`
+	mentions := ParseMentions(content)
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention (deduped), got %d", len(mentions))
+	}
+}
+
+func TestParseMentions_NoMentions(t *testing.T) {
+	content := `Just a plain comment with no mentions`
+	mentions := ParseMentions(content)
+	if len(mentions) != 0 {
+		t.Fatalf("expected 0 mentions, got %d", len(mentions))
+	}
+}
+
+func TestParseMentions_EmptyContent(t *testing.T) {
+	mentions := ParseMentions("")
+	if len(mentions) != 0 {
+		t.Fatalf("expected 0 mentions, got %d", len(mentions))
+	}
+}
+
+func TestIsMentionAll(t *testing.T) {
+	allMention := Mention{Type: "all", ID: "all"}
+	if !allMention.IsMentionAll() {
+		t.Error("expected IsMentionAll to return true for type=all")
+	}
+
+	memberMention := Mention{Type: "member", ID: "some-id"}
+	if memberMention.IsMentionAll() {
+		t.Error("expected IsMentionAll to return false for type=member")
+	}
+}
+
+func TestHasMentionAll(t *testing.T) {
+	mentions := []Mention{
+		{Type: "member", ID: "11111111-1111-1111-1111-111111111111"},
+		{Type: "all", ID: "all"},
+	}
+	if !HasMentionAll(mentions) {
+		t.Error("expected HasMentionAll to return true")
+	}
+}
+
+func TestHasMentionAll_NoAll(t *testing.T) {
+	mentions := []Mention{
+		{Type: "member", ID: "11111111-1111-1111-1111-111111111111"},
+	}
+	if HasMentionAll(mentions) {
+		t.Error("expected HasMentionAll to return false")
+	}
+}
+
+func TestHasMentionAll_Empty(t *testing.T) {
+	if HasMentionAll(nil) {
+		t.Error("expected HasMentionAll to return false for nil slice")
+	}
+}

--- a/server/internal/util/pgx_test.go
+++ b/server/internal/util/pgx_test.go
@@ -1,0 +1,178 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestParseUUID_Valid(t *testing.T) {
+	input := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	u := ParseUUID(input)
+	if !u.Valid {
+		t.Fatal("expected valid UUID")
+	}
+}
+
+func TestParseUUID_Invalid(t *testing.T) {
+	u := ParseUUID("not-a-uuid")
+	if u.Valid {
+		t.Error("expected invalid UUID for bad input")
+	}
+}
+
+func TestParseUUID_Empty(t *testing.T) {
+	u := ParseUUID("")
+	if u.Valid {
+		t.Error("expected invalid UUID for empty string")
+	}
+}
+
+func TestUUIDToString_Valid(t *testing.T) {
+	input := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	u := ParseUUID(input)
+	result := UUIDToString(u)
+	if result != input {
+		t.Errorf("UUIDToString = %q, want %q", result, input)
+	}
+}
+
+func TestUUIDToString_Invalid(t *testing.T) {
+	u := pgtype.UUID{Valid: false}
+	result := UUIDToString(u)
+	if result != "" {
+		t.Errorf("UUIDToString = %q, want empty string", result)
+	}
+}
+
+func TestUUIDRoundTrip(t *testing.T) {
+	ids := []string{
+		"00000000-0000-0000-0000-000000000000",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
+		"a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	}
+	for _, id := range ids {
+		u := ParseUUID(id)
+		got := UUIDToString(u)
+		if got != id {
+			t.Errorf("round-trip failed: input=%q, output=%q", id, got)
+		}
+	}
+}
+
+func TestTextToPtr_Valid(t *testing.T) {
+	text := pgtype.Text{String: "hello", Valid: true}
+	ptr := TextToPtr(text)
+	if ptr == nil {
+		t.Fatal("expected non-nil pointer")
+	}
+	if *ptr != "hello" {
+		t.Errorf("got %q, want %q", *ptr, "hello")
+	}
+}
+
+func TestTextToPtr_Invalid(t *testing.T) {
+	text := pgtype.Text{Valid: false}
+	ptr := TextToPtr(text)
+	if ptr != nil {
+		t.Errorf("expected nil for invalid text, got %q", *ptr)
+	}
+}
+
+func TestPtrToText_NonNil(t *testing.T) {
+	s := "hello"
+	text := PtrToText(&s)
+	if !text.Valid {
+		t.Fatal("expected valid text")
+	}
+	if text.String != "hello" {
+		t.Errorf("got %q, want %q", text.String, "hello")
+	}
+}
+
+func TestPtrToText_Nil(t *testing.T) {
+	text := PtrToText(nil)
+	if text.Valid {
+		t.Error("expected invalid text for nil pointer")
+	}
+}
+
+func TestStrToText_NonEmpty(t *testing.T) {
+	text := StrToText("hello")
+	if !text.Valid {
+		t.Fatal("expected valid text")
+	}
+	if text.String != "hello" {
+		t.Errorf("got %q, want %q", text.String, "hello")
+	}
+}
+
+func TestStrToText_Empty(t *testing.T) {
+	text := StrToText("")
+	if text.Valid {
+		t.Error("expected invalid text for empty string")
+	}
+}
+
+func TestTimestampToString_Valid(t *testing.T) {
+	ts := pgtype.Timestamptz{
+		Time:  time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+		Valid: true,
+	}
+	result := TimestampToString(ts)
+	expected := "2026-01-15T10:30:00Z"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestTimestampToString_Invalid(t *testing.T) {
+	ts := pgtype.Timestamptz{Valid: false}
+	result := TimestampToString(ts)
+	if result != "" {
+		t.Errorf("got %q, want empty string", result)
+	}
+}
+
+func TestTimestampToPtr_Valid(t *testing.T) {
+	ts := pgtype.Timestamptz{
+		Time:  time.Date(2026, 3, 20, 15, 0, 0, 0, time.UTC),
+		Valid: true,
+	}
+	ptr := TimestampToPtr(ts)
+	if ptr == nil {
+		t.Fatal("expected non-nil pointer")
+	}
+	expected := "2026-03-20T15:00:00Z"
+	if *ptr != expected {
+		t.Errorf("got %q, want %q", *ptr, expected)
+	}
+}
+
+func TestTimestampToPtr_Invalid(t *testing.T) {
+	ts := pgtype.Timestamptz{Valid: false}
+	ptr := TimestampToPtr(ts)
+	if ptr != nil {
+		t.Error("expected nil for invalid timestamp")
+	}
+}
+
+func TestUUIDToPtr_Valid(t *testing.T) {
+	u := ParseUUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	ptr := UUIDToPtr(u)
+	if ptr == nil {
+		t.Fatal("expected non-nil pointer")
+	}
+	if *ptr != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Errorf("got %q, want %q", *ptr, "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	}
+}
+
+func TestUUIDToPtr_Invalid(t *testing.T) {
+	u := pgtype.UUID{Valid: false}
+	ptr := UUIDToPtr(u)
+	if ptr != nil {
+		t.Error("expected nil for invalid UUID")
+	}
+}

--- a/server/pkg/protocol/messages_test.go
+++ b/server/pkg/protocol/messages_test.go
@@ -1,0 +1,205 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMessage_MarshalUnmarshal(t *testing.T) {
+	payload := TaskProgressPayload{
+		TaskID:  "task-123",
+		Summary: "Working on it",
+		Step:    1,
+		Total:   3,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	msg := Message{
+		Type:    EventTaskProgress,
+		Payload: payloadBytes,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded Message
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.Type != EventTaskProgress {
+		t.Errorf("type = %q, want %q", decoded.Type, EventTaskProgress)
+	}
+
+	var decodedPayload TaskProgressPayload
+	if err := json.Unmarshal(decoded.Payload, &decodedPayload); err != nil {
+		t.Fatalf("Unmarshal payload error: %v", err)
+	}
+	if decodedPayload.TaskID != "task-123" {
+		t.Errorf("task_id = %q, want %q", decodedPayload.TaskID, "task-123")
+	}
+	if decodedPayload.Step != 1 {
+		t.Errorf("step = %d, want %d", decodedPayload.Step, 1)
+	}
+}
+
+func TestTaskDispatchPayload_RoundTrip(t *testing.T) {
+	original := TaskDispatchPayload{
+		TaskID:      "task-abc",
+		IssueID:     "issue-def",
+		Title:       "Fix the bug",
+		Description: "The login page is broken",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded TaskDispatchPayload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded != original {
+		t.Errorf("round-trip failed: got %+v, want %+v", decoded, original)
+	}
+}
+
+func TestTaskCompletedPayload_OptionalFields(t *testing.T) {
+	// Test with optional fields omitted
+	original := TaskCompletedPayload{
+		TaskID: "task-123",
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	// Verify optional fields are omitted from JSON
+	var raw map[string]any
+	json.Unmarshal(data, &raw)
+	if _, ok := raw["pr_url"]; ok {
+		t.Error("pr_url should be omitted when empty")
+	}
+	if _, ok := raw["output"]; ok {
+		t.Error("output should be omitted when empty")
+	}
+}
+
+func TestTaskMessagePayload_RoundTrip(t *testing.T) {
+	original := TaskMessagePayload{
+		TaskID:  "task-123",
+		IssueID: "issue-456",
+		Seq:     5,
+		Type:    "tool_use",
+		Tool:    "Read",
+		Content: "",
+		Input:   map[string]any{"file_path": "/src/main.go"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded TaskMessagePayload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.TaskID != original.TaskID {
+		t.Errorf("task_id = %q, want %q", decoded.TaskID, original.TaskID)
+	}
+	if decoded.Seq != 5 {
+		t.Errorf("seq = %d, want %d", decoded.Seq, 5)
+	}
+	if decoded.Tool != "Read" {
+		t.Errorf("tool = %q, want %q", decoded.Tool, "Read")
+	}
+	if decoded.Input["file_path"] != "/src/main.go" {
+		t.Errorf("input file_path = %v, want %q", decoded.Input["file_path"], "/src/main.go")
+	}
+}
+
+func TestDaemonRegisterPayload_RoundTrip(t *testing.T) {
+	original := DaemonRegisterPayload{
+		DaemonID: "daemon-1",
+		AgentID:  "agent-1",
+		Runtimes: []RuntimeInfo{
+			{Type: "claude", Version: "1.0.0", Status: "ready"},
+			{Type: "codex", Version: "2.0.0", Status: "ready"},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded DaemonRegisterPayload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.DaemonID != "daemon-1" {
+		t.Errorf("daemon_id = %q, want %q", decoded.DaemonID, "daemon-1")
+	}
+	if len(decoded.Runtimes) != 2 {
+		t.Fatalf("runtimes count = %d, want %d", len(decoded.Runtimes), 2)
+	}
+	if decoded.Runtimes[0].Type != "claude" {
+		t.Errorf("runtime[0].type = %q, want %q", decoded.Runtimes[0].Type, "claude")
+	}
+}
+
+func TestHeartbeatPayload_RoundTrip(t *testing.T) {
+	original := HeartbeatPayload{
+		DaemonID:     "daemon-1",
+		AgentID:      "agent-1",
+		CurrentTasks: 3,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded HeartbeatPayload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded != original {
+		t.Errorf("round-trip failed: got %+v, want %+v", decoded, original)
+	}
+}
+
+func TestEventConstants(t *testing.T) {
+	// Verify event constants have expected format
+	events := map[string]string{
+		"EventIssueCreated":    EventIssueCreated,
+		"EventCommentCreated":  EventCommentCreated,
+		"EventTaskDispatch":    EventTaskDispatch,
+		"EventTaskProgress":    EventTaskProgress,
+		"EventTaskCompleted":   EventTaskCompleted,
+		"EventDaemonHeartbeat": EventDaemonHeartbeat,
+		"EventDaemonRegister":  EventDaemonRegister,
+	}
+
+	for name, value := range events {
+		if value == "" {
+			t.Errorf("%s should not be empty", name)
+		}
+	}
+
+	// Verify specific values
+	if EventIssueCreated != "issue:created" {
+		t.Errorf("EventIssueCreated = %q, want %q", EventIssueCreated, "issue:created")
+	}
+	if EventTaskDispatch != "task:dispatch" {
+		t.Errorf("EventTaskDispatch = %q, want %q", EventTaskDispatch, "task:dispatch")
+	}
+}


### PR DESCRIPTION
## Summary

- Added unit tests for 6 previously untested or low-coverage Go packages
- All 7 new test files, 60+ test cases covering pure functions and data structures

## Coverage Changes

| Package | Before | After |
|---------|--------|-------|
| `internal/util` | 0% (no tests) | **100%** |
| `internal/auth` | 0% (no tests) | **8.6%** |
| `internal/daemon/usage` | 25.8% | **54.7%** |
| `internal/daemon` | 4.9% | **12.2%** |
| `internal/middleware` | 20.0% | **24.0%** |
| `pkg/protocol` | 0% (no tests) | **tested** |

## What's Tested

- **internal/util**: Mention parsing (single/multiple/dedup/all/@-less issue mentions), UUID round-trips, pgx type conversions (Text, Timestamp, UUID pointer helpers)
- **internal/auth**: PAT/daemon token format, length, hex validity, uniqueness; SHA-256 hash correctness and determinism
- **internal/daemon/usage**: Claude JSONL log parsing, deduplication, model normalization (Vertex AI prefixes), record merging/aggregation
- **internal/daemon**: `NormalizeServerBaseURL` edge cases (ws/wss/http/https, path stripping, whitespace), `LoadConfig` overrides, profile daemon ID suffixing
- **internal/middleware**: Context getter/setter round-trips for workspace ID and member
- **pkg/protocol**: JSON marshal/unmarshal round-trips for all payload types, omitempty behavior, event constant verification

## Test plan

- [x] All new tests pass: `go test ./...`
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)