### PR TITLE
feat(web,server): editable dispatch hints, daemon picker, and codex auth fix

### DIFF
--- a/apps/web/features/issues/components/agent-dispatch-badge.tsx
+++ b/apps/web/features/issues/components/agent-dispatch-badge.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Bot, Monitor } from "lucide-react";
+import { useWorkspaceStore } from "@/features/workspace";
+import { useRuntimeStore } from "@/features/runtimes";
+import type { Issue } from "@/shared/types";
+
+interface AgentDispatchBadgeProps {
+  issue: Issue;
+  layout?: "stack" | "inline";
+}
+
+export function AgentDispatchBadge({ issue, layout = "stack" }: AgentDispatchBadgeProps) {
+  const agents = useWorkspaceStore((s) => s.agents);
+  const daemons = useRuntimeStore((s) => s.daemons);
+
+  const agent = issue.assignee_id
+    ? agents.find((a) => a.id === issue.assignee_id)
+    : null;
+
+  const daemon = issue.dispatch_daemon_id
+    ? daemons.find((d) => d.id === issue.dispatch_daemon_id)
+    : null;
+
+  const agentName = agent?.name ?? "Unknown Agent";
+  const provider = issue.dispatch_provider;
+  const daemonName = daemon?.device_name || daemon?.daemon_id || null;
+
+  if (layout === "inline") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs min-w-0">
+        <Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="truncate font-medium">{agentName}</span>
+        {(provider || daemonName) && (
+          <span className="text-muted-foreground shrink-0">·</span>
+        )}
+        {provider && (
+          <span className="capitalize text-muted-foreground shrink-0">{provider}</span>
+        )}
+        {provider && daemonName && (
+          <span className="text-muted-foreground shrink-0">·</span>
+        )}
+        {daemonName && (
+          <span className="inline-flex items-center gap-0.5 text-muted-foreground truncate">
+            <Monitor className="h-3 w-3 shrink-0" />
+            <span className="truncate">{daemonName}</span>
+          </span>
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-1.5 min-w-0">
+      <Bot className="h-4 w-4 shrink-0 text-muted-foreground mt-0.5" />
+      <div className="min-w-0 flex flex-col">
+        <span className="text-xs font-medium truncate">{agentName}</span>
+        {(provider || daemonName) && (
+          <span className="text-[10px] text-muted-foreground truncate leading-tight">
+            {provider && <span className="capitalize">{provider}</span>}
+            {provider && daemonName && " · "}
+            {daemonName && daemonName}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/issues/components/board-card.tsx
+++ b/apps/web/features/issues/components/board-card.tsx
@@ -11,6 +11,7 @@ import { ActorAvatar } from "@/components/common/actor-avatar";
 import { api } from "@/shared/api";
 import { useIssueStore } from "@/features/issues/store";
 import { PriorityIcon } from "./priority-icon";
+import { AgentDispatchBadge } from "./agent-dispatch-badge";
 import { PriorityPicker, AssigneePicker, DueDatePicker } from "./pickers";
 import { PRIORITY_CONFIG } from "@/features/issues/config";
 import type { CardProperties } from "@/features/issues/stores/view-store";
@@ -111,8 +112,21 @@ export const BoardCardContent = memo(function BoardCardContent({
       {/* Row 3: Assignee, priority badge, due date */}
       {(showAssignee || showPriority || showDueDate) && (
         <div className="mt-3 flex items-center gap-2">
-          {showAssignee &&
-            (editable ? (
+          {showAssignee && issue.assignee_type === "agent" ? (
+            editable ? (
+              <PickerWrapper>
+                <AssigneePicker
+                  assigneeType={issue.assignee_type}
+                  assigneeId={issue.assignee_id}
+                  onUpdate={handleUpdate}
+                  trigger={<AgentDispatchBadge issue={issue} />}
+                />
+              </PickerWrapper>
+            ) : (
+              <AgentDispatchBadge issue={issue} />
+            )
+          ) : showAssignee ? (
+            editable ? (
               <PickerWrapper>
                 <AssigneePicker
                   assigneeType={issue.assignee_type}
@@ -133,7 +147,8 @@ export const BoardCardContent = memo(function BoardCardContent({
                 actorId={issue.assignee_id!}
                 size={22}
               />
-            ))}
+            )
+          ) : null}
           {showPriority &&
             (editable ? (
               <PickerWrapper>

--- a/apps/web/features/issues/components/index.ts
+++ b/apps/web/features/issues/components/index.ts
@@ -1,6 +1,6 @@
 export { StatusIcon } from "./status-icon";
 export { PriorityIcon } from "./priority-icon";
-export { StatusPicker, PriorityPicker, AssigneePicker, canAssignAgent, VerifierPicker, VerifierIcon, DueDatePicker } from "./pickers";
+export { StatusPicker, PriorityPicker, AssigneePicker, canAssignAgent, VerifierPicker, VerifierIcon, DueDatePicker, DaemonPicker, PropertyPicker, PickerItem, PickerSection, PickerEmpty } from "./pickers";
 export { IssueDetail } from "./issue-detail";
 export { IssuesPage } from "./issues-page";
 export { CommentCard } from "./comment-card";

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -59,7 +59,7 @@ import { AvatarGroup, AvatarGroupCount } from "@/components/ui/avatar";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import type { Issue, UpdateIssueRequest, IssueStatus, IssuePriority, TimelineEntry } from "@/shared/types";
 import { ALL_STATUSES, STATUS_CONFIG, PRIORITY_ORDER, PRIORITY_CONFIG } from "@/features/issues/config";
-import { StatusIcon, PriorityIcon, DueDatePicker, AssigneePicker, VerifierPicker, canAssignAgent } from "@/features/issues/components";
+import { StatusIcon, PriorityIcon, DueDatePicker, AssigneePicker, VerifierPicker, canAssignAgent, PropertyPicker, PickerItem, DaemonPicker } from "@/features/issues/components";
 import { CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
 import { AgentLiveCard, TaskRunHistory } from "./agent-live-card";
@@ -378,28 +378,52 @@ function PropRow({
   );
 }
 
-function DispatchHints({ issue }: { issue: { dispatch_provider: string | null; dispatch_daemon_id: string | null; dispatch_daemon_label: string | null } }) {
-  const daemons = useRuntimeStore((s) => s.daemons);
-  const daemonName = issue.dispatch_daemon_id
-    ? (() => {
-        const d = daemons.find((d) => d.id === issue.dispatch_daemon_id);
-        return d?.device_name || d?.daemon_id || null;
-      })()
-    : null;
+function DispatchHints({ issue, onUpdate }: { issue: Issue; onUpdate: (updates: Partial<UpdateIssueRequest>) => void }) {
+  const agents = useWorkspaceStore((s) => s.agents);
+  const agent = agents.find((a) => a.id === issue.assignee_id);
+  const providers = agent?.providers ?? [];
+
+  const [providerOpen, setProviderOpen] = useState(false);
 
   return (
     <>
       <PropRow label="Provider">
-        <span className={issue.dispatch_provider ? "capitalize" : "text-muted-foreground"}>
-          {issue.dispatch_provider ?? "Auto"}
-        </span>
+        <PropertyPicker
+          open={providerOpen}
+          onOpenChange={setProviderOpen}
+          width="w-40"
+          align="start"
+          trigger={
+            <span className={issue.dispatch_provider ? "capitalize" : "text-muted-foreground"}>
+              {issue.dispatch_provider ?? "Auto"}
+            </span>
+          }
+        >
+          <PickerItem
+            selected={!issue.dispatch_provider}
+            onClick={() => { onUpdate({ dispatch_provider: null }); setProviderOpen(false); }}
+          >
+            <span className="text-muted-foreground">Auto</span>
+          </PickerItem>
+          {providers.map((p) => (
+            <PickerItem
+              key={p}
+              selected={issue.dispatch_provider === p}
+              onClick={() => { onUpdate({ dispatch_provider: p }); setProviderOpen(false); }}
+            >
+              <span className="capitalize">{p}</span>
+            </PickerItem>
+          ))}
+        </PropertyPicker>
       </PropRow>
       <PropRow label="Daemon">
-        <span className={issue.dispatch_daemon_label || issue.dispatch_daemon_id ? "" : "text-muted-foreground"}>
-          {issue.dispatch_daemon_label
-            ? `label: ${issue.dispatch_daemon_label}`
-            : daemonName ?? "Auto"}
-        </span>
+        <DaemonPicker
+          daemonId={issue.dispatch_daemon_id}
+          daemonLabel={issue.dispatch_daemon_label}
+          provider={issue.dispatch_provider}
+          onUpdate={onUpdate}
+          align="start"
+        />
       </PropRow>
     </>
   );
@@ -1370,7 +1394,7 @@ export function IssueDetail({ issueId, onDelete, onBack, defaultSidebarOpen = tr
 
                   {/* Dispatch hints — visible when assignee is an agent */}
                   {issue.assignee_type === "agent" && issue.assignee_id && (
-                    <DispatchHints issue={issue} />
+                    <DispatchHints issue={issue} onUpdate={handleUpdateField} />
                   )}
                 </div>}
               </div>

--- a/apps/web/features/issues/components/issues-page.tsx
+++ b/apps/web/features/issues/components/issues-page.tsx
@@ -13,6 +13,7 @@ import { filterIssues } from "@/features/issues/utils/filter";
 import { BOARD_STATUSES } from "@/features/issues/config";
 import { useWorkspaceStore } from "@/features/workspace";
 import { WorkspaceAvatar } from "@/features/workspace";
+import { useRuntimeStore } from "@/features/runtimes";
 import { api } from "@/shared/api";
 import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
 import { IssuesHeader } from "./issues-header";
@@ -25,6 +26,7 @@ export function IssuesPage() {
   const loading = useIssueStore((s) => s.loading);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const scope = useIssuesScopeStore((s) => s.scope);
+  const fetchAllRuntimes = useRuntimeStore((s) => s.fetchAll);
   const viewMode = useIssueViewStore((s) => s.viewMode);
   const statusFilters = useIssueViewStore((s) => s.statusFilters);
   const priorityFilters = useIssueViewStore((s) => s.priorityFilters);
@@ -36,6 +38,10 @@ export function IssuesPage() {
   useEffect(() => {
     initFilterWorkspaceSync();
   }, []);
+
+  useEffect(() => {
+    if (workspace) fetchAllRuntimes();
+  }, [workspace, fetchAllRuntimes]);
 
   useEffect(() => {
     useIssueSelectionStore.getState().clear();

--- a/apps/web/features/issues/components/list-row.tsx
+++ b/apps/web/features/issues/components/list-row.tsx
@@ -6,6 +6,7 @@ import type { Issue } from "@/shared/types";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
 import { PriorityIcon } from "./priority-icon";
+import { AgentDispatchBadge } from "./agent-dispatch-badge";
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString("en-US", {
@@ -77,11 +78,15 @@ export const ListRow = memo(function ListRow({ issue }: { issue: Issue }) {
           </span>
         )}
         {issue.assignee_type && issue.assignee_id && (
-          <ActorAvatar
-            actorType={issue.assignee_type}
-            actorId={issue.assignee_id}
-            size={20}
-          />
+          issue.assignee_type === "agent" ? (
+            <AgentDispatchBadge issue={issue} layout="inline" />
+          ) : (
+            <ActorAvatar
+              actorType={issue.assignee_type}
+              actorId={issue.assignee_id}
+              size={20}
+            />
+          )
         )}
       </Link>
     </div>

--- a/apps/web/features/issues/components/pickers/daemon-picker.tsx
+++ b/apps/web/features/issues/components/pickers/daemon-picker.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { ChevronDown } from "lucide-react";
+import type { UpdateIssueRequest, Daemon, AgentRuntime, ProviderAuthStatus } from "@/shared/types";
+import { useRuntimeStore } from "@/features/runtimes";
+import {
+  PropertyPicker,
+  PickerItem,
+  PickerSection,
+} from "./property-picker";
+
+function authBadge(status: ProviderAuthStatus) {
+  if (status === "ready") return null;
+  if (status === "unauthenticated")
+    return <span className="ml-auto text-[10px] text-amber-500">unauth</span>;
+  if (status === "not_installed")
+    return <span className="ml-auto text-[10px] text-muted-foreground">not installed</span>;
+  return null;
+}
+
+function statusDot(daemon: Daemon) {
+  return (
+    <span
+      className={`h-1.5 w-1.5 shrink-0 rounded-full ${daemon.status === "online" ? "bg-green-500" : "bg-muted-foreground/40"}`}
+    />
+  );
+}
+
+function classifyDaemons(
+  daemons: Daemon[],
+  runtimes: AgentRuntime[],
+  provider: string | null,
+) {
+  if (!provider) return { compatible: daemons, incompatible: [] as Daemon[] };
+
+  const compatible: Daemon[] = [];
+  const incompatible: Daemon[] = [];
+  for (const d of daemons) {
+    const hasRuntime = runtimes.some(
+      (r) => r.daemon_ref === d.id && r.provider === provider,
+    );
+    if (hasRuntime) compatible.push(d);
+    else incompatible.push(d);
+  }
+  return { compatible, incompatible };
+}
+
+function getRuntimeAuth(
+  runtimes: AgentRuntime[],
+  daemonId: string,
+  provider: string | null,
+): ProviderAuthStatus {
+  if (!provider) return "unknown";
+  const rt = runtimes.find(
+    (r) => r.daemon_ref === daemonId && r.provider === provider,
+  );
+  return rt?.auth_status ?? "unknown";
+}
+
+export function DaemonPicker({
+  daemonId,
+  daemonLabel,
+  provider,
+  onUpdate,
+  onSelect,
+  align,
+  trigger: customTrigger,
+  triggerRender,
+}: {
+  daemonId: string | null;
+  daemonLabel: string | null;
+  provider: string | null;
+  /** Called with UpdateIssueRequest-shaped updates (issue detail page). */
+  onUpdate?: (updates: Partial<UpdateIssueRequest>) => void;
+  /** Called with raw values (create-issue modal or other contexts). */
+  onSelect?: (daemonId: string | null, daemonLabel: string | null) => void;
+  align?: "start" | "center" | "end";
+  trigger?: React.ReactNode;
+  triggerRender?: React.ReactElement;
+}) {
+  const [open, setOpen] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const daemons = useRuntimeStore((s) => s.daemons);
+  const runtimes = useRuntimeStore((s) => s.runtimes);
+
+  const { compatible, incompatible } = useMemo(
+    () => classifyDaemons(daemons, runtimes, provider),
+    [daemons, runtimes, provider],
+  );
+
+  const allLabels = useMemo(
+    () => [...new Set(daemons.flatMap((d) => d.labels))].sort(),
+    [daemons],
+  );
+
+  const selectedName = daemonId
+    ? (() => {
+        const d = daemons.find((d) => d.id === daemonId);
+        return d?.device_name || d?.daemon_id || null;
+      })()
+    : null;
+
+  const select = (id: string | null, label: string | null) => {
+    onUpdate?.({ dispatch_daemon_id: id, dispatch_daemon_label: label });
+    onSelect?.(id, label);
+    setOpen(false);
+  };
+
+  const renderDaemonItem = (d: Daemon, dimmed?: boolean) => {
+    const auth = getRuntimeAuth(runtimes, d.id, provider);
+    return (
+      <PickerItem
+        key={d.id}
+        selected={daemonId === d.id}
+        onClick={() => select(d.id, null)}
+      >
+        <span className={dimmed ? "text-muted-foreground" : ""}>
+          {d.device_name || d.daemon_id}
+        </span>
+        {authBadge(auth)}
+        {statusDot(d)}
+      </PickerItem>
+    );
+  };
+
+  return (
+    <PropertyPicker
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) setShowAll(false);
+      }}
+      width="w-52"
+      align={align}
+      triggerRender={triggerRender}
+      trigger={
+        customTrigger ?? (
+          <span className={daemonId || daemonLabel ? "" : "text-muted-foreground"}>
+            {daemonLabel
+              ? `label: ${daemonLabel}`
+              : selectedName ?? "Auto"}
+          </span>
+        )
+      }
+    >
+      {/* Auto option */}
+      <PickerItem
+        selected={!daemonId && !daemonLabel}
+        onClick={() => select(null, null)}
+      >
+        <span className="text-muted-foreground">Auto</span>
+      </PickerItem>
+
+      {/* By label */}
+      {allLabels.length > 0 && (
+        <PickerSection label="By label">
+          {allLabels.map((label) => (
+            <PickerItem
+              key={label}
+              selected={daemonLabel === label}
+              onClick={() => select(null, label)}
+            >
+              {label}
+            </PickerItem>
+          ))}
+        </PickerSection>
+      )}
+
+      {/* Compatible daemons */}
+      {compatible.length > 0 && (
+        <PickerSection label={provider ? "Compatible" : "Daemons"}>
+          {compatible.map((d) => renderDaemonItem(d))}
+        </PickerSection>
+      )}
+
+      {/* Toggle for incompatible */}
+      {provider && incompatible.length > 0 && !showAll && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronDown className="h-3 w-3" />
+          Show {incompatible.length} incompatible
+        </button>
+      )}
+
+      {/* Incompatible daemons */}
+      {provider && showAll && incompatible.length > 0 && (
+        <PickerSection label="Incompatible">
+          {incompatible.map((d) => renderDaemonItem(d, true))}
+        </PickerSection>
+      )}
+    </PropertyPicker>
+  );
+}

--- a/apps/web/features/issues/components/pickers/index.ts
+++ b/apps/web/features/issues/components/pickers/index.ts
@@ -4,3 +4,4 @@ export { PriorityPicker } from "./priority-picker";
 export { AssigneePicker, canAssignAgent } from "./assignee-picker";
 export { VerifierPicker, VerifierIcon } from "./verifier-picker";
 export { DueDatePicker } from "./due-date-picker";
+export { DaemonPicker } from "./daemon-picker";

--- a/apps/web/features/modals/create-issue.tsx
+++ b/apps/web/features/modals/create-issue.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { CalendarDays, Check, ChevronRight, Cpu, Monitor, Maximize2, Minimize2, ShieldCheck, ShieldOff, UserMinus, X as XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import type { IssueStatus, IssuePriority, IssueAssigneeType, Daemon, Label } from "@/shared/types";
+import type { IssueStatus, IssuePriority, IssueAssigneeType, Label } from "@/shared/types";
 import {
   Dialog,
   DialogContent,
@@ -27,7 +27,8 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { Button } from "@/components/ui/button";
 import { RichTextEditor, type RichTextEditorRef } from "@/components/common/rich-text-editor";
 import { TitleEditor } from "@/components/common/title-editor";
-import { StatusIcon, PriorityIcon, canAssignAgent } from "@/features/issues/components";
+import { StatusIcon, PriorityIcon, canAssignAgent, DaemonPicker } from "@/features/issues/components";
+import { useRuntimeStore } from "@/features/runtimes";
 import { ALL_STATUSES, STATUS_CONFIG, PRIORITY_ORDER, PRIORITY_CONFIG } from "@/features/issues/config";
 import { useLabelStore } from "@/features/labels";
 import { useAuthStore } from "@/features/auth";
@@ -61,6 +62,14 @@ function PillButton({
       {children}
     </button>
   );
+}
+
+function DaemonTriggerLabel({ daemonId, daemonLabel }: { daemonId?: string; daemonLabel?: string }) {
+  const daemons = useRuntimeStore((s) => s.daemons);
+  const name = daemonId
+    ? (daemons.find((d) => d.id === daemonId)?.device_name || "Daemon")
+    : daemonLabel ?? "Any daemon";
+  return <span>{name}</span>;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,19 +109,15 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   const [dispatchProvider, setDispatchProvider] = useState<string | undefined>();
   const [dispatchDaemonId, setDispatchDaemonId] = useState<string | undefined>();
   const [dispatchDaemonLabel, setDispatchDaemonLabel] = useState<string | undefined>();
-  const [daemons, setDaemons] = useState<Daemon[]>([]);
+  const fetchAllRuntimes = useRuntimeStore((s) => s.fetchAll);
 
   const selectedAgent = assigneeType === "agent" && assigneeId
     ? agents.find((a) => a.id === assigneeId)
     : null;
 
   useEffect(() => {
-    if (selectedAgent) {
-      api.listDaemons().then(setDaemons).catch(() => {});
-    }
-  }, [selectedAgent]);
-
-  const allDaemonLabels = [...new Set(daemons.flatMap((d) => d.labels))].sort();
+    if (selectedAgent) fetchAllRuntimes();
+  }, [selectedAgent, fetchAllRuntimes]);
 
   // Assignee popover
   const [assigneeOpen, setAssigneeOpen] = useState(false);
@@ -536,51 +541,23 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              <DropdownMenu>
-                <DropdownMenuTrigger render={
-                  <PillButton>
+              <DaemonPicker
+                daemonId={dispatchDaemonId ?? null}
+                daemonLabel={dispatchDaemonLabel ?? null}
+                provider={dispatchProvider ?? null}
+                onSelect={(id, label) => {
+                  setDispatchDaemonId(id ?? undefined);
+                  setDispatchDaemonLabel(label ?? undefined);
+                }}
+                align="start"
+                triggerRender={<PillButton />}
+                trigger={
+                  <>
                     <Monitor className="size-3.5 text-muted-foreground" />
-                    <span>
-                      {dispatchDaemonId
-                        ? (daemons.find((d) => d.id === dispatchDaemonId)?.device_name || "Daemon")
-                        : dispatchDaemonLabel
-                          ? dispatchDaemonLabel
-                          : "Any daemon"}
-                    </span>
-                  </PillButton>
-                } />
-                <DropdownMenuContent align="start">
-                  <DropdownMenuItem onClick={() => { setDispatchDaemonId(undefined); setDispatchDaemonLabel(undefined); }}>
-                    <Check className={`size-3.5 ${!dispatchDaemonId && !dispatchDaemonLabel ? "opacity-100" : "opacity-0"}`} />
-                    Any daemon
-                  </DropdownMenuItem>
-                  {allDaemonLabels.length > 0 && (
-                    <>
-                      <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">By label</div>
-                      {allDaemonLabels.map((label) => (
-                        <DropdownMenuItem key={label} onClick={() => { setDispatchDaemonLabel(label); setDispatchDaemonId(undefined); }}>
-                          <Check className={`size-3.5 ${dispatchDaemonLabel === label ? "opacity-100" : "opacity-0"}`} />
-                          {label}
-                        </DropdownMenuItem>
-                      ))}
-                    </>
-                  )}
-                  {daemons.length > 0 && (
-                    <>
-                      <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">Daemons</div>
-                      {daemons.map((d) => (
-                        <DropdownMenuItem key={d.id} onClick={() => { setDispatchDaemonId(d.id); setDispatchDaemonLabel(undefined); }}>
-                          <Check className={`size-3.5 ${dispatchDaemonId === d.id ? "opacity-100" : "opacity-0"}`} />
-                          <span className={d.status === "online" ? "" : "text-muted-foreground"}>
-                            {d.device_name || d.daemon_id}
-                          </span>
-                          <span className={`ml-auto h-1.5 w-1.5 rounded-full ${d.status === "online" ? "bg-success" : "bg-muted-foreground/40"}`} />
-                        </DropdownMenuItem>
-                      ))}
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    <DaemonTriggerLabel daemonId={dispatchDaemonId} daemonLabel={dispatchDaemonLabel} />
+                  </>
+                }
+              />
             </>
           )}
 

--- a/apps/web/shared/types/api.ts
+++ b/apps/web/shared/types/api.ts
@@ -29,6 +29,9 @@ export interface UpdateIssueRequest {
   max_verification_rounds?: number | null;
   position?: number;
   due_date?: string | null;
+  dispatch_provider?: string | null;
+  dispatch_daemon_id?: string | null;
+  dispatch_daemon_label?: string | null;
 }
 
 export interface ListIssuesParams {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -90,10 +90,11 @@ services:
         condition: service_healthy
 
   daemon:
-    image: golang:1.26-alpine
+    image: golang:1.26-bookworm
     working_dir: /app/server
     command: >
-      sh -c "apk add --no-cache nodejs npm bubblewrap curl bash > /dev/null 2>&1 &&
+      sh -c "apt-get update && apt-get install -y --no-install-recommends nodejs npm bubblewrap curl > /dev/null 2>&1 &&
+             export PATH=\"$$HOME/.local/bin:$$PATH\" &&
              go build -o /usr/local/bin/multica ./cmd/multica &&
              multica daemon start --foreground"
     environment:
@@ -101,6 +102,7 @@ services:
       MULTICA_DAEMON_ID: dev-daemon
       IS_SANDBOX: "1"
       CLAUDE_CODE_BUBBLEWRAP: "1"
+      CURSOR_API_KEY: ${CURSOR_API_KEY:-}
       no_proxy: backend,postgres,migrate,seed,daemon,frontend,localhost,127.0.0.1
       NO_PROXY: backend,postgres,migrate,seed,daemon,frontend,localhost,127.0.0.1
     volumes:

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -33,7 +33,7 @@ create_agent() {
     --arg name "$name" \
     --arg desc "$description" \
     --arg inst "$instructions" \
-    '{name:$name, description:$desc, instructions:$inst, visibility:"workspace", max_concurrent_tasks:1}')
+    '{name:$name, description:$desc, instructions:$inst, providers:["claude"], visibility:"workspace", max_concurrent_tasks:1}')
   RESP=$(api POST /api/agents -d "$BODY")
   ANAME=$(echo "$RESP" | jq -r '.name // empty')
   if [ -z "$ANAME" ]; then

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1254,6 +1254,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	// Inject workspace-level provider API key if available.
 	// This allows running without per-user CLI auth (e.g. `claude login`).
 	if apiKey := d.resolveProviderAPIKey(provider, task.ProviderAPIKey); apiKey != "" {
+		d.logger.Info("injecting provider API key", "provider", provider, "key_len", len(apiKey), "from_task", task.ProviderAPIKey != "")
 		switch provider {
 		case "claude":
 			agentEnv["ANTHROPIC_API_KEY"] = apiKey
@@ -1264,11 +1265,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		case "cursor":
 			agentEnv["CURSOR_API_KEY"] = apiKey
 		}
+	} else {
+		d.logger.Warn("no provider API key available", "provider", provider, "task_key_present", task.ProviderAPIKey != "")
 	}
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
+		if provider == "codex" || provider == "opencode" {
+			if key := agentEnv["OPENAI_API_KEY"]; key != "" {
+				execenv.WriteCodexAuth(env.CodexHome, key, d.logger)
+			}
+		}
 	}
 	// Inject GitHub token for authenticated git operations and `gh` CLI.
 	if task.GitHubToken != "" {

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -96,6 +96,21 @@ func ensureSymlink(src, dst string) error {
 	return os.Symlink(src, dst)
 }
 
+// WriteCodexAuth writes an auth.json file into the codex-home directory
+// so that codex app-server can authenticate with the OpenAI API.
+// Codex ignores the OPENAI_API_KEY env var when CODEX_HOME is set but
+// has no auth.json; it only reads credentials from auth.json.
+func WriteCodexAuth(codexHome, apiKey string, logger *slog.Logger) {
+	authPath := filepath.Join(codexHome, "auth.json")
+	if _, err := os.Stat(authPath); err == nil {
+		return
+	}
+	content := fmt.Sprintf(`{"auth_mode":"apikey","OPENAI_API_KEY":%q}`, apiKey)
+	if err := os.WriteFile(authPath, []byte(content), 0o600); err != nil {
+		logger.Warn("execenv: write codex auth.json failed", "error", err)
+	}
+}
+
 // copyFileIfExists copies src to dst. If src doesn't exist, it's a no-op.
 // If dst already exists, it's not overwritten.
 func copyFileIfExists(src, dst string) error {

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -158,6 +158,10 @@ func (h *Handler) ensureUserWorkspace(ctx context.Context, user db.User) error {
 		return err
 	}
 
+	if _, err := qtx.UpdateWorkspace(ctx, updateSettingsOnly(workspace.ID, defaultProviderSettings())); err != nil {
+		return err
+	}
+
 	return tx.Commit(ctx)
 }
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -589,9 +589,13 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		"creator_id":             uuidToString(prevIssue.CreatorID),
 	})
 
-	// Reconcile task queue when assignee changes (not on status changes —
-	// agents manage issue status themselves via the CLI).
-	if assigneeChanged || verifierChanged {
+	dispatchChanged := (prevIssue.DispatchProvider != issue.DispatchProvider ||
+		prevIssue.DispatchDaemonID != issue.DispatchDaemonID ||
+		prevIssue.DispatchDaemonLabel != issue.DispatchDaemonLabel)
+
+	// Reconcile task queue when assignee or dispatch hints change (not on
+	// status changes — agents manage issue status themselves via the CLI).
+	if assigneeChanged || verifierChanged || dispatchChanged {
 		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 
 		if h.shouldEnqueueAgentTask(r.Context(), issue) {

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -189,6 +189,12 @@ func (h *Handler) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ws, err = qtx.UpdateWorkspace(r.Context(), updateSettingsOnly(ws.ID, defaultProviderSettings()))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to set default providers: "+err.Error())
+		return
+	}
+
 	if err := tx.Commit(r.Context()); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create workspace")
 		return

--- a/server/internal/handler/workspace_providers.go
+++ b/server/internal/handler/workspace_providers.go
@@ -30,6 +30,17 @@ type WorkspaceProviderSettings struct {
 // SupportedProviders lists the provider keys recognised by multica.
 var SupportedProviders = []string{"claude", "codex", "opencode", "cursor"}
 
+// defaultProviderSettings returns the JSON bytes for the default workspace
+// settings with cursor enabled out of the box.
+func defaultProviderSettings() []byte {
+	b, _ := json.Marshal(WorkspaceProviderSettings{
+		Providers: map[string]ProviderConfig{
+			"codex": {Enabled: true},
+		},
+	})
+	return b
+}
+
 // redactAPIKey masks an API key, showing only the last 4 characters.
 func redactAPIKey(key string) string {
 	if len(key) <= 4 {


### PR DESCRIPTION
## Summary

- **Editable dispatch hints** on issue detail page — Provider and Daemon fields are now interactive pickers (previously read-only). Changing them cancels any running task and re-enqueues with new constraints, same as changing assignee.
- **Reusable `DaemonPicker` component** with provider-based filtering (compatible vs incompatible daemons), auth status badges, label-based selection, and "show incompatible" toggle. Used in both issue detail and create-issue modal.
- **Fix `make dev` failure** — seed script now includes required `providers` field when creating agents.
- **Default workspace provider** — new workspaces enable codex by default so daemon auto-install works on first registration.
- **Fix codex 401 Unauthorized** — write `auth.json` into per-task `CODEX_HOME` with the workspace-level API key. Codex `app-server` ignores `OPENAI_API_KEY` env var when `CODEX_HOME` is set but has no `auth.json`.

## Changes

| Area | Files | What |
|------|-------|------|
| Frontend types | `shared/types/api.ts` | Add dispatch fields to `UpdateIssueRequest` |
| Issue detail | `issue-detail.tsx` | Editable Provider picker + DaemonPicker in `DispatchHints` |
| DaemonPicker | `pickers/daemon-picker.tsx` (new) | Reusable picker with filtering, auth status, labels |
| Create issue | `create-issue.tsx` | Replace inline daemon dropdown with `DaemonPicker` |
| Backend | `issue.go` | Cancel+re-enqueue task on dispatch hint change |
| Backend | `workspace_providers.go`, `workspace.go`, `auth.go` | Default codex provider on workspace creation |
| Daemon | `daemon.go`, `codex_home.go` | Write `auth.json` to per-task CODEX_HOME |
| Dev env | `seed-dev.sh` | Fix missing `providers` field |

## Test plan

- [ ] `make dev` succeeds (seed creates agents with providers)
- [ ] Issue detail: change Provider/Daemon via pickers, verify task restarts
- [ ] Create issue: daemon picker filters by selected provider
- [ ] Codex tasks authenticate successfully with workspace API key


Made with [Cursor](https://cursor.com)