### PR TITLE
fix(webhook): treat empty dispatch_daemon_label as NULL, not empty string

### DIFF
--- a/server/internal/handler/webhook.go
+++ b/server/internal/handler/webhook.go
@@ -795,7 +795,7 @@ func (h *Handler) executeCreateIssueAction(r *http.Request, webhook db.Webhook, 
 		Number:              issueNumber,
 		DispatchProvider:    strToText(cfg.DispatchProvider),
 		DispatchDaemonID:    parseOptionalUUID(&cfg.DispatchDaemonID),
-		DispatchDaemonLabel: ptrToText(&cfg.DispatchDaemonLabel),
+		DispatchDaemonLabel: strToText(cfg.DispatchDaemonLabel),
 	})
 	if err != nil {
 		return pgtype.UUID{}, err

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -180,7 +180,12 @@ func (s *TaskService) enqueueTaskToAgent(ctx context.Context, issue db.Issue, ag
 
 	runtime, err := s.Queries.FindAvailableRuntimeConstrained(ctx, params)
 	if err != nil {
-		return db.AgentTaskQueue{}, fmt.Errorf("no online runtime for providers %v (dispatch hints: provider=%s, daemon_label=%s)", agent.Providers, issue.DispatchProvider.String, issue.DispatchDaemonLabel.String)
+		return db.AgentTaskQueue{}, fmt.Errorf("no online runtime for providers %v (dispatch hints: provider=%q valid=%v, daemon_id=%s valid=%v, daemon_label=%q valid=%v)",
+			agent.Providers,
+			issue.DispatchProvider.String, issue.DispatchProvider.Valid,
+			util.UUIDToString(issue.DispatchDaemonID), issue.DispatchDaemonID.Valid,
+			issue.DispatchDaemonLabel.String, issue.DispatchDaemonLabel.Valid,
+		)
 	}
 
 	runtimeID := runtime.ID


### PR DESCRIPTION
## Summary

- **Root cause**: `executeCreateIssueAction` used `ptrToText(&cfg.DispatchDaemonLabel)` to convert the config field to a DB value. Since `DispatchDaemonLabel` is a plain `string` (not `*string`), `&cfg.DispatchDaemonLabel` is never nil — so `PtrToText` treated the empty string `""` as a valid value, writing it to the issue's `dispatch_daemon_label` column as `''` instead of `NULL`.
- The runtime selection query (`FindAvailableRuntimeConstrained`) then applied `'' = ANY(d.labels)`, which never matches any daemon's label array (even empty `{}`), so **every** webhook-created issue consistently failed with "no online runtime".
- **Fix**: Use `strToText(cfg.DispatchDaemonLabel)` which correctly maps `""` → NULL.
- **Bonus**: Improved the "no online runtime" error message to include validity flags (`valid=true/false`) for all dispatch hints, making it easy to spot "configured as empty string" vs "not configured" in logs.

## Remediation for existing data

Affected issues in production need their `dispatch_daemon_label` set to NULL:
```sql
UPDATE issue SET dispatch_daemon_label = NULL
WHERE dispatch_daemon_label = '' AND creator_type = 'webhook';
```
Then re-trigger task enqueue (reassign or comment).

## Test plan

- [x] `make test-go` passes
- [ ] Manual: create webhook without daemon label, ingest event, verify issue has `dispatch_daemon_label IS NULL` and task dispatches successfully


Made with [Cursor](https://cursor.com)