### PR TITLE
feat(daemon): env viewer, create-issue UX, install path fix

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -23,7 +23,7 @@ brew install multica-cli
 git clone https://github.com/nullne/multica.git
 cd multica
 make build
-cp server/bin/multica /usr/local/bin/multica
+cp server/bin/multica ~/.local/bin/multica
 ```
 
 ### Update

--- a/apps/web/app/(dashboard)/settings/_components/providers-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/providers-tab.tsx
@@ -188,18 +188,11 @@ export function ProvidersTab() {
                     <div className="space-y-1.5">
                       <Label className="text-xs">Target Version</Label>
                       <Input
-                        placeholder="latest"
-                        value={config.target_version}
-                        onChange={(e) =>
-                          updateProvider(key, {
-                            target_version: e.target.value,
-                          })
-                        }
+                        value="latest"
+                        readOnly
+                        disabled
                         className="text-xs"
                       />
-                      <p className="text-xs text-muted-foreground">
-                        Version to install/update to. Leave empty for latest.
-                      </p>
                     </div>
                   </div>
                 )}

--- a/apps/web/features/modals/create-issue.tsx
+++ b/apps/web/features/modals/create-issue.tsx
@@ -157,8 +157,20 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   const [labelOpen, setLabelOpen] = useState(false);
   const [labelFilter, setLabelFilter] = useState("");
 
-  const [dispatchProvider, setDispatchProvider] = useState<string | undefined>();
-  const [dispatchDaemonId, setDispatchDaemonId] = useState<string | undefined>();
+  const initDispatch = (() => {
+    if (initAssigneeType !== "agent" || !initAssigneeId) return {};
+    const agent = agents.find((a) => a.id === initAssigneeId);
+    if (!agent) return {};
+    const saved = defaults.getAgentDispatch(initAssigneeId);
+    const currentRuntimes = useRuntimeStore.getState().runtimes;
+    const daemonId = agent.default_daemon_id ?? saved?.daemonId ?? undefined;
+    return {
+      daemonId,
+      provider: saved?.provider ?? pickBestProvider(agent.providers ?? [], currentRuntimes, daemonId),
+    };
+  })();
+  const [dispatchProvider, setDispatchProvider] = useState<string | undefined>(initDispatch.provider);
+  const [dispatchDaemonId, setDispatchDaemonId] = useState<string | undefined>(initDispatch.daemonId);
   const fetchAllRuntimes = useRuntimeStore((s) => s.fetchAll);
   const runtimes = useRuntimeStore((s) => s.runtimes);
 
@@ -170,6 +182,11 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   useEffect(() => {
     if (selectedAgent) fetchAllRuntimes();
   }, [selectedAgent, fetchAllRuntimes]);
+
+  useEffect(() => {
+    const t = setTimeout(() => descEditorRef.current?.focus(), 0);
+    return () => clearTimeout(t);
+  }, []);
 
   // Assignee popover
   const [assigneeOpen, setAssigneeOpen] = useState(false);
@@ -192,7 +209,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
 
   const assigneeQuery = assigneeFilter.toLowerCase();
   const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(assigneeQuery));
-  const filteredAgents = agents.filter((a) => a.name.toLowerCase().includes(assigneeQuery));
+  const filteredAgents = agents.filter((a) => !a.archived_at && a.name.toLowerCase().includes(assigneeQuery));
 
   const verifierQuery = verifierFilter.toLowerCase();
   const filteredVerifierAgents = agents.filter(
@@ -362,7 +379,6 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         {/* Title */}
         <div className="px-5 pb-2 shrink-0">
           <TitleEditor
-            autoFocus
             defaultValue={draft.title}
             placeholder="Issue title"
             className="text-lg font-semibold"

--- a/apps/web/features/runtimes/components/daemon-detail.tsx
+++ b/apps/web/features/runtimes/components/daemon-detail.tsx
@@ -1,7 +1,13 @@
 import { useState, useCallback } from "react";
-import { Monitor, Archive, ArchiveRestore, MoreHorizontal } from "lucide-react";
+import { Monitor, Archive, ArchiveRestore, MoreHorizontal, Terminal, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -71,6 +77,94 @@ function EditableDeviceName({ daemon }: { daemon: Daemon }) {
   );
 }
 
+function EnvDialog({ daemonId, open, onOpenChange }: { daemonId: string; open: boolean; onOpenChange: (v: boolean) => void }) {
+  const [envVars, setEnvVars] = useState<Record<string, string> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [filter, setFilter] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.getDaemonEnv(daemonId);
+      setEnvVars(data);
+    } catch {
+      toast.error("Failed to load environment variables");
+    } finally {
+      setLoading(false);
+    }
+  }, [daemonId]);
+
+  const handleOpenChange = useCallback((v: boolean) => {
+    onOpenChange(v);
+    if (v) {
+      setFilter("");
+      load();
+    }
+  }, [onOpenChange, load]);
+
+  const entries = envVars
+    ? Object.entries(envVars)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .filter(([k, v]) => {
+          if (!filter) return true;
+          const lower = filter.toLowerCase();
+          return k.toLowerCase().includes(lower) || v.toLowerCase().includes(lower);
+        })
+    : [];
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Environment Variables</DialogTitle>
+        </DialogHeader>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Filter variables..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="pl-8 h-8 text-sm"
+          />
+        </div>
+        <div className="flex-1 overflow-y-auto min-h-0 border rounded-md">
+          {loading ? (
+            <div className="p-4 text-sm text-muted-foreground text-center">Loading...</div>
+          ) : entries.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground text-center">
+              {envVars && Object.keys(envVars).length === 0
+                ? "No environment variables reported. Re-register the daemon to populate."
+                : "No matches"}
+            </div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-muted/80 backdrop-blur-sm">
+                <tr>
+                  <th className="text-left font-medium px-3 py-1.5 text-muted-foreground">Name</th>
+                  <th className="text-left font-medium px-3 py-1.5 text-muted-foreground">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {entries.map(([key, value]) => (
+                  <tr key={key} className="hover:bg-muted/40">
+                    <td className="px-3 py-1.5 font-mono whitespace-nowrap font-medium">{key}</td>
+                    <td className="px-3 py-1.5 font-mono break-all text-muted-foreground">{value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+        {envVars && Object.keys(envVars).length > 0 && (
+          <div className="text-xs text-muted-foreground">
+            {entries.length} of {Object.keys(envVars).length} variables
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 interface ProviderEntry {
   provider: string;
   runtime: AgentRuntime | null;
@@ -106,6 +200,7 @@ export function DaemonDetail({
   const providerEntries = buildProviderEntries(daemonRuntimes, enabledProviders);
   const firstRuntimeId = daemonRuntimes[0]?.id;
   const isArchived = !!daemon.archived_at;
+  const [envOpen, setEnvOpen] = useState(false);
 
   const handleArchiveToggle = useCallback(async () => {
     try {
@@ -195,6 +290,18 @@ export function DaemonDetail({
             <PingSection runtimeId={firstRuntimeId} />
           </div>
         )}
+
+        {/* Environment Variables */}
+        <div>
+          <h3 className="text-xs font-medium text-muted-foreground mb-3">
+            Environment
+          </h3>
+          <Button variant="outline" size="sm" onClick={() => setEnvOpen(true)}>
+            <Terminal className="h-3.5 w-3.5" />
+            View Environment Variables
+          </Button>
+          <EnvDialog daemonId={daemon.id} open={envOpen} onOpenChange={setEnvOpen} />
+        </div>
 
         {/* Providers with tabs */}
         {providerEntries.length > 0 && (

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -355,6 +355,10 @@ export class ApiClient {
     return this.fetch(`/api/daemons/${id}/restore`, { method: "POST" });
   }
 
+  async getDaemonEnv(id: string): Promise<Record<string, string>> {
+    return this.fetch(`/api/daemons/${id}/env`);
+  }
+
   async listRuntimes(params?: { workspace_id?: string }): Promise<AgentRuntime[]> {
     const search = new URLSearchParams();
     const wsId = params?.workspace_id ?? this.workspaceId;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO="nullne/multica"
 BINARY="multica"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${MULTICA_INSTALL_DIR:-${HOME}/.local/bin}"
 
 info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 error() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
@@ -93,6 +93,8 @@ main() {
 
   [ -f "${tmpdir}/${BINARY}" ] || error "Binary not found in archive"
 
+  mkdir -p "$INSTALL_DIR"
+
   info "Installing to ${INSTALL_DIR}/${BINARY}..."
   if [ -w "$INSTALL_DIR" ]; then
     mv "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
@@ -102,6 +104,26 @@ main() {
   chmod +x "${INSTALL_DIR}/${BINARY}"
 
   info "Installed ${BINARY} ${version} to ${INSTALL_DIR}/${BINARY}"
+
+  if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+    local shell_rc
+    case "$(basename "$SHELL")" in
+      zsh)  shell_rc="$HOME/.zshrc" ;;
+      bash) shell_rc="$HOME/.bashrc" ;;
+      fish) shell_rc="$HOME/.config/fish/config.fish" ;;
+      *)    shell_rc="$HOME/.profile" ;;
+    esac
+
+    if [ "$(basename "$SHELL")" = "fish" ]; then
+      echo "set -gx PATH \"$INSTALL_DIR\" \$PATH" >> "$shell_rc"
+    else
+      echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$shell_rc"
+    fi
+
+    export PATH="$INSTALL_DIR:$PATH"
+    info "Added ${INSTALL_DIR} to PATH in ${shell_rc}"
+  fi
+
   "${INSTALL_DIR}/${BINARY}" version 2>/dev/null || true
 }
 

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -249,6 +249,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		// Daemons
 		r.Get("/api/daemons", h.ListDaemons)
 		r.Patch("/api/daemons/{daemonId}", h.UpdateDaemon)
+		r.Get("/api/daemons/{daemonId}/env", h.GetDaemonEnv)
 		r.Post("/api/daemons/{daemonId}/archive", h.ArchiveDaemon)
 		r.Post("/api/daemons/{daemonId}/restore", h.RestoreDaemon)
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -363,8 +363,38 @@ func (d *Daemon) doRegister(ctx context.Context, workspaceID string, runtimes []
 		"device_name":  d.cfg.DeviceName,
 		"cli_version":  d.cfg.CLIVersion,
 		"runtimes":     runtimes,
+		"env_vars":     collectSanitizedEnv(),
 	}
 	return d.client.Register(ctx, req)
+}
+
+// collectSanitizedEnv returns the current process environment as a key-value
+// map with sensitive values masked (keys containing KEY, SECRET, TOKEN, etc.).
+func collectSanitizedEnv() map[string]string {
+	sensitiveSubstrings := []string{
+		"KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD",
+		"CREDENTIAL", "AUTH", "PRIVATE",
+	}
+	env := make(map[string]string)
+	for _, e := range os.Environ() {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		upper := strings.ToUpper(k)
+		masked := false
+		for _, sub := range sensitiveSubstrings {
+			if strings.Contains(upper, sub) {
+				env[k] = "********"
+				masked = true
+				break
+			}
+		}
+		if !masked {
+			env[k] = v
+		}
+	}
+	return env
 }
 
 // reconcileProviders checks heartbeat provider config against locally installed

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -20,10 +20,11 @@ import (
 // ---------------------------------------------------------------------------
 
 type DaemonRegisterRequest struct {
-	WorkspaceID string `json:"workspace_id"`
-	DaemonID    string `json:"daemon_id"`
-	DeviceName  string `json:"device_name"`
-	CLIVersion  string `json:"cli_version"` // multica CLI version
+	WorkspaceID string            `json:"workspace_id"`
+	DaemonID    string            `json:"daemon_id"`
+	DeviceName  string            `json:"device_name"`
+	CLIVersion  string            `json:"cli_version"` // multica CLI version
+	EnvVars     map[string]string `json:"env_vars,omitempty"`
 	Runtimes    []struct {
 		Name       string `json:"name"`
 		Type       string `json:"type"`
@@ -63,7 +64,11 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Upsert the daemon entity first.
-	daemonMeta, _ := json.Marshal(map[string]any{"cli_version": req.CLIVersion})
+	meta := map[string]any{"cli_version": req.CLIVersion}
+	if len(req.EnvVars) > 0 {
+		meta["env_vars"] = req.EnvVars
+	}
+	daemonMeta, _ := json.Marshal(meta)
 	daemon, err := h.Queries.UpsertDaemon(r.Context(), db.UpsertDaemonParams{
 		WorkspaceID: parseUUID(req.WorkspaceID),
 		DaemonID:    req.DaemonID,

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -293,6 +293,41 @@ func (h *Handler) GetRuntimeTaskActivity(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// GetDaemonEnv returns the environment variables reported by a daemon during registration.
+func (h *Handler) GetDaemonEnv(w http.ResponseWriter, r *http.Request) {
+	daemonID := chi.URLParam(r, "daemonId")
+
+	d, err := h.Queries.GetDaemon(r.Context(), parseUUID(daemonID))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "daemon not found")
+		return
+	}
+
+	if _, ok := h.requireWorkspaceMember(w, r, uuidToString(d.WorkspaceID), "daemon not found"); !ok {
+		return
+	}
+
+	var metadata map[string]any
+	if d.Metadata != nil {
+		json.Unmarshal(d.Metadata, &metadata)
+	}
+
+	envVars := map[string]string{}
+	if metadata != nil {
+		if raw, ok := metadata["env_vars"]; ok {
+			if m, ok := raw.(map[string]any); ok {
+				for k, v := range m {
+					if s, ok := v.(string); ok {
+						envVars[k] = s
+					}
+				}
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, envVars)
+}
+
 func (h *Handler) ListDaemons(w http.ResponseWriter, r *http.Request) {
 	workspaceID := resolveWorkspaceID(r)
 


### PR DESCRIPTION
## Summary

- **Daemon env viewer**: Daemons report sanitized environment variables during registration. New dialog in daemon detail page to view and filter env vars for debugging.
- **Create-issue UX**: Auto-focus description editor, pre-select dispatch provider from saved defaults, filter archived agents from assignee list, make target version read-only.
- **Install path**: Default install directory changed from `/usr/local/bin` to `~/.local/bin` to avoid `sudo`. Auto-creates directory and appends to shell PATH if missing.

## Test plan

- [ ] Register a daemon and verify env vars appear in daemon detail dialog (sensitive values masked)
- [ ] Create an issue with an agent assignee and verify dispatch provider is pre-selected
- [ ] Verify archived agents are not shown in assignee list
- [ ] Run `scripts/install.sh` and confirm it installs to `~/.local/bin` without sudo
- [ ] Verify `MULTICA_INSTALL_DIR=/custom/path scripts/install.sh` respects the override
- [ ] Run `multica update` after install and confirm it updates in-place at `~/.local/bin`


Made with [Cursor](https://cursor.com)