### PR TITLE
feat(cli): show agent skills, add skill commands, and tighten GitHub PR permissions

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -1296,8 +1296,8 @@ function SettingsTab({
         <div className="mt-1.5 flex gap-2">
           {([
             { value: "read", label: "Read", desc: "Read-only code access" },
-            { value: "write", label: "Write", desc: "Push code, create PRs" },
-            { value: "admin", label: "Admin", desc: "Push, create & merge PRs" },
+            { value: "write", label: "Write", desc: "Push branches (PRs opened by reviewer)" },
+            { value: "admin", label: "Admin", desc: "Push, open & merge PRs" },
           ] as const).map((opt) => (
             <button
               key={opt.value}

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 
@@ -113,7 +115,7 @@ func runAgentList(cmd *cobra.Command, _ []string) error {
 		return cli.PrintJSON(os.Stdout, agents)
 	}
 
-	headers := []string{"ID", "NAME", "STATUS", "RUNTIME"}
+	headers := []string{"ID", "NAME", "STATUS", "RUNTIME", "SKILLS"}
 	rows := make([][]string, 0, len(agents))
 	for _, a := range agents {
 		rows = append(rows, []string{
@@ -121,10 +123,45 @@ func runAgentList(cmd *cobra.Command, _ []string) error {
 			strVal(a, "name"),
 			strVal(a, "status"),
 			strVal(a, "runtime_mode"),
+			formatSkillsSummary(a["skills"]),
 		})
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil
+}
+
+// formatSkillsSummary renders the agent's skills column for the list table as
+// a comma-separated "name(idShort)" list, truncated to keep the row readable.
+func formatSkillsSummary(raw any) string {
+	skills, ok := raw.([]any)
+	if !ok || len(skills) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(skills))
+	for _, item := range skills {
+		s, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := strVal(s, "name")
+		id := strVal(s, "id")
+		switch {
+		case name != "" && id != "":
+			parts = append(parts, fmt.Sprintf("%s(%s)", name, truncateID(id)))
+		case name != "":
+			parts = append(parts, name)
+		case id != "":
+			parts = append(parts, truncateID(id))
+		}
+	}
+
+	out := strings.Join(parts, ", ")
+	if utf8.RuneCountInString(out) > 60 {
+		runes := []rune(out)
+		out = string(runes[:57]) + "..."
+	}
+	return out
 }
 
 func strVal(m map[string]any, key string) string {

--- a/server/cmd/multica/cmd_skill.go
+++ b/server/cmd/multica/cmd_skill.go
@@ -1,0 +1,591 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nullne/multica/server/internal/cli"
+)
+
+var skillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage skills",
+}
+
+var skillListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List skills in the workspace",
+	RunE:  runSkillList,
+}
+
+var skillGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get skill details (including files)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSkillGet,
+}
+
+var skillCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new skill",
+	RunE:  runSkillCreate,
+}
+
+var skillUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update an existing skill",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSkillUpdate,
+}
+
+var skillDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a skill",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSkillDelete,
+}
+
+var skillImportCmd = &cobra.Command{
+	Use:   "import <url>",
+	Short: "Import a skill from clawhub.ai or skills.sh",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSkillImport,
+}
+
+var skillAssignCmd = &cobra.Command{
+	Use:   "assign <agent>",
+	Short: "Replace the set of skills attached to an agent",
+	Long: `Replace the skill set on an agent.
+
+Pass each desired skill via --skill (repeatable). Skills can be specified by
+ID or by name (case-insensitive substring match). Pass --skill with no
+values to remove all skills from the agent.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSkillAssign,
+}
+
+func init() {
+	skillCmd.AddCommand(skillListCmd)
+	skillCmd.AddCommand(skillGetCmd)
+	skillCmd.AddCommand(skillCreateCmd)
+	skillCmd.AddCommand(skillUpdateCmd)
+	skillCmd.AddCommand(skillDeleteCmd)
+	skillCmd.AddCommand(skillImportCmd)
+	skillCmd.AddCommand(skillAssignCmd)
+
+	skillListCmd.Flags().String("output", "table", "Output format: table or json")
+
+	skillGetCmd.Flags().String("output", "json", "Output format: table or json")
+
+	skillCreateCmd.Flags().String("name", "", "Skill name (required)")
+	skillCreateCmd.Flags().String("description", "", "Skill description")
+	skillCreateCmd.Flags().String("content", "", "SKILL.md body (use - to read from stdin)")
+	skillCreateCmd.Flags().String("content-file", "", "Path to a file containing the SKILL.md body")
+	skillCreateCmd.Flags().StringSlice("file", nil, "Attach a supporting file: 'localpath' or 'remotepath=localpath' (repeatable)")
+	skillCreateCmd.Flags().String("config", "", "Skill config as inline JSON (default: {})")
+	skillCreateCmd.Flags().String("output", "json", "Output format: table or json")
+
+	skillUpdateCmd.Flags().String("name", "", "New name")
+	skillUpdateCmd.Flags().String("description", "", "New description")
+	skillUpdateCmd.Flags().String("content", "", "New SKILL.md body (use - to read from stdin)")
+	skillUpdateCmd.Flags().String("content-file", "", "Path to a file containing the new SKILL.md body")
+	skillUpdateCmd.Flags().StringSlice("file", nil, "Replace supporting files: 'localpath' or 'remotepath=localpath' (repeatable). Passing --file at all replaces ALL existing files.")
+	skillUpdateCmd.Flags().String("config", "", "New config as inline JSON")
+	skillUpdateCmd.Flags().String("output", "json", "Output format: table or json")
+
+	skillImportCmd.Flags().String("output", "json", "Output format: table or json")
+
+	skillAssignCmd.Flags().StringSlice("skill", nil, "Skill name or ID to attach (repeatable). Omit to clear.")
+	skillAssignCmd.Flags().String("output", "table", "Output format: table or json")
+}
+
+// ---------------------------------------------------------------------------
+// list / get
+// ---------------------------------------------------------------------------
+
+func runSkillList(cmd *cobra.Command, _ []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var skills []map[string]any
+	if err := client.GetJSON(ctx, "/api/skills", &skills); err != nil {
+		return fmt.Errorf("list skills: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, skills)
+	}
+
+	headers := []string{"ID", "NAME", "DESCRIPTION", "UPDATED"}
+	rows := make([][]string, 0, len(skills))
+	for _, s := range skills {
+		desc := strVal(s, "description")
+		if utf8.RuneCountInString(desc) > 60 {
+			runes := []rune(desc)
+			desc = string(runes[:57]) + "..."
+		}
+		updated := strVal(s, "updated_at")
+		if len(updated) >= 16 {
+			updated = updated[:16]
+		}
+		rows = append(rows, []string{
+			truncateID(strVal(s, "id")),
+			strVal(s, "name"),
+			desc,
+			updated,
+		})
+	}
+	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}
+
+func runSkillGet(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var skill map[string]any
+	if err := client.GetJSON(ctx, "/api/skills/"+args[0], &skill); err != nil {
+		return fmt.Errorf("get skill: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		desc := strVal(skill, "description")
+		if utf8.RuneCountInString(desc) > 80 {
+			runes := []rune(desc)
+			desc = string(runes[:77]) + "..."
+		}
+		files, _ := skill["files"].([]any)
+		filePaths := make([]string, 0, len(files))
+		for _, f := range files {
+			if fm, ok := f.(map[string]any); ok {
+				filePaths = append(filePaths, strVal(fm, "path"))
+			}
+		}
+		filesStr := strings.Join(filePaths, ", ")
+		if utf8.RuneCountInString(filesStr) > 60 {
+			runes := []rune(filesStr)
+			filesStr = string(runes[:57]) + "..."
+		}
+		headers := []string{"ID", "NAME", "DESCRIPTION", "FILES"}
+		rows := [][]string{{
+			truncateID(strVal(skill, "id")),
+			strVal(skill, "name"),
+			desc,
+			filesStr,
+		}}
+		cli.PrintTable(os.Stdout, headers, rows)
+		return nil
+	}
+
+	return cli.PrintJSON(os.Stdout, skill)
+}
+
+// ---------------------------------------------------------------------------
+// create / update
+// ---------------------------------------------------------------------------
+
+func runSkillCreate(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	if name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	body := map[string]any{"name": name}
+	if v, _ := cmd.Flags().GetString("description"); v != "" {
+		body["description"] = v
+	}
+
+	content, err := readSkillContent(cmd)
+	if err != nil {
+		return err
+	}
+	if content != "" {
+		body["content"] = content
+	}
+
+	if cmd.Flags().Changed("config") {
+		raw, _ := cmd.Flags().GetString("config")
+		var cfg any
+		if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+			return fmt.Errorf("parse --config JSON: %w", err)
+		}
+		body["config"] = cfg
+	}
+
+	files, err := readSkillFiles(cmd)
+	if err != nil {
+		return err
+	}
+	if files != nil {
+		body["files"] = files
+	}
+
+	timeout := 15 * time.Second
+	if len(files) > 0 {
+		timeout = 60 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/skills", body, &result); err != nil {
+		return fmt.Errorf("create skill: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stderr, "Skill %s created.\n", strVal(result, "id"))
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, result)
+}
+
+func runSkillUpdate(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	body := map[string]any{}
+	if cmd.Flags().Changed("name") {
+		v, _ := cmd.Flags().GetString("name")
+		body["name"] = v
+	}
+	if cmd.Flags().Changed("description") {
+		v, _ := cmd.Flags().GetString("description")
+		body["description"] = v
+	}
+
+	if cmd.Flags().Changed("content") || cmd.Flags().Changed("content-file") {
+		content, err := readSkillContent(cmd)
+		if err != nil {
+			return err
+		}
+		body["content"] = content
+	}
+
+	if cmd.Flags().Changed("config") {
+		raw, _ := cmd.Flags().GetString("config")
+		var cfg any
+		if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+			return fmt.Errorf("parse --config JSON: %w", err)
+		}
+		body["config"] = cfg
+	}
+
+	if cmd.Flags().Changed("file") {
+		files, err := readSkillFiles(cmd)
+		if err != nil {
+			return err
+		}
+		// Always send the array (possibly empty) so the server replaces the
+		// existing file set.
+		if files == nil {
+			files = []map[string]string{}
+		}
+		body["files"] = files
+	}
+
+	if len(body) == 0 {
+		return fmt.Errorf("no fields to update; use --name, --description, --content, --content-file, --config, or --file")
+	}
+
+	timeout := 15 * time.Second
+	if v, ok := body["files"]; ok {
+		if arr, ok := v.([]map[string]string); ok && len(arr) > 0 {
+			timeout = 60 * time.Second
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var result map[string]any
+	if err := client.PutJSON(ctx, "/api/skills/"+args[0], body, &result); err != nil {
+		return fmt.Errorf("update skill: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stderr, "Skill %s updated.\n", strVal(result, "id"))
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, result)
+}
+
+func runSkillDelete(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if err := client.DeleteJSON(ctx, "/api/skills/"+args[0]); err != nil {
+		return fmt.Errorf("delete skill: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Skill %s deleted.\n", truncateID(args[0]))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// import
+// ---------------------------------------------------------------------------
+
+func runSkillImport(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	// Imports may pull many files from the network — give the server some headroom.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	body := map[string]any{"url": args[0]}
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/skills/import", body, &result); err != nil {
+		return fmt.Errorf("import skill: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stderr, "Skill %s imported as %q.\n", strVal(result, "id"), strVal(result, "name"))
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, result)
+}
+
+// ---------------------------------------------------------------------------
+// assign skills to an agent
+// ---------------------------------------------------------------------------
+
+func runSkillAssign(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID is required: use --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+
+	if !cmd.Flags().Changed("skill") {
+		return fmt.Errorf("--skill is required (pass it with no value to clear all skills)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	agentID, err := resolveAgent(ctx, client, args[0])
+	if err != nil {
+		return fmt.Errorf("resolve agent: %w", err)
+	}
+
+	skillRefs, _ := cmd.Flags().GetStringSlice("skill")
+	skillIDs := make([]string, 0, len(skillRefs))
+	if len(skillRefs) > 0 {
+		all, fetchErr := fetchAllSkills(ctx, client)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		for _, ref := range skillRefs {
+			ref = strings.TrimSpace(ref)
+			if ref == "" {
+				continue
+			}
+			id, resolveErr := resolveSkillRef(all, ref)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			skillIDs = append(skillIDs, id)
+		}
+	}
+
+	body := map[string]any{"skill_ids": skillIDs}
+	var result []map[string]any
+	if err := client.PutJSON(ctx, "/api/agents/"+agentID+"/skills", body, &result); err != nil {
+		return fmt.Errorf("assign skills: %w", err)
+	}
+
+	if len(skillIDs) == 0 {
+		fmt.Fprintf(os.Stderr, "Cleared all skills from agent %s.\n", truncateID(agentID))
+	} else {
+		fmt.Fprintf(os.Stderr, "Agent %s now has %d skill(s).\n", truncateID(agentID), len(skillIDs))
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	headers := []string{"ID", "NAME", "DESCRIPTION"}
+	rows := make([][]string, 0, len(result))
+	for _, s := range result {
+		desc := strVal(s, "description")
+		if utf8.RuneCountInString(desc) > 60 {
+			runes := []rune(desc)
+			desc = string(runes[:57]) + "..."
+		}
+		rows = append(rows, []string{
+			truncateID(strVal(s, "id")),
+			strVal(s, "name"),
+			desc,
+		})
+	}
+	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// readSkillContent returns the SKILL.md body from --content (with stdin
+// support via "-") or --content-file. Both may be empty.
+func readSkillContent(cmd *cobra.Command) (string, error) {
+	contentFile, _ := cmd.Flags().GetString("content-file")
+	contentFlag, _ := cmd.Flags().GetString("content")
+
+	if contentFile != "" && contentFlag != "" {
+		return "", fmt.Errorf("--content and --content-file are mutually exclusive")
+	}
+	if contentFile != "" {
+		data, err := os.ReadFile(contentFile)
+		if err != nil {
+			return "", fmt.Errorf("read --content-file: %w", err)
+		}
+		return string(data), nil
+	}
+	return readFlagOrStdin(cmd, "content")
+}
+
+// readSkillFiles parses the --file flag entries into the request payload.
+// Each entry is either "localpath" (remote path = basename) or
+// "remotepath=localpath".
+func readSkillFiles(cmd *cobra.Command) ([]map[string]string, error) {
+	entries, _ := cmd.Flags().GetStringSlice("file")
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	out := make([]map[string]string, 0, len(entries))
+	for _, raw := range entries {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+
+		var remote, local string
+		if idx := strings.Index(raw, "="); idx > 0 {
+			remote = strings.TrimSpace(raw[:idx])
+			local = strings.TrimSpace(raw[idx+1:])
+		} else {
+			local = raw
+			remote = filepath.Base(raw)
+		}
+		if local == "" || remote == "" {
+			return nil, fmt.Errorf("invalid --file %q (expected 'localpath' or 'remotepath=localpath')", raw)
+		}
+
+		data, err := os.ReadFile(local)
+		if err != nil {
+			return nil, fmt.Errorf("read file %s: %w", local, err)
+		}
+		out = append(out, map[string]string{
+			"path":    remote,
+			"content": string(data),
+		})
+	}
+	return out, nil
+}
+
+// fetchAllSkills returns every skill in the current workspace.
+func fetchAllSkills(ctx context.Context, client *cli.APIClient) ([]map[string]any, error) {
+	path := "/api/skills"
+	if client.WorkspaceID != "" {
+		path += "?" + url.Values{"workspace_id": {client.WorkspaceID}}.Encode()
+	}
+	var skills []map[string]any
+	if err := client.GetJSON(ctx, path, &skills); err != nil {
+		return nil, fmt.Errorf("list skills: %w", err)
+	}
+	return skills, nil
+}
+
+// resolveSkillRef returns the skill ID matching ref, which may be an exact
+// ID or a case-insensitive substring of a skill name.
+func resolveSkillRef(all []map[string]any, ref string) (string, error) {
+	refLower := strings.ToLower(ref)
+
+	var idMatch map[string]any
+	var nameMatches []map[string]any
+	for _, s := range all {
+		if strVal(s, "id") == ref {
+			idMatch = s
+			break
+		}
+		if strings.Contains(strings.ToLower(strVal(s, "name")), refLower) {
+			nameMatches = append(nameMatches, s)
+		}
+	}
+	if idMatch != nil {
+		return strVal(idMatch, "id"), nil
+	}
+	switch len(nameMatches) {
+	case 0:
+		return "", fmt.Errorf("no skill found matching %q", ref)
+	case 1:
+		return strVal(nameMatches[0], "id"), nil
+	default:
+		parts := make([]string, 0, len(nameMatches))
+		for _, m := range nameMatches {
+			parts = append(parts, fmt.Sprintf("  %q (%s)", strVal(m, "name"), truncateID(strVal(m, "id"))))
+		}
+		return "", fmt.Errorf("ambiguous skill %q; matches:\n%s", ref, strings.Join(parts, "\n"))
+	}
+}

--- a/server/cmd/multica/cmd_skill_test.go
+++ b/server/cmd/multica/cmd_skill_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillSubcommandsRegistered(t *testing.T) {
+	subcommands := []string{"list", "get", "create", "update", "delete", "import", "assign"}
+	for _, sub := range subcommands {
+		t.Run(sub, func(t *testing.T) {
+			if _, _, err := skillCmd.Find([]string{sub}); err != nil {
+				t.Fatalf("expected skill %s command to exist: %v", sub, err)
+			}
+		})
+	}
+}
+
+func TestSkillCmdRegisteredOnRoot(t *testing.T) {
+	if _, _, err := rootCmd.Find([]string{"skill"}); err != nil {
+		t.Fatalf("expected skill command registered on rootCmd: %v", err)
+	}
+}
+
+func TestFormatSkillsSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "empty slice",
+			in:   []any{},
+			want: "",
+		},
+		{
+			name: "single skill",
+			in: []any{
+				map[string]any{"id": "abcdefgh-1234", "name": "Foo"},
+			},
+			want: "Foo(abcdefgh)",
+		},
+		{
+			name: "multiple skills",
+			in: []any{
+				map[string]any{"id": "abcdefgh-1234", "name": "Foo"},
+				map[string]any{"id": "ijklmnop-5678", "name": "Bar"},
+			},
+			want: "Foo(abcdefgh), Bar(ijklmnop)",
+		},
+		{
+			name: "missing name uses id",
+			in: []any{
+				map[string]any{"id": "abcdefgh-1234"},
+			},
+			want: "abcdefgh",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSkillsSummary(tt.in)
+			if got != tt.want {
+				t.Errorf("formatSkillsSummary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSkillRef(t *testing.T) {
+	all := []map[string]any{
+		{"id": "skill-1111", "name": "Frontend Reviewer"},
+		{"id": "skill-2222", "name": "Backend Reviewer"},
+		{"id": "skill-3333", "name": "Docs Writer"},
+	}
+
+	t.Run("exact id match", func(t *testing.T) {
+		got, err := resolveSkillRef(all, "skill-2222")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "skill-2222" {
+			t.Errorf("got %q, want skill-2222", got)
+		}
+	})
+
+	t.Run("case-insensitive name match", func(t *testing.T) {
+		got, err := resolveSkillRef(all, "docs")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "skill-3333" {
+			t.Errorf("got %q, want skill-3333", got)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		if _, err := resolveSkillRef(all, "nope"); err == nil {
+			t.Fatal("expected error for missing match")
+		}
+	})
+
+	t.Run("ambiguous match", func(t *testing.T) {
+		if _, err := resolveSkillRef(all, "reviewer"); err == nil {
+			t.Fatal("expected error for ambiguous match")
+		}
+	})
+}
+
+func TestReadSkillFiles(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "hello.md")
+	if err := os.WriteFile(localPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	t.Run("nothing returns nil", func(t *testing.T) {
+		cmd := testCmd()
+		cmd.Flags().StringSlice("file", nil, "")
+		out, err := readSkillFiles(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != nil {
+			t.Errorf("expected nil, got %v", out)
+		}
+	})
+
+	t.Run("local-only entry uses basename", func(t *testing.T) {
+		cmd := testCmd()
+		cmd.Flags().StringSlice("file", []string{localPath}, "")
+		out, err := readSkillFiles(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 1 || out[0]["path"] != "hello.md" || out[0]["content"] != "hello" {
+			t.Errorf("unexpected files payload: %+v", out)
+		}
+	})
+
+	t.Run("remote=local entry uses remote path", func(t *testing.T) {
+		cmd := testCmd()
+		cmd.Flags().StringSlice("file", []string{"references/foo.md=" + localPath}, "")
+		out, err := readSkillFiles(cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 1 || out[0]["path"] != "references/foo.md" || out[0]["content"] != "hello" {
+			t.Errorf("unexpected files payload: %+v", out)
+		}
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		cmd := testCmd()
+		cmd.Flags().StringSlice("file", []string{filepath.Join(dir, "missing.md")}, "")
+		if _, err := readSkillFiles(cmd); err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -32,6 +32,7 @@ func init() {
 	rootCmd.AddCommand(workspaceCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(issueCmd)
+	rootCmd.AddCommand(skillCmd)
 	rootCmd.AddCommand(repoCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateCmd)

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -895,12 +895,24 @@ func TestInjectRuntimeConfig_GitHubCodeAccess(t *testing.T) {
 
 	tests := []struct {
 		level    string
-		contains string
-		absent   string
+		contains []string
+		absent   []string
 	}{
-		{"read", "read-only", "MUST NOT"},
-		{"write", "MUST NOT", "full access"},
-		{"admin", "full access", "MUST NOT"},
+		{
+			level:    "read",
+			contains: []string{"read-only"},
+			absent:   []string{"push branches", "full access"},
+		},
+		{
+			level:    "write",
+			contains: []string{"push branches", "cannot"},
+			absent:   []string{"full access"},
+		},
+		{
+			level:    "admin",
+			contains: []string{"full access", "merge"},
+			absent:   []string{"read-only", "cannot"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -923,11 +935,15 @@ func TestInjectRuntimeConfig_GitHubCodeAccess(t *testing.T) {
 			if !strings.Contains(s, "## GitHub Access") {
 				t.Error("should contain GitHub Access section")
 			}
-			if !strings.Contains(s, tt.contains) {
-				t.Errorf("should contain %q for level=%s", tt.contains, tt.level)
+			for _, want := range tt.contains {
+				if !strings.Contains(s, want) {
+					t.Errorf("should contain %q for level=%s", want, tt.level)
+				}
 			}
-			if tt.absent != "" && tt.level != "write" && strings.Contains(s, tt.absent) {
-				t.Errorf("should not contain %q for level=%s", tt.absent, tt.level)
+			for _, unwanted := range tt.absent {
+				if strings.Contains(s, unwanted) {
+					t.Errorf("should not contain %q for level=%s", unwanted, tt.level)
+				}
 			}
 		})
 	}

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -153,8 +153,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 			b.WriteString("Do not attempt to push commits or merge pull requests. ")
 			b.WriteString("You can create issues and comment on issues/PRs.\n\n")
 		case "write":
-			b.WriteString("You can push code and create pull requests. ")
-			b.WriteString("You **MUST NOT** merge pull requests — create PRs for review only.\n\n")
+			b.WriteString("You can push branches to repositories. ")
+			b.WriteString("You **cannot** open, merge, or close pull requests — your installation token does not carry pull_request write access. ")
+			b.WriteString("After pushing, ask a human reviewer or an admin agent to open the PR.\n\n")
 		case "admin":
 			b.WriteString("You have full access: push code, create pull requests, and merge them.\n\n")
 		}

--- a/server/internal/github/permissions.go
+++ b/server/internal/github/permissions.go
@@ -15,10 +15,16 @@ const (
 
 // basePermissions returns the permissions every agent token receives
 // regardless of code access level.
+//
+// Note: pull_requests defaults to read here. Only the admin tier upgrades
+// it to write in PermissionsForCodeAccess. GitHub bundles PR
+// create/update/merge/close under a single "write" permission, so giving
+// the write tier pull_requests=write would also let it merge — see
+// PermissionsForCodeAccess for the full matrix.
 func basePermissions() map[string]string {
 	return map[string]string{
 		"issues":        PermWrite,
-		"pull_requests": PermWrite,
+		"pull_requests": PermRead,
 		"checks":        PermRead,
 		"statuses":      PermRead,
 		"metadata":      PermRead,
@@ -27,13 +33,28 @@ func basePermissions() map[string]string {
 
 // PermissionsForCodeAccess returns the full GitHub installation token
 // permission set for the given code access level.
+//
+// Matrix:
+//
+//	level   contents  pull_requests  issues  checks  statuses  metadata
+//	read    read      read           write   read    read      read
+//	write   write     read           write   read    read      read
+//	admin   write     write          write   read    read      read
+//
+// pull_requests=write covers PR create / update / merge / close at the
+// GitHub API level; it is intentionally restricted to admin so that
+// read/write agents cannot merge or close PRs even by calling the API
+// directly with their installation token.
 func PermissionsForCodeAccess(level string) map[string]string {
 	perms := basePermissions()
 	switch level {
 	case CodeAccessRead:
 		perms["contents"] = PermRead
-	case CodeAccessWrite, CodeAccessAdmin:
+	case CodeAccessWrite:
 		perms["contents"] = PermWrite
+	case CodeAccessAdmin:
+		perms["contents"] = PermWrite
+		perms["pull_requests"] = PermWrite
 	default:
 		perms["contents"] = PermRead
 	}
@@ -42,6 +63,10 @@ func PermissionsForCodeAccess(level string) map[string]string {
 
 // MergeAllowed returns whether the given code access level permits
 // merging pull requests. Only "admin" level allows merging.
+//
+// This is a defense-in-depth check for any future server-side merge proxy
+// flows. The primary enforcement is the GitHub installation token scope —
+// see PermissionsForCodeAccess.
 func MergeAllowed(level string) bool {
 	return level == CodeAccessAdmin
 }

--- a/server/internal/github/permissions_test.go
+++ b/server/internal/github/permissions_test.go
@@ -2,39 +2,61 @@ package github
 
 import "testing"
 
-func TestPermissionsForCodeAccess_Read(t *testing.T) {
-	perms := PermissionsForCodeAccess(CodeAccessRead)
+// TestPermissionsForCodeAccess_Matrix asserts the full permission matrix
+// for every supported code access level. See PermissionsForCodeAccess for
+// the rationale; pull_requests=write is intentionally admin-only.
+func TestPermissionsForCodeAccess_Matrix(t *testing.T) {
+	cases := []struct {
+		level string
+		want  map[string]string
+	}{
+		{
+			level: CodeAccessRead,
+			want: map[string]string{
+				"contents":      PermRead,
+				"pull_requests": PermRead,
+				"issues":        PermWrite,
+				"checks":        PermRead,
+				"statuses":      PermRead,
+				"metadata":      PermRead,
+			},
+		},
+		{
+			level: CodeAccessWrite,
+			want: map[string]string{
+				"contents":      PermWrite,
+				"pull_requests": PermRead,
+				"issues":        PermWrite,
+				"checks":        PermRead,
+				"statuses":      PermRead,
+				"metadata":      PermRead,
+			},
+		},
+		{
+			level: CodeAccessAdmin,
+			want: map[string]string{
+				"contents":      PermWrite,
+				"pull_requests": PermWrite,
+				"issues":        PermWrite,
+				"checks":        PermRead,
+				"statuses":      PermRead,
+				"metadata":      PermRead,
+			},
+		},
+	}
 
-	if perms["contents"] != PermRead {
-		t.Errorf("expected contents=read, got %q", perms["contents"])
-	}
-	if perms["issues"] != PermWrite {
-		t.Errorf("expected issues=write, got %q", perms["issues"])
-	}
-	if perms["pull_requests"] != PermWrite {
-		t.Errorf("expected pull_requests=write, got %q", perms["pull_requests"])
-	}
-	if perms["checks"] != PermRead {
-		t.Errorf("expected checks=read, got %q", perms["checks"])
-	}
-}
-
-func TestPermissionsForCodeAccess_Write(t *testing.T) {
-	perms := PermissionsForCodeAccess(CodeAccessWrite)
-
-	if perms["contents"] != PermWrite {
-		t.Errorf("expected contents=write, got %q", perms["contents"])
-	}
-	if perms["issues"] != PermWrite {
-		t.Errorf("base permission issues should be write, got %q", perms["issues"])
-	}
-}
-
-func TestPermissionsForCodeAccess_Admin(t *testing.T) {
-	perms := PermissionsForCodeAccess(CodeAccessAdmin)
-
-	if perms["contents"] != PermWrite {
-		t.Errorf("expected contents=write for admin, got %q", perms["contents"])
+	for _, tc := range cases {
+		t.Run(tc.level, func(t *testing.T) {
+			got := PermissionsForCodeAccess(tc.level)
+			for key, want := range tc.want {
+				if got[key] != want {
+					t.Errorf("level=%s: %s = %q, want %q", tc.level, key, got[key], want)
+				}
+			}
+			if len(got) != len(tc.want) {
+				t.Errorf("level=%s: got %d perms, want %d (got=%v)", tc.level, len(got), len(tc.want), got)
+			}
+		})
 	}
 }
 
@@ -43,6 +65,9 @@ func TestPermissionsForCodeAccess_Unknown(t *testing.T) {
 
 	if perms["contents"] != PermRead {
 		t.Errorf("unknown level should default to contents=read, got %q", perms["contents"])
+	}
+	if perms["pull_requests"] != PermRead {
+		t.Errorf("unknown level should leave pull_requests=read, got %q", perms["pull_requests"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Three related changes around the agent surface:

### 1. `agent list` — show configured skills
- Default `multica agent list` table now includes a SKILLS column rendered as `name(idShort), name(idShort), …`, truncated at 60 chars. JSON output unchanged.

### 2. `multica skill` — full CRUD CLI
Adds a `multica skill` command group covering the existing skill API:
- `skill list`, `skill get <id>`
- `skill create` / `skill update <id>` with inline content, `--content-file`, JSON `--config`, and repeatable `--file local` or `--file remote=local` attachments (update replaces the file set, matching the server contract)
- `skill delete <id>`
- `skill import <url>` for clawhub.ai / skills.sh
- `skill assign <agent> --skill ...` — replaces an agent's skills, accepting agents and skills by ID or by case-insensitive name match

Why: skills already exist server-side but were invisible from the CLI. This brings the CLI to feature parity with the basics needed to drive agent + skill workflows from a terminal or daemon.

### 3. `fix(github)`: scope `pull_requests` permission to admin tier only
Token permissions previously gave every tier `pull_requests: write`, so a `read` or `write` agent could merge, close, or edit PRs at the GitHub API level — only the system prompt was stopping them. New matrix:

| level | contents | pull_requests | issues | checks | statuses | metadata |
|---|---|---|---|---|---|---|
| read  | read  | **read**  | write | read | read | read |
| write | write | **read**  | write | read | read | read |
| admin | write | **write** | write | read | read | read |

Trade-off (called out in the original issue): GitHub bundles PR create/update/merge/close under a single `write` scope. To keep merge admin-only at the token level, `write` agents lose the ability to open PRs from their installation token too — they can push branches and a human reviewer or admin agent opens the PR. The daemon system prompt and agent settings UI copy are updated to reflect this.

Acceptance criteria from the issue:
- [x] `PermissionsForCodeAccess("read")["pull_requests"] == "read"`
- [x] `PermissionsForCodeAccess("write")["pull_requests"] == "read"`
- [x] `PermissionsForCodeAccess("admin")["pull_requests"] == "write"`
- [x] `contents` matrix unchanged (`read` / `write` / `write`)
- [x] System prompt for the `write` tier no longer claims "create pull requests"
- [x] Settings UI copy reflects the new tier semantics
- [n/a] `MergeAllowed()` left in place as defense-in-depth for future server-side merge proxy flows; doc-comment updated to make that explicit

## Test plan

- [x] `cd server && go build ./...`
- [x] `cd server && go vet ./...`
- [x] `cd server && go test ./internal/github/... ./internal/daemon/execenv/... ./cmd/multica/...`
- [ ] Manual smoke against a running server: login, set workspace, exercise `multica skill list/create/update/assign/get/delete`, confirm `multica agent list` shows the SKILLS column
- [ ] Manual: install/refresh the GitHub App on a write-tier agent and confirm a `gh pr merge` from the agent's token is rejected with 403