### PR TITLE
fix(daemon): inherit login shell PATH so agents find user-installed CLIs

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -60,6 +60,11 @@ type Overrides struct {
 // LoadConfig builds the daemon configuration from environment variables
 // and optional CLI flag overrides.
 func LoadConfig(overrides Overrides) (Config, error) {
+	// Inherit PATH from the user's login shell so that CLIs installed via
+	// bash_profile/zprofile (e.g. multica, ops-cli) are discoverable both
+	// during agent probing below and inside spawned agent subprocesses.
+	inheritLoginEnv()
+
 	// Server URL: override > env > default
 	rawServerURL := envOrDefault("MULTICA_SERVER_URL", DefaultServerURL)
 	if overrides.ServerURL != "" {

--- a/server/internal/daemon/helpers.go
+++ b/server/internal/daemon/helpers.go
@@ -3,7 +3,10 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
+	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +42,93 @@ func intFromEnv(key string, fallback int) (int, error) {
 		return 0, fmt.Errorf("%s: invalid integer %q: %w", key, value, err)
 	}
 	return n, nil
+}
+
+// inheritLoginEnv spawns a login shell to resolve the user's full PATH
+// (including entries added by ~/.bash_profile, ~/.zprofile, etc.) and sets
+// it in the current process. This ensures exec.LookPath and agent child
+// processes see the same PATH the user expects from an interactive session.
+//
+// This is necessary because non-login contexts (systemd, cron, non-login SSH
+// commands) don't source profile files, so PATH may be missing user-installed
+// directories like /usr/local/bin.
+//
+// Only runs on macOS/Linux; no-op on other platforms.
+func inheritLoginEnv() {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		return
+	}
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
+	// Use a login shell (-l) to source profile files, then print PATH.
+	// Timeout guards against profiles that hang (e.g. interactive prompts,
+	// slow network mounts).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, shell, "-l", "-c", "echo $PATH")
+	cmd.Env = os.Environ()
+	out, err := cmd.Output()
+	if err != nil {
+		slog.Debug("inheritLoginEnv: failed to resolve login shell PATH", "shell", shell, "error", err)
+		return
+	}
+
+	loginPath := strings.TrimSpace(string(out))
+	if loginPath == "" {
+		return
+	}
+
+	currentPath := os.Getenv("PATH")
+	if loginPath == currentPath {
+		return
+	}
+
+	// Merge: start with the login shell PATH, then append any entries from
+	// the current PATH that aren't already present (e.g. Go-added dirs).
+	merged := mergePathValues(loginPath, currentPath)
+	os.Setenv("PATH", merged)
+	slog.Info("inherited PATH from login shell", "shell", shell, "added_dirs", pathDiff(currentPath, merged))
+}
+
+// pathDiff returns directories present in updated but not in original.
+func pathDiff(original, updated string) []string {
+	orig := map[string]bool{}
+	for _, p := range strings.Split(original, string(os.PathListSeparator)) {
+		orig[p] = true
+	}
+	var added []string
+	for _, p := range strings.Split(updated, string(os.PathListSeparator)) {
+		if p != "" && !orig[p] {
+			added = append(added, p)
+		}
+	}
+	return added
+}
+
+// mergePathValues merges two colon-separated PATH strings. Entries from
+// primary appear first; entries from secondary are appended if not already
+// present.
+func mergePathValues(primary, secondary string) string {
+	seen := map[string]bool{}
+	var parts []string
+	for _, p := range strings.Split(primary, string(os.PathListSeparator)) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			parts = append(parts, p)
+		}
+	}
+	for _, p := range strings.Split(secondary, string(os.PathListSeparator)) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, string(os.PathListSeparator))
 }
 
 func sleepWithContext(ctx context.Context, d time.Duration) error {


### PR DESCRIPTION
## Summary

- Daemon started from non-login contexts (systemd, cron, non-login SSH) doesn't source `~/.bash_profile`, causing `PATH` to miss user-installed directories like `/usr/local/bin`
- Spawned coding agents then waste tokens searching for CLIs like `multica`, `ops-cli`, etc.
- At daemon startup, spawn a login shell (`$SHELL -l`) with a 5s timeout to resolve the full PATH, then merge it into the daemon's process environment

## Test plan

- [ ] Deploy to CentOS machine where the issue occurs, start daemon via systemd/non-login SSH
- [ ] Verify daemon log shows `inherited PATH from login shell` with the added directories
- [ ] Assign an issue to an agent, confirm it finds `multica` and `ops-cli` without extra token-wasting searches
- [ ] Verify Rocky 9 machine still works (no regression — PATH should be unchanged if already correct)

Made with [Cursor](https://cursor.com)