### PR TITLE
fix(web): fix undefined `agents` and missing `cn` import in agents page

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -79,6 +79,7 @@ import { useIssueStore } from "@/features/issues";
 import { useRuntimeStore } from "@/features/runtimes";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import { useFileUpload } from "@/shared/hooks/use-file-upload";
+import { cn } from "@/lib/utils";
 
 
 // ---------------------------------------------------------------------------
@@ -1608,10 +1609,10 @@ export default function AgentsPage() {
 
   // Select first agent on initial load
   useEffect(() => {
-    if (agents.length > 0 && !selectedId) {
-      setSelectedId(agents[0]!.id);
+    if (activeAgents.length > 0 && !selectedId) {
+      setSelectedId(activeAgents[0]!.id);
     }
-  }, [agents, selectedId]);
+  }, [activeAgents, selectedId]);
 
   const handleCreate = async (data: CreateAgentRequest) => {
     const agent = await api.createAgent(data);


### PR DESCRIPTION
The agents page referenced an undefined `agents` variable instead of
`activeAgents`, and was missing the `cn` utility import used for the
archived agents toggle. Both caused the frontend build to fail in CI.

https://claude.ai/code/session_01Bcyc4wXhvpRNuNTabxzFrj