### PR TITLE
feat(webhook): support Alertmanager batch format in oss-alert adapter

### DIFF
--- a/server/internal/webhook/oss_alert.go
+++ b/server/internal/webhook/oss_alert.go
@@ -8,17 +8,11 @@ import (
 	"time"
 )
 
-// ossAlertAdapter handles the internal OSS alert format (Prometheus AlertManager style).
+// ossAlertAdapter handles Prometheus AlertManager style payloads.
 //
-// Schema:
-//
-//	{
-//	  "labels":       { "alertname": "...", "app": "..." },
-//	  "annotations":  { "value": "...", "labels": "..." },
-//	  "startsAt":     "2026-04-13T07:39:46.089Z",
-//	  "endsAt":       "2026-04-13T07:43:46.089Z",
-//	  "generatorURL": "https://..."
-//	}
+// Supports two formats:
+//   - Single alert object (original format)
+//   - Alertmanager batch format: {"alerts": [...], "status": "firing", ...}
 type ossAlertAdapter struct{}
 
 type ossAlertPayload struct {
@@ -29,10 +23,35 @@ type ossAlertPayload struct {
 	GeneratorURL string            `json:"generatorURL"`
 }
 
+type ossAlertBatchPayload struct {
+	Alerts []json.RawMessage `json:"alerts"`
+}
+
 func (a *ossAlertAdapter) Parse(payload json.RawMessage, _ http.Header) ([]Event, error) {
+	var batch ossAlertBatchPayload
+	if err := json.Unmarshal(payload, &batch); err == nil && len(batch.Alerts) > 0 {
+		var events []Event
+		for _, raw := range batch.Alerts {
+			ev, err := a.parseSingle(raw)
+			if err != nil {
+				return nil, err
+			}
+			events = append(events, ev)
+		}
+		return events, nil
+	}
+
+	ev, err := a.parseSingle(payload)
+	if err != nil {
+		return nil, err
+	}
+	return []Event{ev}, nil
+}
+
+func (a *ossAlertAdapter) parseSingle(payload json.RawMessage) (Event, error) {
 	var p ossAlertPayload
 	if err := json.Unmarshal(payload, &p); err != nil {
-		return nil, fmt.Errorf("parse oss-alert payload: %w", err)
+		return Event{}, fmt.Errorf("parse oss-alert payload: %w", err)
 	}
 
 	alertName := p.Labels["alertname"]
@@ -79,7 +98,6 @@ func (a *ossAlertAdapter) Parse(payload json.RawMessage, _ http.Header) ([]Event
 		dedupKey = alertName + ":" + app
 	}
 
-	// Build Data map: deterministic bare keys + prefixed external data
 	data := map[string]string{
 		"title":     title,
 		"body":      body.String(),
@@ -99,12 +117,12 @@ func (a *ossAlertAdapter) Parse(payload json.RawMessage, _ http.Header) ([]Event
 		data["annotations."+k] = v
 	}
 
-	return []Event{{
+	return Event{
 		Type:       "alert.firing",
 		DedupKey:   dedupKey,
 		Data:       data,
 		RawPayload: payload,
-	}}, nil
+	}, nil
 }
 
 func (a *ossAlertAdapter) Keys() []AdapterKey {
@@ -121,16 +139,21 @@ func (a *ossAlertAdapter) Keys() []AdapterKey {
 
 func (a *ossAlertAdapter) Example() string {
 	return `{
-  "labels": {
-    "alertname": "ServicePanic",
-    "app": "my-service"
-  },
-  "annotations": {
-    "value": "1.2",
-    "labels": "map[app:my-service]"
-  },
-  "startsAt": "2026-04-13T07:39:46.089Z",
-  "endsAt": "2026-04-13T07:43:46.089Z",
-  "generatorURL": "https://prometheus.example.com/graph?..."
+  "alerts": [
+    {
+      "labels": {
+        "alertname": "ServicePanic",
+        "app": "my-service"
+      },
+      "annotations": {
+        "value": "1.2",
+        "labels": "map[app:my-service]"
+      },
+      "startsAt": "2026-04-13T07:39:46.089Z",
+      "endsAt": "2026-04-13T07:43:46.089Z",
+      "generatorURL": "https://prometheus.example.com/graph?..."
+    }
+  ],
+  "status": "firing"
 }`
 }

--- a/server/internal/webhook/oss_alert_test.go
+++ b/server/internal/webhook/oss_alert_test.go
@@ -1,0 +1,114 @@
+package webhook
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOssAlertAdapter_ParseSingle(t *testing.T) {
+	adapter := &ossAlertAdapter{}
+	payload := json.RawMessage(`{
+		"labels": {"alertname": "HighMemory", "app": "api-gateway"},
+		"annotations": {"summary": "Memory usage above 90%"},
+		"startsAt": "2026-04-15T10:00:00Z",
+		"generatorURL": "https://prometheus.example.com/graph?g0.expr=mem"
+	}`)
+
+	events, err := adapter.Parse(payload, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	ev := events[0]
+	if ev.Type != "alert.firing" {
+		t.Errorf("expected type alert.firing, got %s", ev.Type)
+	}
+	if ev.DedupKey != "HighMemory:api-gateway" {
+		t.Errorf("expected dedup key HighMemory:api-gateway, got %s", ev.DedupKey)
+	}
+	if ev.Data["title"] != "HighMemory (api-gateway)" {
+		t.Errorf("expected title 'HighMemory (api-gateway)', got %s", ev.Data["title"])
+	}
+	if ev.Data["alertname"] != "HighMemory" {
+		t.Errorf("expected alertname HighMemory, got %s", ev.Data["alertname"])
+	}
+	if ev.Data["app"] != "api-gateway" {
+		t.Errorf("expected app api-gateway, got %s", ev.Data["app"])
+	}
+	if ev.Data["generator_url"] != "https://prometheus.example.com/graph?g0.expr=mem" {
+		t.Errorf("unexpected generator_url: %s", ev.Data["generator_url"])
+	}
+	if ev.Data["labels.alertname"] != "HighMemory" {
+		t.Errorf("expected labels.alertname HighMemory, got %s", ev.Data["labels.alertname"])
+	}
+	if ev.Data["annotations.summary"] != "Memory usage above 90%" {
+		t.Errorf("expected annotations.summary, got %s", ev.Data["annotations.summary"])
+	}
+}
+
+func TestOssAlertAdapter_ParseBatch(t *testing.T) {
+	adapter := &ossAlertAdapter{}
+	payload := json.RawMessage(`{
+		"status": "firing",
+		"alerts": [
+			{
+				"labels": {"alertname": "HighMemory", "app": "api-gateway"},
+				"annotations": {"summary": "Memory above 90%"},
+				"startsAt": "2026-04-15T10:00:00Z"
+			},
+			{
+				"labels": {"alertname": "ServicePanic", "app": "user-service"},
+				"annotations": {"value": "3"},
+				"startsAt": "2026-04-15T10:01:00Z",
+				"generatorURL": "https://prometheus.example.com/graph"
+			}
+		]
+	}`)
+
+	events, err := adapter.Parse(payload, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	if events[0].Data["alertname"] != "HighMemory" {
+		t.Errorf("event 0: expected alertname HighMemory, got %s", events[0].Data["alertname"])
+	}
+	if events[0].DedupKey != "HighMemory:api-gateway" {
+		t.Errorf("event 0: expected dedup key HighMemory:api-gateway, got %s", events[0].DedupKey)
+	}
+
+	if events[1].Data["alertname"] != "ServicePanic" {
+		t.Errorf("event 1: expected alertname ServicePanic, got %s", events[1].Data["alertname"])
+	}
+	if events[1].Data["app"] != "user-service" {
+		t.Errorf("event 1: expected app user-service, got %s", events[1].Data["app"])
+	}
+	if events[1].Data["generator_url"] != "https://prometheus.example.com/graph" {
+		t.Errorf("event 1: unexpected generator_url: %s", events[1].Data["generator_url"])
+	}
+}
+
+func TestOssAlertAdapter_ParseBatchEmpty(t *testing.T) {
+	adapter := &ossAlertAdapter{}
+	payload := json.RawMessage(`{
+		"labels": {"alertname": "NoApp"},
+		"startsAt": "2026-04-15T10:00:00Z"
+	}`)
+
+	events, err := adapter.Parse(payload, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].DedupKey != "NoApp" {
+		t.Errorf("expected dedup key NoApp, got %s", events[0].DedupKey)
+	}
+}


### PR DESCRIPTION
## Summary

- Extend the `oss-alert` adapter to accept Alertmanager's standard batch payload format (`{"alerts": [...], "status": "firing"}`) in addition to the existing single-alert object format.
- Each alert in the batch produces an independent `Event` with its own dedup key, enabling direct integration with Prometheus Alertmanager `webhook_configs`.
- Fully backward-compatible — existing single-alert payloads continue to work unchanged.

## Test plan

- [x] Unit test: single alert object parsed correctly (`TestOssAlertAdapter_ParseSingle`)
- [x] Unit test: batch payload with 2 alerts produces 2 events (`TestOssAlertAdapter_ParseBatch`)
- [x] Unit test: payload without `alerts` field falls back to single-alert path (`TestOssAlertAdapter_ParseBatchEmpty`)


Made with [Cursor](https://cursor.com)