### PR TITLE
fix(web): constrain dashboard layout to viewport height

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -41,9 +41,9 @@ export default function DashboardLayout({
   if (!user) return null;
 
   return (
-    <SidebarProvider className="min-h-dvh">
+    <SidebarProvider className="h-dvh overflow-hidden">
       <AppSidebar />
-      <SidebarInset className="overflow-hidden">
+      <SidebarInset className="overflow-hidden min-h-0">
         {/* Mobile sidebar trigger — fixed at bottom-left */}
         <SidebarTrigger className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-[max(1rem,env(safe-area-inset-left))] z-50 h-10 w-10 rounded-full bg-primary text-primary-foreground shadow-lg md:hidden" />
         {workspace ? (

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo, memo } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, memo } from "react";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -547,6 +547,19 @@ export function IssueDetail({ issueId, onDelete, onBack, defaultSidebarOpen = tr
   } = useIssueSubscribers(id, user?.id);
 
   const loading = issueLoading;
+
+  // Reset internal scroll to top whenever the displayed issue changes.
+  // The scroll container belongs to IssueDetail itself; when this component
+  // is reused (or React's natural mount/remount doesn't reset the inner
+  // scrollTop reliably — e.g. when nested inside another resizable panel
+  // group like the Inbox), we must explicitly snap back to the top so the
+  // user always lands on the issue title rather than a stale scroll
+  // position. The highlight-comment effect below runs after timeline data
+  // loads and will smoothly scroll past this reset when applicable.
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (container) container.scrollTop = 0;
+  }, [id]);
 
   // Scroll to highlighted comment once timeline loads
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fix Inbox split-view scrolling: clicking a notification used to reset the **whole document** scroll to the top of the issue detail, forcing you to scroll back to find your place in the list. Root cause was that the entire dashboard tree was never bounded to the viewport.

`SidebarProvider` only set `min-h-dvh`, so any page whose content exceeded the viewport (Inbox with many notifications, long Issues list, etc.) caused `SidebarInset` and every descendant to grow past the viewport. All the intended `flex-1 min-h-0 overflow-y-auto` scroll containers became no-ops because their "remaining space" was unbounded — actual scrolling fell through to the document.

### Fix

- `SidebarProvider` → `h-dvh overflow-hidden` (pin to viewport)
- `SidebarInset` → add `min-h-0` so children's `flex-1 min-h-0` works
- `IssueDetail` → add `useLayoutEffect` to snap its inner scroll container to the top whenever the displayed issue changes, so notification clicks always land on the issue title. The existing highlight-comment effect still smoothly scrolls past this when applicable.

### Behavior after fix (verified end-to-end with Playwright)

| Action | List scrollTop | Detail scrollTop | Document scrollTop |
|---|---|---|---|
| Initial load | 0 | — | 0 ✓ (viewport-bound) |
| Manually scroll list to middle | **1132** | — | 0 |
| Click a notification | **1132** (preserved) | 0 (snaps to top) | 0 |
| Comment notification, after timeline loads | **1132** | scrolled to highlighted comment ✓ | 0 |
| Click another notification | unchanged | 0 (snaps to top) | 0 |

This fix also benefits other dashboard pages (Issues list, Settings, etc.) — their `flex-1 min-h-0 overflow-y-auto` containers now scroll independently as intended instead of falling back to a document-level scroll.

## Test plan

- [x] Inbox: list scroll position preserved when clicking any item (top, middle, bottom)
- [x] Inbox: detail panel auto-scrolls to top on issue switch
- [x] Inbox: comment notifications still scroll to the highlighted comment
- [x] No `<html>` / `<body>` scroll on dashboard pages (entire UI fits viewport)
- [ ] Spot-check Issues list, Board, Settings, Agents, Daemons pages on desktop + mobile after merge


Made with [Cursor](https://cursor.com)