### PR TITLE
chore(ci): make deploy version optional, auto-resolve latest release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to deploy (e.g. v0.2.2). Must be a released tag with built images."
-        required: true
+        description: "Version to deploy (e.g. v0.2.2). Leave empty to deploy latest release."
+        required: false
         type: string
       clean:
         description: "Clean deploy: remove existing database and start fresh"
@@ -25,7 +25,26 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_exists: ${{ steps.check.outputs.exists }}
+      version: ${{ steps.resolve.outputs.version }}
     steps:
+      - name: Resolve version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "Using specified version: ${{ inputs.version }}"
+          else
+            LATEST=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+            if [ -z "$LATEST" ]; then
+              echo "::error::No releases found. Please specify a version manually."
+              exit 1
+            fi
+            echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+            echo "No version specified — using latest release: $LATEST"
+          fi
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -35,14 +54,21 @@ jobs:
 
       - name: Verify image exists
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}/backend:${{ inputs.version }}"
+          VERSION="${{ steps.resolve.outputs.version }}"
+          IMAGE="ghcr.io/${{ github.repository }}/backend:${VERSION}"
           if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
             echo "Image $IMAGE found"
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::Image $IMAGE not found. Available versions:"
-            echo "::error::Check https://github.com/${{ github.repository }}/pkgs/container/multica%2Fbackend for available tags."
+            echo "::error::Image $IMAGE not found."
+            echo ""
+            echo "Available releases:"
+            gh release list --repo "${{ github.repository }}" --limit 10 | awk '{print "  " $1}'
+            echo ""
+            echo "Check https://github.com/${{ github.repository }}/pkgs/container/multica%2Fbackend for available image tags."
             exit 1
           fi
 
@@ -54,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ needs.verify.outputs.version }}
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -81,7 +107,7 @@ jobs:
           MULTICA_GITHUB_APP_SLUG=${{ vars.MULTICA_GITHUB_APP_SLUG }}
           LISTEN_PORT=${{ vars.LISTEN_PORT || '80' }}
           PGDATA_DIR=${{ vars.PGDATA_DIR || './data/postgres' }}
-          IMAGE_TAG=${{ inputs.version }}
+          IMAGE_TAG=${{ needs.verify.outputs.version }}
           ENVEOF
 
       - name: Write GitHub App private key file
@@ -131,7 +157,7 @@ jobs:
         run: |
           DEPLOYED=$(curl -sf http://localhost:${LISTEN_PORT}/health | jq -r '.version // "unknown"')
           echo "Deployed version: $DEPLOYED"
-          echo "Expected version: ${{ inputs.version }}"
+          echo "Expected version: ${{ needs.verify.outputs.version }}"
 
       - name: Cleanup secrets
         if: always()


### PR DESCRIPTION
## Summary
- Make the `version` input optional in the Deploy workflow — leaving it empty automatically deploys the latest GitHub release
- On image verification failure, list the 10 most recent releases for reference
- All downstream steps now use the resolved version from the `verify` job output

## Context
GitHub Actions `workflow_dispatch` doesn't support dynamic `choice` dropdowns from tags. This change provides a pragmatic alternative: default to latest release when no version is specified.

## Test plan
- [x] Trigger Deploy workflow on this branch with version left empty — should resolve to latest release
- [x] Trigger with a specific version — should use the specified version
- [x] Trigger with an invalid version — should fail and list available releases


Made with [Cursor](https://cursor.com)