### PR TITLE
fix(webhook): merge action config on partial updates instead of replacing

### DIFF
--- a/server/internal/handler/webhook.go
+++ b/server/internal/handler/webhook.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -541,12 +542,12 @@ func (h *Handler) UpdateWebhookAction(w http.ResponseWriter, r *http.Request) {
 		params.ActionType = pgtype.Text{String: *req.ActionType, Valid: true}
 	}
 	if req.Config != nil {
-		configJSON, err := json.Marshal(req.Config)
+		merged, err := mergeActionConfig(action, req.Config)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid config")
+			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		params.Config = configJSON
+		params.Config = merged
 	}
 	if req.Enabled != nil {
 		params.Enabled = pgtype.Bool{Bool: *req.Enabled, Valid: true}
@@ -563,6 +564,36 @@ func (h *Handler) UpdateWebhookAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, webhookActionToResponse(updated))
+}
+
+// mergeActionConfig merges incoming config fields into the existing action
+// config. For create_issue actions, this prevents partial updates from
+// clobbering required fields like agent_id.
+func mergeActionConfig(action db.WebhookAction, incoming any) ([]byte, error) {
+	actionType := action.ActionType
+	if actionType != "create_issue" {
+		return json.Marshal(incoming)
+	}
+
+	var base CreateIssueActionConfig
+	if action.Config != nil {
+		json.Unmarshal(action.Config, &base)
+	}
+
+	incomingJSON, err := json.Marshal(incoming)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	if err := json.Unmarshal(incomingJSON, &base); err != nil {
+		return nil, fmt.Errorf("invalid create_issue config: %w", err)
+	}
+
+	if base.AgentID == "" {
+		return nil, fmt.Errorf("agent_id is required in create_issue config")
+	}
+
+	return json.Marshal(base)
 }
 
 func (h *Handler) DeleteWebhookAction(w http.ResponseWriter, r *http.Request) {
@@ -715,7 +746,10 @@ func (h *Handler) IngestWebhook(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) executeCreateIssueAction(r *http.Request, webhook db.Webhook, action db.WebhookAction, evt wh.Event) (pgtype.UUID, error) {
 	var cfg CreateIssueActionConfig
 	if err := json.Unmarshal(action.Config, &cfg); err != nil {
-		return pgtype.UUID{}, err
+		return pgtype.UUID{}, fmt.Errorf("invalid action config: %w", err)
+	}
+	if cfg.AgentID == "" {
+		return pgtype.UUID{}, fmt.Errorf("action config missing agent_id")
 	}
 
 	title := renderTemplate(cfg.TitleTemplate, evt.Data)

--- a/server/internal/handler/webhook_test.go
+++ b/server/internal/handler/webhook_test.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	db "github.com/nullne/multica/server/pkg/db/generated"
+)
+
+func TestMergeActionConfig_PartialUpdate(t *testing.T) {
+	existing := db.WebhookAction{
+		ActionType: "create_issue",
+		Config: mustJSON(CreateIssueActionConfig{
+			AgentID:          "agent-123",
+			TitleTemplate:    "[Alert] {{.title}}",
+			DispatchDaemonID: "daemon-456",
+		}),
+	}
+
+	incoming := map[string]any{
+		"dispatch_provider": "codex",
+	}
+
+	merged, err := mergeActionConfig(existing, incoming)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result CreateIssueActionConfig
+	if err := json.Unmarshal(merged, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if result.AgentID != "agent-123" {
+		t.Errorf("agent_id clobbered: got %q, want %q", result.AgentID, "agent-123")
+	}
+	if result.TitleTemplate != "[Alert] {{.title}}" {
+		t.Errorf("title_template clobbered: got %q", result.TitleTemplate)
+	}
+	if result.DispatchDaemonID != "daemon-456" {
+		t.Errorf("dispatch_daemon_id clobbered: got %q", result.DispatchDaemonID)
+	}
+	if result.DispatchProvider != "codex" {
+		t.Errorf("dispatch_provider not applied: got %q, want %q", result.DispatchProvider, "codex")
+	}
+}
+
+func TestMergeActionConfig_FullReplace(t *testing.T) {
+	existing := db.WebhookAction{
+		ActionType: "create_issue",
+		Config: mustJSON(CreateIssueActionConfig{
+			AgentID:       "agent-old",
+			TitleTemplate: "old title",
+		}),
+	}
+
+	incoming := CreateIssueActionConfig{
+		AgentID:          "agent-new",
+		TitleTemplate:    "new title",
+		DispatchProvider: "claude",
+	}
+
+	merged, err := mergeActionConfig(existing, incoming)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result CreateIssueActionConfig
+	json.Unmarshal(merged, &result)
+
+	if result.AgentID != "agent-new" {
+		t.Errorf("agent_id not updated: got %q", result.AgentID)
+	}
+	if result.TitleTemplate != "new title" {
+		t.Errorf("title_template not updated: got %q", result.TitleTemplate)
+	}
+	if result.DispatchProvider != "claude" {
+		t.Errorf("dispatch_provider not set: got %q", result.DispatchProvider)
+	}
+}
+
+func TestMergeActionConfig_MissingAgentID(t *testing.T) {
+	existing := db.WebhookAction{
+		ActionType: "create_issue",
+		Config:     mustJSON(CreateIssueActionConfig{}),
+	}
+
+	incoming := map[string]any{
+		"dispatch_provider": "codex",
+	}
+
+	_, err := mergeActionConfig(existing, incoming)
+	if err == nil {
+		t.Fatal("expected error for missing agent_id, got nil")
+	}
+}
+
+func TestMergeActionConfig_NonCreateIssue(t *testing.T) {
+	existing := db.WebhookAction{
+		ActionType: "custom",
+		Config:     []byte(`{"foo":"bar"}`),
+	}
+
+	incoming := map[string]any{"baz": "qux"}
+
+	merged, err := mergeActionConfig(existing, incoming)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(merged, &result)
+	if result["baz"] != "qux" {
+		t.Errorf("expected baz=qux, got %v", result["baz"])
+	}
+	if _, ok := result["foo"]; ok {
+		t.Errorf("non-create_issue should not merge, but found 'foo'")
+	}
+}
+


### PR DESCRIPTION
## Summary

- **Root cause**: `UpdateWebhookAction` replaced the entire JSONB config blob with incoming JSON. A partial update (e.g. setting only `dispatch_provider`) would clobber required fields like `agent_id`, causing subsequent webhook ingestions to silently fail at issue creation.
- For `create_issue` actions, incoming config fields are now merged into the existing config via `mergeActionConfig()` — unspecified fields are preserved.
- Added `agent_id` validation in both `UpdateWebhookAction` (rejects updates that would leave `agent_id` empty) and `executeCreateIssueAction` (fails early with a clear error message).
- Non-`create_issue` action types continue to use full replacement (no merge).

## Test plan

- [x] `make test-go` passes (all Go tests including handler tests with DB)
- [x] Unit tests for `mergeActionConfig`: partial update preserves existing fields, full replace works, missing `agent_id` rejected, non-create_issue passthrough


Made with [Cursor](https://cursor.com)