### PR TITLE
feat(github): per-repository overrides for GitHub event rules

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/github-events-section.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/github-events-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { GitBranch, ChevronDown, ChevronRight } from "lucide-react";
+import { GitBranch, ChevronDown, ChevronRight, Plus } from "lucide-react";
 import type { GitHubEventRule, GitHubEventType, Agent, Daemon } from "@/shared/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -56,6 +56,8 @@ const EVENT_TYPES: EventTypeConfig[] = [
   },
 ];
 
+const REPO_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
 export function GitHubEventsSection() {
   const workspace = useWorkspaceStore((s) => s.workspace);
   const agents = useWorkspaceStore((s) => s.agents);
@@ -88,8 +90,7 @@ export function GitHubEventsSection() {
 
   if (!isConnected || !workspace) return null;
 
-  const ruleByType = (type: GitHubEventType) =>
-    rules.find((r) => r.event_type === type) ?? null;
+  const rulesByType = (type: GitHubEventType) => rules.filter((r) => r.event_type === type);
 
   return (
     <section className="space-y-4">
@@ -100,7 +101,9 @@ export function GitHubEventsSection() {
       </div>
 
       <p className="text-xs text-muted-foreground">
-        Configure which GitHub events automatically create issues for your agents. Events are received through the GitHub App installed on your organization.
+        Configure which GitHub events automatically create issues for your agents. Each event type
+        has a workspace-wide default plus optional per-repository overrides; the most-specific
+        matching rule wins.
       </p>
 
       {loading ? (
@@ -123,7 +126,7 @@ export function GitHubEventsSection() {
             <EventTypeCard
               key={et.type}
               config={et}
-              rule={ruleByType(et.type)}
+              rules={rulesByType(et.type)}
               agents={agents}
               daemons={daemons}
               workspaceId={workspace.id}
@@ -138,52 +141,63 @@ export function GitHubEventsSection() {
 
 function EventTypeCard({
   config,
-  rule,
+  rules,
   agents,
   daemons,
   workspaceId,
   onUpdated,
 }: {
   config: EventTypeConfig;
-  rule: GitHubEventRule | null;
+  rules: GitHubEventRule[];
   agents: Agent[];
   daemons: Daemon[];
   workspaceId: string;
   onUpdated: () => Promise<void>;
 }) {
   const [expanded, setExpanded] = useState(false);
+  // Drafts for repo-override rules that exist locally but aren't yet saved.
+  // Keyed by a stable client-side id.
+  const [drafts, setDrafts] = useState<{ id: string }[]>([]);
   const [saving, setSaving] = useState(false);
 
-  const [agentId, setAgentId] = useState(rule?.agent_id ?? "");
-  const [enabled, setEnabled] = useState(rule?.enabled ?? false);
-  const [titleTemplate, setTitleTemplate] = useState(rule?.title_template ?? "");
-  const [descriptionTemplate, setDescriptionTemplate] = useState(rule?.description_template ?? "");
-  const [dispatchProvider, setDispatchProvider] = useState(rule?.dispatch_provider ?? "");
-  const [dispatchDaemonId, setDispatchDaemonId] = useState(rule?.dispatch_daemon_id ?? "");
-
-  useEffect(() => {
-    setAgentId(rule?.agent_id ?? "");
-    setEnabled(rule?.enabled ?? false);
-    setTitleTemplate(rule?.title_template ?? "");
-    setDescriptionTemplate(rule?.description_template ?? "");
-    setDispatchProvider(rule?.dispatch_provider ?? "");
-    setDispatchDaemonId(rule?.dispatch_daemon_id ?? "");
-  }, [rule]);
-
+  const defaultRule = rules.find((r) => r.repo_full_name === "") ?? null;
+  const overrideRules = rules.filter((r) => r.repo_full_name !== "");
   const activeAgents = agents.filter((a) => !a.archived_at);
 
-  const handleToggle = async (checked: boolean) => {
-    if (!rule && !checked) return;
+  const enabledCount = rules.filter((r) => r.enabled).length;
+  const summaryLabel = (() => {
+    if (defaultRule?.enabled && overrideRules.length === 0) {
+      return agentName(agents, defaultRule.agent_id);
+    }
+    if (enabledCount === 0) return null;
+    return `${enabledCount} rule${enabledCount === 1 ? "" : "s"}`;
+  })();
 
-    if (!rule && checked) {
+  const handleToggleDefault = async (checked: boolean) => {
+    if (!defaultRule && !checked) return;
+
+    if (!defaultRule && checked) {
       const firstAgent = activeAgents[0];
       if (!firstAgent) {
         toast.error("No agents available. Create an agent first.");
         return;
       }
-      setEnabled(true);
-      setAgentId(firstAgent.id);
-      setExpanded(true);
+      setSaving(true);
+      try {
+        await api.upsertGitHubEventRule(workspaceId, {
+          event_type: config.type,
+          repo_full_name: "",
+          agent_id: firstAgent.id,
+          enabled: true,
+        });
+        await onUpdated();
+        setExpanded(true);
+        toast.success(`${config.label} default enabled`);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Failed to enable");
+      } finally {
+        setSaving(false);
+      }
       return;
     }
 
@@ -191,11 +205,12 @@ function EventTypeCard({
     try {
       await api.upsertGitHubEventRule(workspaceId, {
         event_type: config.type,
-        agent_id: rule!.agent_id,
+        repo_full_name: "",
+        agent_id: defaultRule!.agent_id,
         enabled: checked,
       });
       await onUpdated();
-      toast.success(checked ? `${config.label} events enabled` : `${config.label} events disabled`);
+      toast.success(checked ? `${config.label} default enabled` : `${config.label} default disabled`);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed to update");
     } finally {
@@ -203,53 +218,13 @@ function EventTypeCard({
     }
   };
 
-  const handleSave = async () => {
-    if (!agentId) {
-      toast.error("Please select an agent");
-      return;
-    }
-    setSaving(true);
-    try {
-      await api.upsertGitHubEventRule(workspaceId, {
-        event_type: config.type,
-        agent_id: agentId,
-        enabled,
-        title_template: titleTemplate,
-        description_template: descriptionTemplate,
-        dispatch_provider: dispatchProvider || undefined,
-        dispatch_daemon_id: dispatchDaemonId || undefined,
-      });
-      await onUpdated();
-      toast.success(`${config.label} rule saved`);
-      setExpanded(false);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to save");
-    } finally {
-      setSaving(false);
-    }
+  const addDraft = () => {
+    setDrafts((d) => [...d, { id: `draft-${Date.now()}-${Math.random().toString(36).slice(2, 6)}` }]);
+    setExpanded(true);
   };
 
-  const handleDelete = async () => {
-    if (!rule) return;
-    setSaving(true);
-    try {
-      await api.deleteGitHubEventRule(workspaceId, rule.id);
-      await onUpdated();
-      setExpanded(false);
-      setEnabled(false);
-      setAgentId("");
-      toast.success(`${config.label} rule removed`);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to delete");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const agentName = (id: string) => agents.find((a) => a.id === id)?.name ?? "Unknown";
-  const daemonName = (id: string) => {
-    const d = daemons.find((dm) => dm.id === id);
-    return d?.device_name || d?.daemon_id || "Unknown";
+  const removeDraft = (id: string) => {
+    setDrafts((d) => d.filter((x) => x.id !== id));
   };
 
   return (
@@ -266,9 +241,12 @@ function EventTypeCard({
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium">{config.label}</span>
-              {rule?.enabled && (
-                <Badge variant="outline" className="text-xs">
-                  {agentName(rule.agent_id)}
+              {summaryLabel && (
+                <Badge variant="outline" className="text-xs">{summaryLabel}</Badge>
+              )}
+              {overrideRules.length > 0 && (
+                <Badge variant="secondary" className="text-xs">
+                  {overrideRules.length} repo override{overrideRules.length === 1 ? "" : "s"}
                 </Badge>
               )}
             </div>
@@ -276,86 +254,59 @@ function EventTypeCard({
           </div>
 
           <Switch
-            checked={rule ? enabled : enabled}
-            onCheckedChange={handleToggle}
+            checked={defaultRule?.enabled ?? false}
+            onCheckedChange={handleToggleDefault}
             disabled={saving}
           />
         </div>
 
         {expanded && (
-          <div className="border-t px-4 py-3 space-y-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">Agent</Label>
-              <Select value={agentId} onValueChange={(v) => { if (v) setAgentId(v); }}>
-                <SelectTrigger className="h-8 text-xs">
-                  <SelectValue placeholder="Select agent..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {activeAgents.map((a) => (
-                    <SelectItem key={a.id} value={a.id}>
-                      {a.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+          <div className="border-t px-4 py-3 space-y-4">
+            <RuleEditor
+              key={defaultRule?.id ?? "default-new"}
+              variant="default"
+              eventConfig={config}
+              rule={defaultRule}
+              agents={agents}
+              daemons={daemons}
+              workspaceId={workspaceId}
+              onUpdated={onUpdated}
+            />
 
-            <div className="space-y-1.5">
-              <Label className="text-xs">Environment</Label>
-              <Select
-                value={dispatchDaemonId || "__auto__"}
-                onValueChange={(v) => setDispatchDaemonId(v === "__auto__" ? "" : v ?? "")}
-              >
-                <SelectTrigger className="h-8 text-xs">
-                  <SelectValue placeholder="Auto (agent default)" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__auto__">Auto (agent default)</SelectItem>
-                  {daemons.filter((d) => !d.archived_at).map((d) => (
-                    <SelectItem key={d.id} value={d.id}>
-                      {daemonName(d.id)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label className="text-xs">
-                Issue Title Template
-                <span className="text-muted-foreground ml-1">(leave empty for default)</span>
-              </Label>
-              <Input
-                className="h-8 text-xs"
-                placeholder={config.defaultTitle}
-                value={titleTemplate}
-                onChange={(e) => setTitleTemplate(e.target.value)}
+            {overrideRules.map((rule) => (
+              <RuleEditor
+                key={rule.id}
+                variant="override"
+                eventConfig={config}
+                rule={rule}
+                agents={agents}
+                daemons={daemons}
+                workspaceId={workspaceId}
+                onUpdated={onUpdated}
               />
-            </div>
+            ))}
 
-            <div className="space-y-1.5">
-              <Label className="text-xs">
-                Issue Description Template
-                <span className="text-muted-foreground ml-1">(leave empty for auto-generated)</span>
-              </Label>
-              <Textarea
-                className="text-xs min-h-[60px]"
-                placeholder="{{.body}}"
-                value={descriptionTemplate}
-                onChange={(e) => setDescriptionTemplate(e.target.value)}
+            {drafts.map((draft) => (
+              <RuleEditor
+                key={draft.id}
+                variant="override"
+                eventConfig={config}
+                rule={null}
+                agents={agents}
+                daemons={daemons}
+                workspaceId={workspaceId}
+                onUpdated={async () => {
+                  removeDraft(draft.id);
+                  await onUpdated();
+                }}
+                onCancel={() => removeDraft(draft.id)}
               />
-            </div>
+            ))}
 
-            <div className="flex items-center justify-between pt-1">
-              <div>
-                {rule && (
-                  <Button variant="ghost" size="sm" className="text-destructive text-xs" onClick={handleDelete} disabled={saving}>
-                    Remove
-                  </Button>
-                )}
-              </div>
-              <Button size="sm" className="text-xs" onClick={handleSave} disabled={saving || !agentId}>
-                {saving ? "Saving..." : "Save"}
+            <div>
+              <Button variant="outline" size="sm" className="text-xs" onClick={addDraft}>
+                <Plus className="h-3.5 w-3.5 mr-1" />
+                Add per-repo override
               </Button>
             </div>
           </div>
@@ -363,4 +314,239 @@ function EventTypeCard({
       </CardContent>
     </Card>
   );
+}
+
+function RuleEditor({
+  variant,
+  eventConfig,
+  rule,
+  agents,
+  daemons,
+  workspaceId,
+  onUpdated,
+  onCancel,
+}: {
+  variant: "default" | "override";
+  eventConfig: EventTypeConfig;
+  rule: GitHubEventRule | null;
+  agents: Agent[];
+  daemons: Daemon[];
+  workspaceId: string;
+  onUpdated: () => Promise<void>;
+  onCancel?: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [repoFullName, setRepoFullName] = useState(rule?.repo_full_name ?? "");
+  const [agentId, setAgentId] = useState(rule?.agent_id ?? "");
+  const [enabled, setEnabled] = useState(rule?.enabled ?? true);
+  const [titleTemplate, setTitleTemplate] = useState(rule?.title_template ?? "");
+  const [descriptionTemplate, setDescriptionTemplate] = useState(rule?.description_template ?? "");
+  const [dispatchDaemonId, setDispatchDaemonId] = useState(rule?.dispatch_daemon_id ?? "");
+  const [dispatchProvider, setDispatchProvider] = useState(rule?.dispatch_provider ?? "");
+
+  useEffect(() => {
+    setRepoFullName(rule?.repo_full_name ?? "");
+    setAgentId(rule?.agent_id ?? "");
+    setEnabled(rule?.enabled ?? true);
+    setTitleTemplate(rule?.title_template ?? "");
+    setDescriptionTemplate(rule?.description_template ?? "");
+    setDispatchDaemonId(rule?.dispatch_daemon_id ?? "");
+    setDispatchProvider(rule?.dispatch_provider ?? "");
+  }, [rule]);
+
+  const activeAgents = agents.filter((a) => !a.archived_at);
+  const isOverride = variant === "override";
+  const isExisting = rule !== null;
+
+  const handleSave = async () => {
+    if (!agentId) {
+      toast.error("Please select an agent");
+      return;
+    }
+    if (isOverride) {
+      const trimmed = repoFullName.trim();
+      if (!trimmed) {
+        toast.error("Repository is required for per-repo overrides");
+        return;
+      }
+      if (!REPO_PATTERN.test(trimmed)) {
+        toast.error("Repository must be in 'owner/repo' format");
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      await api.upsertGitHubEventRule(workspaceId, {
+        event_type: eventConfig.type,
+        repo_full_name: isOverride ? repoFullName.trim() : "",
+        agent_id: agentId,
+        enabled,
+        title_template: titleTemplate,
+        description_template: descriptionTemplate,
+        dispatch_provider: dispatchProvider || undefined,
+        dispatch_daemon_id: dispatchDaemonId || undefined,
+      });
+      await onUpdated();
+      toast.success(
+        isOverride
+          ? `Override for ${repoFullName.trim()} saved`
+          : `${eventConfig.label} default saved`,
+      );
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!rule) {
+      onCancel?.();
+      return;
+    }
+    setSaving(true);
+    try {
+      await api.deleteGitHubEventRule(workspaceId, rule.id);
+      await onUpdated();
+      toast.success(
+        isOverride
+          ? `Override for ${rule.repo_full_name} removed`
+          : `${eventConfig.label} default removed`,
+      );
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const daemonName = (id: string) => {
+    const d = daemons.find((dm) => dm.id === id);
+    return d?.device_name || d?.daemon_id || "Unknown";
+  };
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge variant={isOverride ? "secondary" : "outline"} className="text-xs">
+            {isOverride ? (rule?.repo_full_name || "New override") : "Workspace default"}
+          </Badge>
+          {!isOverride && !isExisting && (
+            <span className="text-xs text-muted-foreground">Not configured yet</span>
+          )}
+        </div>
+        {isOverride && (
+          <div className="flex items-center gap-2">
+            <Label className="text-xs text-muted-foreground">Enabled</Label>
+            <Switch checked={enabled} onCheckedChange={setEnabled} disabled={saving} />
+          </div>
+        )}
+      </div>
+
+      {isOverride && (
+        <div className="space-y-1.5">
+          <Label className="text-xs">Repository</Label>
+          <Input
+            className="h-8 text-xs font-mono"
+            placeholder="owner/repo"
+            value={repoFullName}
+            onChange={(e) => setRepoFullName(e.target.value)}
+            disabled={saving || isExisting}
+          />
+          {isExisting && (
+            <p className="text-[11px] text-muted-foreground">
+              Repository name cannot be changed. Remove this override and add a new one to retarget.
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Agent</Label>
+        <Select value={agentId} onValueChange={(v) => { if (v) setAgentId(v); }}>
+          <SelectTrigger className="h-8 text-xs">
+            <SelectValue placeholder="Select agent..." />
+          </SelectTrigger>
+          <SelectContent>
+            {activeAgents.map((a) => (
+              <SelectItem key={a.id} value={a.id}>
+                {a.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Environment</Label>
+        <Select
+          value={dispatchDaemonId || "__auto__"}
+          onValueChange={(v) => setDispatchDaemonId(v === "__auto__" ? "" : v ?? "")}
+        >
+          <SelectTrigger className="h-8 text-xs">
+            <SelectValue placeholder="Auto (agent default)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__auto__">Auto (agent default)</SelectItem>
+            {daemons.filter((d) => !d.archived_at).map((d) => (
+              <SelectItem key={d.id} value={d.id}>
+                {daemonName(d.id)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">
+          Issue Title Template
+          <span className="text-muted-foreground ml-1">(leave empty for default)</span>
+        </Label>
+        <Input
+          className="h-8 text-xs"
+          placeholder={eventConfig.defaultTitle}
+          value={titleTemplate}
+          onChange={(e) => setTitleTemplate(e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">
+          Issue Description Template
+          <span className="text-muted-foreground ml-1">(leave empty for auto-generated)</span>
+        </Label>
+        <Textarea
+          className="text-xs min-h-[60px]"
+          placeholder="{{.body}}"
+          value={descriptionTemplate}
+          onChange={(e) => setDescriptionTemplate(e.target.value)}
+        />
+      </div>
+
+      <div className="flex items-center justify-between pt-1">
+        <div>
+          {(isExisting || onCancel) && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-destructive text-xs"
+              onClick={handleDelete}
+              disabled={saving}
+            >
+              {isExisting ? "Remove" : "Cancel"}
+            </Button>
+          )}
+        </div>
+        <Button size="sm" className="text-xs" onClick={handleSave} disabled={saving || !agentId}>
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function agentName(agents: Agent[], id: string) {
+  return agents.find((a) => a.id === id)?.name ?? "Unknown";
 }

--- a/apps/web/shared/types/github-event.ts
+++ b/apps/web/shared/types/github-event.ts
@@ -4,6 +4,12 @@ export interface GitHubEventRule {
   id: string;
   workspace_id: string;
   event_type: GitHubEventType;
+  /**
+   * Repository this rule applies to in "owner/repo" form. Empty string means
+   * the rule is the workspace-wide default for the event type and is used as
+   * a fallback when no per-repo rule matches.
+   */
+  repo_full_name: string;
   agent_id: string;
   enabled: boolean;
   title_template: string;
@@ -17,6 +23,8 @@ export interface GitHubEventRule {
 
 export interface UpsertGitHubEventRuleRequest {
   event_type: GitHubEventType;
+  /** Empty / omitted = workspace-default rule for the event type. */
+  repo_full_name?: string;
   agent_id: string;
   enabled?: boolean;
   title_template?: string;

--- a/server/internal/handler/github_event.go
+++ b/server/internal/handler/github_event.go
@@ -53,6 +53,9 @@ func (h *Handler) ReceiveGitHubEvent(w http.ResponseWriter, r *http.Request) {
 		Installation struct {
 			ID int64 `json:"id"`
 		} `json:"installation"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON payload")
@@ -75,9 +78,14 @@ func (h *Handler) ReceiveGitHubEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve the most-specific rule for this (workspace, event_type, repo).
+	// Returns the per-repo rule if one exists, otherwise the workspace-default
+	// rule (repo_full_name = ''). If neither exists or the matched rule is
+	// disabled, the event is silently dropped.
 	rule, err := h.Queries.GetGitHubEventRule(r.Context(), db.GetGitHubEventRuleParams{
-		WorkspaceID: ws.ID,
-		EventType:   eventType,
+		WorkspaceID:  ws.ID,
+		EventType:    eventType,
+		RepoFullName: envelope.Repository.FullName,
 	})
 	if err != nil || !rule.Enabled {
 		w.WriteHeader(http.StatusOK)
@@ -421,6 +429,7 @@ type GitHubEventRuleResponse struct {
 	ID                  string  `json:"id"`
 	WorkspaceID         string  `json:"workspace_id"`
 	EventType           string  `json:"event_type"`
+	RepoFullName        string  `json:"repo_full_name"`
 	AgentID             string  `json:"agent_id"`
 	Enabled             bool    `json:"enabled"`
 	TitleTemplate       string  `json:"title_template"`
@@ -437,6 +446,7 @@ func githubEventRuleToResponse(r db.GithubEventRule) GitHubEventRuleResponse {
 		ID:                  uuidToString(r.ID),
 		WorkspaceID:         uuidToString(r.WorkspaceID),
 		EventType:           r.EventType,
+		RepoFullName:        r.RepoFullName,
 		AgentID:             uuidToString(r.AgentID),
 		Enabled:             r.Enabled,
 		TitleTemplate:       r.TitleTemplate,
@@ -466,6 +476,7 @@ func (h *Handler) ListGitHubEventRules(w http.ResponseWriter, r *http.Request) {
 
 type UpsertGitHubEventRuleRequest struct {
 	EventType           string  `json:"event_type"`
+	RepoFullName        string  `json:"repo_full_name"`
 	AgentID             string  `json:"agent_id"`
 	Enabled             *bool   `json:"enabled"`
 	TitleTemplate       string  `json:"title_template"`
@@ -480,6 +491,32 @@ var validGitHubEventTypes = map[string]bool{
 	"pull_request":  true,
 	"issues":        true,
 	"issue_comment": true,
+}
+
+// isValidRepoFullName checks the GitHub "owner/repo" format. Both segments
+// must be non-empty and contain only characters GitHub allows in a name
+// (alphanumerics, hyphen, underscore, and dot).
+func isValidRepoFullName(s string) bool {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+		for _, r := range p {
+			switch {
+			case r >= 'a' && r <= 'z':
+			case r >= 'A' && r <= 'Z':
+			case r >= '0' && r <= '9':
+			case r == '-' || r == '_' || r == '.':
+			default:
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (h *Handler) UpsertGitHubEventRule(w http.ResponseWriter, r *http.Request) {
@@ -499,6 +536,12 @@ func (h *Handler) UpsertGitHubEventRule(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	repoFullName := strings.TrimSpace(req.RepoFullName)
+	if repoFullName != "" && !isValidRepoFullName(repoFullName) {
+		writeError(w, http.StatusBadRequest, "repo_full_name must be in 'owner/repo' format")
+		return
+	}
+
 	enabled := true
 	if req.Enabled != nil {
 		enabled = *req.Enabled
@@ -507,6 +550,7 @@ func (h *Handler) UpsertGitHubEventRule(w http.ResponseWriter, r *http.Request) 
 	params := db.UpsertGitHubEventRuleParams{
 		WorkspaceID:         parseUUID(workspaceID),
 		EventType:           req.EventType,
+		RepoFullName:        repoFullName,
 		AgentID:             parseUUID(req.AgentID),
 		Enabled:             enabled,
 		TitleTemplate:       req.TitleTemplate,

--- a/server/internal/handler/github_event_test.go
+++ b/server/internal/handler/github_event_test.go
@@ -1,8 +1,11 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+
+	db "github.com/nullne/multica/server/pkg/db/generated"
 )
 
 func TestIsRelevantAction(t *testing.T) {
@@ -236,5 +239,165 @@ func assertField(t *testing.T, data map[string]string, key, want string) {
 	}
 	if got != want {
 		t.Errorf("data[%q] = %q, want %q", key, got, want)
+	}
+}
+
+func TestIsValidRepoFullName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"owner/repo", true},
+		{"my-org/my-repo", true},
+		{"foo.bar/baz_qux-1", true},
+		{"a/b", true},
+		{"", false},
+		{"owner", false},
+		{"owner/", false},
+		{"/repo", false},
+		{"owner/repo/extra", false},
+		{"owner/re po", false},
+		{"owner repo", false},
+		{"owner/re$po", false},
+	}
+	for _, tc := range cases {
+		if got := isValidRepoFullName(tc.in); got != tc.want {
+			t.Errorf("isValidRepoFullName(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestGitHubEventRulePerRepoLookup verifies that GetGitHubEventRule prefers
+// an exact repo match and falls back to the workspace-default rule
+// (repo_full_name = '') when no per-repo rule exists. Requires the test
+// database fixture from TestMain.
+func TestGitHubEventRulePerRepoLookup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+
+	ctx := context.Background()
+	q := testHandler.Queries
+
+	var agentIDStr string
+	err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentIDStr)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+	agentID := parseUUID(agentIDStr)
+	wsID := parseUUID(testWorkspaceID)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM github_event_rule WHERE workspace_id = $1`, testWorkspaceID)
+	})
+
+	defaultRule, err := q.UpsertGitHubEventRule(ctx, db.UpsertGitHubEventRuleParams{
+		WorkspaceID:   wsID,
+		EventType:     "pull_request",
+		RepoFullName:  "",
+		AgentID:       agentID,
+		Enabled:       true,
+		TitleTemplate: "default-title",
+	})
+	if err != nil {
+		t.Fatalf("upsert default rule: %v", err)
+	}
+
+	overrideRule, err := q.UpsertGitHubEventRule(ctx, db.UpsertGitHubEventRuleParams{
+		WorkspaceID:   wsID,
+		EventType:     "pull_request",
+		RepoFullName:  "acme/widgets",
+		AgentID:       agentID,
+		Enabled:       true,
+		TitleTemplate: "override-title",
+	})
+	if err != nil {
+		t.Fatalf("upsert override rule: %v", err)
+	}
+
+	matched, err := q.GetGitHubEventRule(ctx, db.GetGitHubEventRuleParams{
+		WorkspaceID:  wsID,
+		EventType:    "pull_request",
+		RepoFullName: "acme/widgets",
+	})
+	if err != nil {
+		t.Fatalf("lookup matching repo: %v", err)
+	}
+	if matched.ID != overrideRule.ID {
+		t.Fatalf("expected override rule for matching repo")
+	}
+	if matched.TitleTemplate != "override-title" {
+		t.Fatalf("expected override title, got %q", matched.TitleTemplate)
+	}
+
+	fallback, err := q.GetGitHubEventRule(ctx, db.GetGitHubEventRuleParams{
+		WorkspaceID:  wsID,
+		EventType:    "pull_request",
+		RepoFullName: "other/repo",
+	})
+	if err != nil {
+		t.Fatalf("lookup unmatched repo: %v", err)
+	}
+	if fallback.ID != defaultRule.ID {
+		t.Fatalf("expected default rule for unmatched repo")
+	}
+	if fallback.TitleTemplate != "default-title" {
+		t.Fatalf("expected default title, got %q", fallback.TitleTemplate)
+	}
+
+	if err := q.DeleteGitHubEventRule(ctx, defaultRule.ID); err != nil {
+		t.Fatalf("delete default rule: %v", err)
+	}
+
+	matched2, err := q.GetGitHubEventRule(ctx, db.GetGitHubEventRuleParams{
+		WorkspaceID:  wsID,
+		EventType:    "pull_request",
+		RepoFullName: "acme/widgets",
+	})
+	if err != nil {
+		t.Fatalf("lookup matching repo after default removed: %v", err)
+	}
+	if matched2.ID != overrideRule.ID {
+		t.Fatalf("expected override rule still matches its repo")
+	}
+
+	if _, err := q.GetGitHubEventRule(ctx, db.GetGitHubEventRuleParams{
+		WorkspaceID:  wsID,
+		EventType:    "pull_request",
+		RepoFullName: "other/repo",
+	}); err == nil {
+		t.Fatalf("expected no-rows error for unmatched repo with no default")
+	}
+
+	rules, err := q.ListGitHubEventRules(ctx, wsID)
+	if err != nil {
+		t.Fatalf("list rules: %v", err)
+	}
+	if len(rules) != 1 || rules[0].ID != overrideRule.ID {
+		t.Fatalf("unexpected list result after delete: %+v", rules)
+	}
+
+	if _, err := q.UpsertGitHubEventRule(ctx, db.UpsertGitHubEventRuleParams{
+		WorkspaceID:   wsID,
+		EventType:     "pull_request",
+		RepoFullName:  "",
+		AgentID:       agentID,
+		Enabled:       true,
+		TitleTemplate: "default-title",
+	}); err != nil {
+		t.Fatalf("re-insert default: %v", err)
+	}
+	rules, err = q.ListGitHubEventRules(ctx, wsID)
+	if err != nil {
+		t.Fatalf("list rules: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+	if rules[0].RepoFullName != "" || rules[1].RepoFullName != "acme/widgets" {
+		t.Fatalf("unexpected list ordering: %q then %q", rules[0].RepoFullName, rules[1].RepoFullName)
 	}
 }

--- a/server/migrations/049_github_event_rule_repo.down.sql
+++ b/server/migrations/049_github_event_rule_repo.down.sql
@@ -1,0 +1,27 @@
+DROP INDEX IF EXISTS idx_github_event_rule_lookup;
+
+-- Collapse multi-repo rules back to a single (workspace_id, event_type) row.
+-- Keep the workspace-default rule (repo_full_name = '') if present, otherwise
+-- the lexicographically first repo-specific rule.
+DELETE FROM github_event_rule g
+USING (
+    SELECT id FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                   PARTITION BY workspace_id, event_type
+                   ORDER BY (repo_full_name = '') DESC, repo_full_name ASC, created_at ASC
+               ) AS rn
+        FROM github_event_rule
+    ) t
+    WHERE rn > 1
+) dup
+WHERE g.id = dup.id;
+
+ALTER TABLE github_event_rule
+    DROP CONSTRAINT github_event_rule_workspace_event_repo_key;
+
+ALTER TABLE github_event_rule
+    ADD CONSTRAINT github_event_rule_workspace_id_event_type_key
+    UNIQUE (workspace_id, event_type);
+
+ALTER TABLE github_event_rule DROP COLUMN repo_full_name;

--- a/server/migrations/049_github_event_rule_repo.up.sql
+++ b/server/migrations/049_github_event_rule_repo.up.sql
@@ -1,0 +1,15 @@
+-- Add per-repository scoping to GitHub event rules.
+-- A rule with repo_full_name = '' is a workspace-wide default for the event type.
+-- A rule with a specific "owner/repo" overrides the default for that repo.
+ALTER TABLE github_event_rule
+    ADD COLUMN repo_full_name TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE github_event_rule
+    DROP CONSTRAINT github_event_rule_workspace_id_event_type_key;
+
+ALTER TABLE github_event_rule
+    ADD CONSTRAINT github_event_rule_workspace_event_repo_key
+    UNIQUE (workspace_id, event_type, repo_full_name);
+
+CREATE INDEX idx_github_event_rule_lookup
+    ON github_event_rule(workspace_id, event_type, repo_full_name);

--- a/server/pkg/db/generated/github_event.sql.go
+++ b/server/pkg/db/generated/github_event.sql.go
@@ -21,16 +21,25 @@ func (q *Queries) DeleteGitHubEventRule(ctx context.Context, id pgtype.UUID) err
 }
 
 const getGitHubEventRule = `-- name: GetGitHubEventRule :one
-SELECT id, workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, created_at, updated_at FROM github_event_rule WHERE workspace_id = $1 AND event_type = $2
+SELECT id, workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, created_at, updated_at, repo_full_name FROM github_event_rule
+WHERE workspace_id = $1
+  AND event_type = $2
+  AND repo_full_name IN ($3, '')
+ORDER BY (repo_full_name = '') ASC
+LIMIT 1
 `
 
 type GetGitHubEventRuleParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	EventType   string      `json:"event_type"`
+	WorkspaceID  pgtype.UUID `json:"workspace_id"`
+	EventType    string      `json:"event_type"`
+	RepoFullName string      `json:"repo_full_name"`
 }
 
+// Returns the most-specific enabled rule for the given event:
+//  1. Exact match on (workspace_id, event_type, repo_full_name).
+//  2. Falls back to the workspace-default rule (repo_full_name = ”).
 func (q *Queries) GetGitHubEventRule(ctx context.Context, arg GetGitHubEventRuleParams) (GithubEventRule, error) {
-	row := q.db.QueryRow(ctx, getGitHubEventRule, arg.WorkspaceID, arg.EventType)
+	row := q.db.QueryRow(ctx, getGitHubEventRule, arg.WorkspaceID, arg.EventType, arg.RepoFullName)
 	var i GithubEventRule
 	err := row.Scan(
 		&i.ID,
@@ -45,6 +54,7 @@ func (q *Queries) GetGitHubEventRule(ctx context.Context, arg GetGitHubEventRule
 		&i.DispatchDaemonLabel,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.RepoFullName,
 	)
 	return i, err
 }
@@ -74,7 +84,9 @@ func (q *Queries) GetWorkspaceByInstallationID(ctx context.Context, githubInstal
 }
 
 const listGitHubEventRules = `-- name: ListGitHubEventRules :many
-SELECT id, workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, created_at, updated_at FROM github_event_rule WHERE workspace_id = $1 ORDER BY event_type ASC
+SELECT id, workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, created_at, updated_at, repo_full_name FROM github_event_rule
+WHERE workspace_id = $1
+ORDER BY event_type ASC, repo_full_name ASC
 `
 
 func (q *Queries) ListGitHubEventRules(ctx context.Context, workspaceID pgtype.UUID) ([]GithubEventRule, error) {
@@ -99,6 +111,7 @@ func (q *Queries) ListGitHubEventRules(ctx context.Context, workspaceID pgtype.U
 			&i.DispatchDaemonLabel,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.RepoFullName,
 		); err != nil {
 			return nil, err
 		}
@@ -111,9 +124,9 @@ func (q *Queries) ListGitHubEventRules(ctx context.Context, workspaceID pgtype.U
 }
 
 const upsertGitHubEventRule = `-- name: UpsertGitHubEventRule :one
-INSERT INTO github_event_rule (workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (workspace_id, event_type) DO UPDATE SET
+INSERT INTO github_event_rule (workspace_id, event_type, repo_full_name, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (workspace_id, event_type, repo_full_name) DO UPDATE SET
     agent_id = EXCLUDED.agent_id,
     enabled = EXCLUDED.enabled,
     title_template = EXCLUDED.title_template,
@@ -122,12 +135,13 @@ ON CONFLICT (workspace_id, event_type) DO UPDATE SET
     dispatch_daemon_id = EXCLUDED.dispatch_daemon_id,
     dispatch_daemon_label = EXCLUDED.dispatch_daemon_label,
     updated_at = now()
-RETURNING id, workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, created_at, updated_at
+RETURNING id, workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, created_at, updated_at, repo_full_name
 `
 
 type UpsertGitHubEventRuleParams struct {
 	WorkspaceID         pgtype.UUID `json:"workspace_id"`
 	EventType           string      `json:"event_type"`
+	RepoFullName        string      `json:"repo_full_name"`
 	AgentID             pgtype.UUID `json:"agent_id"`
 	Enabled             bool        `json:"enabled"`
 	TitleTemplate       string      `json:"title_template"`
@@ -141,6 +155,7 @@ func (q *Queries) UpsertGitHubEventRule(ctx context.Context, arg UpsertGitHubEve
 	row := q.db.QueryRow(ctx, upsertGitHubEventRule,
 		arg.WorkspaceID,
 		arg.EventType,
+		arg.RepoFullName,
 		arg.AgentID,
 		arg.Enabled,
 		arg.TitleTemplate,
@@ -163,6 +178,7 @@ func (q *Queries) UpsertGitHubEventRule(ctx context.Context, arg UpsertGitHubEve
 		&i.DispatchDaemonLabel,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.RepoFullName,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -168,6 +168,7 @@ type GithubEventRule struct {
 	DispatchDaemonLabel pgtype.Text        `json:"dispatch_daemon_label"`
 	CreatedAt           pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	RepoFullName        string             `json:"repo_full_name"`
 }
 
 type InboxItem struct {

--- a/server/pkg/db/queries/github_event.sql
+++ b/server/pkg/db/queries/github_event.sql
@@ -2,15 +2,25 @@
 SELECT * FROM workspace WHERE github_installation_id = $1;
 
 -- name: GetGitHubEventRule :one
-SELECT * FROM github_event_rule WHERE workspace_id = $1 AND event_type = $2;
+-- Returns the most-specific enabled rule for the given event:
+--   1. Exact match on (workspace_id, event_type, repo_full_name).
+--   2. Falls back to the workspace-default rule (repo_full_name = '').
+SELECT * FROM github_event_rule
+WHERE workspace_id = $1
+  AND event_type = $2
+  AND repo_full_name IN ($3, '')
+ORDER BY (repo_full_name = '') ASC
+LIMIT 1;
 
 -- name: ListGitHubEventRules :many
-SELECT * FROM github_event_rule WHERE workspace_id = $1 ORDER BY event_type ASC;
+SELECT * FROM github_event_rule
+WHERE workspace_id = $1
+ORDER BY event_type ASC, repo_full_name ASC;
 
 -- name: UpsertGitHubEventRule :one
-INSERT INTO github_event_rule (workspace_id, event_type, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label)
-VALUES ($1, $2, $3, $4, $5, $6, sqlc.narg(dispatch_provider), sqlc.narg(dispatch_daemon_id), sqlc.narg(dispatch_daemon_label))
-ON CONFLICT (workspace_id, event_type) DO UPDATE SET
+INSERT INTO github_event_rule (workspace_id, event_type, repo_full_name, agent_id, enabled, title_template, description_template, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label)
+VALUES ($1, $2, $3, $4, $5, $6, $7, sqlc.narg(dispatch_provider), sqlc.narg(dispatch_daemon_id), sqlc.narg(dispatch_daemon_label))
+ON CONFLICT (workspace_id, event_type, repo_full_name) DO UPDATE SET
     agent_id = EXCLUDED.agent_id,
     enabled = EXCLUDED.enabled,
     title_template = EXCLUDED.title_template,


### PR DESCRIPTION
## Summary

Today every \`github_event_rule\` is keyed only by \`(workspace_id, event_type)\`, so a single \`pull_request\` rule fires for every repo the GitHub App can see. This PR adds a \`repo_full_name\` dimension so each event type can have a workspace-wide default plus per-repo overrides.

- New migration \`049\` adds \`repo_full_name TEXT NOT NULL DEFAULT ''\` to \`github_event_rule\` and replaces the unique constraint with \`(workspace_id, event_type, repo_full_name)\` (plus a lookup index).
- \`GetGitHubEventRule\` resolves the rule in a single query: exact \`owner/repo\` match preferred, falls back to the workspace default (\`repo_full_name = ''\`). If neither exists or the matched rule is disabled, the event is dropped silently as before.
- \`ReceiveGitHubEvent\` parses \`repository.full_name\` from the webhook envelope and passes it into the lookup.
- \`UpsertGitHubEventRule\` accepts \`repo_full_name\` (validated as GitHub's \`owner/repo\` charset). \`GET\` / \`PUT\` / \`LIST\` responses include the field. \`DELETE\` is unchanged.
- Settings UI: each event type now lists the workspace default plus optional per-repo overrides; each card has its own enable toggle, agent / environment / templates, and a save / remove control. \"Add per-repo override\" creates a draft form for a new \`owner/repo\`.

## Test plan

- \`make test-go\` (Docker) — passes; new \`TestIsValidRepoFullName\` and \`TestGitHubEventRulePerRepoLookup\` cover the validator and the exact-match-with-fallback semantics.
- \`make typecheck\` + \`make test-ts\` (Docker) — pass.
- Manual smoke: existing webhooks keep working because rules created before the migration retain \`repo_full_name = ''\` (the workspace default).

Made with [Cursor](https://cursor.com)