### PR TITLE
ci: auto-deploy to prod when a release tag is pushed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,17 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to deploy (e.g. v0.2.2)."
+        required: true
+        type: string
+      clean:
+        description: "Clean deploy: remove existing database and start fresh"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,10 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.value }}
             COMMIT=${{ github.sha }}
+
+  deploy:
+    needs: [cli, images]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,15 +193,21 @@ CI runs on Node 22 and Go 1.26.1 with a `pgvector/pgvector:pg17` PostgreSQL serv
   - `test(scope): ...`
   - `chore(scope): ...`
 
-## CLI Release
+## Release & Production Deploy
 
-**Prerequisite:** A CLI release must accompany every Production deployment. When deploying to Production, always release a new CLI version as part of the process.
+Pushing a `v*` tag on `main` is the single action that ships a release **and** deploys it to production. There is no separate manual deploy step.
 
 1. Create a tag on the `main` branch: `git tag v0.x.x`
 2. Push the tag: `git push origin v0.x.x`
-3. GitHub Actions automatically triggers `release.yml`: runs Go tests → GoReleaser builds multi-platform binaries → publishes to GitHub Releases + Homebrew tap
+3. GitHub Actions runs `release.yml`, which:
+   - Runs Go tests
+   - GoReleaser builds multi-platform binaries → publishes to GitHub Releases + Homebrew tap
+   - Builds and pushes backend + frontend Docker images to ghcr.io
+   - Calls `deploy.yml` to deploy that exact tag to the `prod` environment
 
 By default, bump the patch version each release (e.g. `v0.1.12` → `v0.1.13`), unless the user specifies a specific version.
+
+`deploy.yml` is still runnable manually via "Run workflow" for one-off needs (rollback to an older tag, redeploy without rebuilding, or `clean: true` to wipe the database and start fresh).
 
 ## Minimum Pre-Push Checks
 


### PR DESCRIPTION
## Summary

Today, shipping to production is two manual actions: push a `v*` tag (runs `release.yml` → publishes CLI + Docker images), then go to the Actions tab and click **Run workflow** on `Deploy`. This change collapses it into one action so that pushing a release tag also deploys it to prod.

- `deploy.yml`: add a `workflow_call` trigger alongside the existing `workflow_dispatch`, so the deploy can be invoked both manually and from another workflow. Manual dispatch (with optional `version` and `clean` inputs) is preserved for rollbacks, redeploys, and clean deploys.
- `release.yml`: add a `deploy` job that `needs: [cli, images]` and `uses: ./.github/workflows/deploy.yml` with `secrets: inherit`, passing `github.ref_name` (the pushed tag) as `version`.
- `CLAUDE.md`: rename "CLI Release" → "Release & Production Deploy" and document the single-step flow.

New flow on `git push origin v0.x.x`:

\`\`\`
test-backend
   ├── cli (GoReleaser → GitHub Releases + Homebrew)
   └── images (backend + frontend → ghcr.io)
        │
        └── deploy (workflow_call → deploy.yml)
              ├── verify (image exists)
              └── deploy (self-hosted, environment: prod)
\`\`\`

Any failed step short-circuits the chain — prod isn't touched if tests, GoReleaser, or image build fail.

## Notes

- The `prod` environment's protection rules still apply. If you want a human approval gate before the auto-deploy, add required reviewers to the `prod` environment in repo settings — no workflow change needed.
- `deploy.yml` is still listed under Actions and can be run manually for one-off needs (rollback to an older tag, redeploy without rebuilding, `clean: true` to wipe the database).
- `cli` (GoReleaser) is now a hard dependency of deploy. If GoReleaser fails (e.g. expired `HOMEBREW_TAP_GITHUB_TOKEN`), prod won't deploy. This matches the prior CLAUDE.md rule that a CLI release must accompany every prod deploy. Drop `cli` from `needs:` if you want to decouple them.

## Test plan

- [ ] Merge to `main`.
- [ ] Optionally add a temporary required reviewer to the `prod` GitHub environment for the first run.
- [ ] Cut a patch release: `git tag v0.x.y && git push origin v0.x.y`.
- [ ] Watch `release.yml` run: `test-backend → cli + images → deploy (calls deploy.yml) → verify → deploy on self-hosted`.
- [ ] Confirm `/health` on prod reports the new version.
- [ ] Confirm manual `Run workflow` on `Deploy` still works (try with an older tag).

Made with [Cursor](https://cursor.com)