### PR TITLE
fix(deploy): resolve nginx upstreams at runtime via docker DNS

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,10 +1,8 @@
-upstream frontend {
-    server frontend:3000;
-}
-
-upstream backend {
-    server backend:8080;
-}
+# Use Docker's embedded DNS so backend/frontend hostnames are re-resolved at
+# runtime. Without this, nginx caches upstream IPs at startup and starts
+# returning 502 whenever the backend/frontend container is recreated and gets a
+# new IP (which happens on every image update).
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 server {
     listen 80;
@@ -12,9 +10,13 @@ server {
 
     client_max_body_size 50m;
 
+    # Upstream targets resolved per request via the resolver above.
+    set $backend_upstream  http://backend:8080;
+    set $frontend_upstream http://frontend:3000;
+
     # API and auth — route directly to Go backend
     location /api/ {
-        proxy_pass http://backend;
+        proxy_pass $backend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -22,7 +24,7 @@ server {
     }
 
     location /auth/ {
-        proxy_pass http://backend;
+        proxy_pass $backend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -31,12 +33,12 @@ server {
 
     # Health check
     location = /health {
-        proxy_pass http://backend;
+        proxy_pass $backend_upstream;
     }
 
     # WebSocket — direct to backend with upgrade support
     location /ws {
-        proxy_pass http://backend;
+        proxy_pass $backend_upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -50,7 +52,7 @@ server {
 
     # Everything else — Next.js frontend
     location / {
-        proxy_pass http://frontend;
+        proxy_pass $frontend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

Fixes the production 502 storm seen after deploying `v0.2.22`.

`deploy/nginx.conf` previously declared upstreams as:

```nginx
upstream backend  { server backend:8080; }
upstream frontend { server frontend:3000; }
```

nginx resolves these hostnames **once at startup** and caches the IP. When `docker compose up -d` recreates the `backend` container with a new image (which happens on every release), it gets a new container IP but the nginx container is not recreated, so nginx keeps proxying to the old IP. Every request then fails with:

```
connect() failed (111: Connection refused) while connecting to upstream
upstream: "http://172.20.0.3:8080/..."  -> 502
```

That's exactly what we observed in the v0.2.22 deploy logs — backend was Healthy and serving on `:8080`, but nginx still pointed at the previous container's IP, so the deploy's `/health` curl looped 30 times and the workflow failed. Production has been stuck in 502 since.

## Fix

Switch to docker's embedded DNS resolver (`127.0.0.11`) and put the upstream URL in a variable. Whenever `proxy_pass` references a variable, nginx resolves the name **at request time** through the configured `resolver`, so backend/frontend container restarts no longer poison the cache.

```nginx
resolver 127.0.0.11 valid=10s ipv6=off;

set $backend_upstream  http://backend:8080;
set $frontend_upstream http://frontend:3000;

location /api/ { proxy_pass $backend_upstream;  ... }
location /     { proxy_pass $frontend_upstream; ... }
```

No changes to `docker-compose.prod.yml` or `deploy.yml` required — once nginx picks up this config, future deploys are robust to container recreation without an explicit reload step.

## Restoring production now

This PR alone won't unstick prod, because the nginx config is bind-mounted and the running nginx container hasn't reloaded. After merging + deploying, also run on the prod host:

```bash
docker compose -f docker-compose.prod.yml --env-file .env.prod restart nginx
# or, equivalently:
docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
```

(For the immediate outage, the same `restart nginx` already restores service even without this PR — this PR just prevents it happening again on the next release.)

## Test plan

- [ ] Merge and tag a new release
- [ ] Confirm deploy workflow's `/health` check passes
- [ ] On prod host, `docker compose ... restart nginx` to pick up the new config
- [ ] Recreate backend container manually (`docker compose ... up -d --force-recreate backend`) and confirm nginx still serves /api/* without 502

Made with [Cursor](https://cursor.com)