### PR TITLE
fix(webhook): add dispatch_provider to webhook action config

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
@@ -395,6 +395,10 @@ function WebhookCard({ wh, agentName, envName, apiBaseUrl, onToggle, onEdit, onR
                   <span>{agentName(primaryConfig.agent_id)}</span>
                 </div>
                 <div className="flex gap-2">
+                  <span className="font-medium w-28 shrink-0">Provider:</span>
+                  <span className="capitalize">{primaryConfig.dispatch_provider || "Auto"}</span>
+                </div>
+                <div className="flex gap-2">
                   <span className="font-medium w-28 shrink-0">Environment:</span>
                   <span>{primaryConfig.dispatch_daemon_id ? envName(primaryConfig.dispatch_daemon_id) : "Any"}</span>
                 </div>
@@ -431,6 +435,7 @@ function CreateWebhookDialog({ open, onOpenChange, agents, daemons, apiBaseUrl, 
   const [sourceType, setSourceType] = useState("standard");
   const [actionType, setActionType] = useState("create_issue");
   const [agentId, setAgentId] = useState("");
+  const [dispatchProvider, setDispatchProvider] = useState("");
   const [dispatchDaemonId, setDispatchDaemonId] = useState("");
   const [titleTemplate, setTitleTemplate] = useState("");
   const [descriptionTemplate, setDescriptionTemplate] = useState("");
@@ -439,6 +444,7 @@ function CreateWebhookDialog({ open, onOpenChange, agents, daemons, apiBaseUrl, 
   const [showSchema, setShowSchema] = useState(false);
 
   const activeAgents = agents.filter((a: Agent) => !a.archived_at);
+  const selectedAgent = activeAgents.find((a) => a.id === agentId);
 
   useEffect(() => {
     if (open) {
@@ -463,6 +469,7 @@ function CreateWebhookDialog({ open, onOpenChange, agents, daemons, apiBaseUrl, 
         agent_id: agentId,
         title_template: titleTemplate || undefined,
         description_template: descriptionTemplate || undefined,
+        dispatch_provider: dispatchProvider || undefined,
         dispatch_daemon_id: dispatchDaemonId || undefined,
       });
       onCreated({ token: result.token, webhookId: result.webhook.id, url: `${apiBaseUrl}/api/webhooks/${result.webhook.id}` });
@@ -471,6 +478,7 @@ function CreateWebhookDialog({ open, onOpenChange, agents, daemons, apiBaseUrl, 
       setSourceType("standard");
       setActionType("create_issue");
       setAgentId("");
+      setDispatchProvider("");
       setDispatchDaemonId("");
       setTitleTemplate("");
       setDescriptionTemplate("");
@@ -583,6 +591,26 @@ function CreateWebhookDialog({ open, onOpenChange, agents, daemons, apiBaseUrl, 
                     </SelectContent>
                   </Select>
                 </div>
+                {selectedAgent && selectedAgent.providers.length > 0 && (
+                  <div className="flex items-center gap-3">
+                    <Label className="w-24 shrink-0 text-right">Provider</Label>
+                    <Select value={dispatchProvider} onValueChange={(v) => setDispatchProvider(v ?? "")}>
+                      <SelectTrigger size="sm" className="w-auto">
+                        <SelectValue placeholder="Auto">
+                          {dispatchProvider ? <span className="capitalize">{dispatchProvider}</span> : "Auto"}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="">Auto</SelectItem>
+                        {selectedAgent.providers.map((p) => (
+                          <SelectItem key={p} value={p}>
+                            <span className="capitalize">{p}</span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
                 <div className="flex items-center gap-3">
                   <Label className="w-24 shrink-0 text-right">Environment</Label>
                   <Select value={dispatchDaemonId} onValueChange={(v) => setDispatchDaemonId(v ?? "")}>
@@ -640,6 +668,7 @@ function EditWebhookDialog({ webhook, onOpenChange, agents, daemons, onUpdated }
   const [sourceType, setSourceType] = useState("standard");
   const [actionType, setActionType] = useState("create_issue");
   const [agentId, setAgentId] = useState("");
+  const [dispatchProvider, setDispatchProvider] = useState("");
   const [dispatchDaemonId, setDispatchDaemonId] = useState("");
   const [titleTemplate, setTitleTemplate] = useState("");
   const [descriptionTemplate, setDescriptionTemplate] = useState("");
@@ -648,6 +677,7 @@ function EditWebhookDialog({ webhook, onOpenChange, agents, daemons, onUpdated }
   const [showSchema, setShowSchema] = useState(false);
 
   const activeAgents = agents.filter((a: Agent) => !a.archived_at);
+  const selectedAgent = activeAgents.find((a) => a.id === agentId);
 
   useEffect(() => {
     if (webhook) {
@@ -658,6 +688,7 @@ function EditWebhookDialog({ webhook, onOpenChange, agents, daemons, onUpdated }
         setActionType(action.action_type);
         const cfg = action.config as CreateIssueActionConfig;
         setAgentId(cfg.agent_id || "");
+        setDispatchProvider(cfg.dispatch_provider || "");
         setDispatchDaemonId(cfg.dispatch_daemon_id || "");
         setTitleTemplate(cfg.title_template || "");
         setDescriptionTemplate(cfg.description_template || "");
@@ -684,6 +715,7 @@ function EditWebhookDialog({ webhook, onOpenChange, agents, daemons, onUpdated }
           title_template: titleTemplate,
           description_template: descriptionTemplate,
           labels: (action.config as CreateIssueActionConfig).labels || [],
+          dispatch_provider: dispatchProvider || undefined,
           dispatch_daemon_id: dispatchDaemonId || undefined,
           dispatch_daemon_label: undefined,
         };
@@ -801,6 +833,26 @@ function EditWebhookDialog({ webhook, onOpenChange, agents, daemons, onUpdated }
                     </SelectContent>
                   </Select>
                 </div>
+                {selectedAgent && selectedAgent.providers.length > 0 && (
+                  <div className="flex items-center gap-3">
+                    <Label className="w-24 shrink-0 text-right">Provider</Label>
+                    <Select value={dispatchProvider} onValueChange={(v) => setDispatchProvider(v ?? "")}>
+                      <SelectTrigger size="sm" className="w-auto">
+                        <SelectValue placeholder="Auto">
+                          {dispatchProvider ? <span className="capitalize">{dispatchProvider}</span> : "Auto"}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="">Auto</SelectItem>
+                        {selectedAgent.providers.map((p) => (
+                          <SelectItem key={p} value={p}>
+                            <span className="capitalize">{p}</span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
                 <div className="flex items-center gap-3">
                   <Label className="w-24 shrink-0 text-right">Environment</Label>
                   <Select value={dispatchDaemonId} onValueChange={(v) => setDispatchDaemonId(v ?? "")}>

--- a/apps/web/shared/types/webhook.ts
+++ b/apps/web/shared/types/webhook.ts
@@ -30,6 +30,7 @@ export interface CreateIssueActionConfig {
   title_template: string;
   description_template: string;
   labels: string[];
+  dispatch_provider?: string;
   dispatch_daemon_id?: string;
   dispatch_daemon_label?: string;
 }
@@ -48,6 +49,7 @@ export interface CreateWebhookRequest {
   title_template?: string;
   description_template?: string;
   labels?: string[];
+  dispatch_provider?: string;
   dispatch_daemon_id?: string;
   dispatch_daemon_label?: string;
 }

--- a/docs/webhook-design.md
+++ b/docs/webhook-design.md
@@ -69,6 +69,7 @@ Defines what to do when an event is received. Each webhook can have one or more 
   "title_template": "{{.title}}",
   "description_template": "{{.body}}",
   "labels": ["incident"],
+  "dispatch_provider": "string (optional, e.g. codex, claude)",
   "dispatch_daemon_id": "uuid (optional)",
   "dispatch_daemon_label": "string (optional)"
 }

--- a/server/internal/handler/webhook.go
+++ b/server/internal/handler/webhook.go
@@ -118,6 +118,7 @@ type CreateWebhookRequest struct {
 	TitleTemplate       string   `json:"title_template"`
 	DescriptionTemplate string   `json:"description_template"`
 	Labels              []string `json:"labels"`
+	DispatchProvider    string   `json:"dispatch_provider"`
 	DispatchDaemonID    string   `json:"dispatch_daemon_id"`
 	DispatchDaemonLabel string   `json:"dispatch_daemon_label"`
 }
@@ -199,6 +200,7 @@ func (h *Handler) CreateWebhook(w http.ResponseWriter, r *http.Request) {
 		TitleTemplate:       req.TitleTemplate,
 		DescriptionTemplate: req.DescriptionTemplate,
 		Labels:              req.Labels,
+		DispatchProvider:    req.DispatchProvider,
 		DispatchDaemonID:    req.DispatchDaemonID,
 		DispatchDaemonLabel: req.DispatchDaemonLabel,
 	}
@@ -601,6 +603,7 @@ type CreateIssueActionConfig struct {
 	TitleTemplate       string   `json:"title_template"`
 	DescriptionTemplate string   `json:"description_template"`
 	Labels              []string `json:"labels"`
+	DispatchProvider    string   `json:"dispatch_provider,omitempty"`
 	DispatchDaemonID    string   `json:"dispatch_daemon_id,omitempty"`
 	DispatchDaemonLabel string   `json:"dispatch_daemon_label,omitempty"`
 }
@@ -756,6 +759,7 @@ func (h *Handler) executeCreateIssueAction(r *http.Request, webhook db.Webhook, 
 		CreatorType:         "webhook",
 		CreatorID:           webhook.ID,
 		Number:              issueNumber,
+		DispatchProvider:    strToText(cfg.DispatchProvider),
 		DispatchDaemonID:    parseOptionalUUID(&cfg.DispatchDaemonID),
 		DispatchDaemonLabel: ptrToText(&cfg.DispatchDaemonLabel),
 	})


### PR DESCRIPTION
## Summary

- **Root cause**: Webhook-created issues were missing the `dispatch_provider` hint on the issue record. When an agent has multiple providers (e.g. claude, codex, cursor) but only one is authenticated on the target daemon, the scheduler could dispatch the task to an unusable runtime — causing the task to silently fail to execute.
- Add `dispatch_provider` field to `CreateIssueActionConfig`, `CreateWebhookRequest`, and the `executeCreateIssueAction` issue creation path so webhook-created issues carry the provider constraint.
- Add Provider picker (Select dropdown) to both Create and Edit webhook dialogs in the frontend, shown when the selected agent has multiple providers.
- Display configured provider in webhook card expanded details.

## Test plan

- [x] Go build + vet passes
- [x] TypeScript typecheck passes
- [x] Existing webhook adapter tests pass
- [ ] Manual: create webhook with `dispatch_provider=codex`, trigger via curl, verify created issue has `dispatch_provider` set and task dispatches to codex runtime


Made with [Cursor](https://cursor.com)