### PR TITLE
fix(agent): capture exec command from Codex approval request

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -71,6 +71,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		cfg:                  b.cfg,
 		stdin:                stdin,
 		pending:              make(map[int]*pendingRPC),
+		pendingCommands:      make(map[string]string),
 		notificationProtocol: "unknown",
 		onMessage: func(msg Message) {
 			if msg.Type == MessageText {
@@ -247,6 +248,10 @@ type codexClient struct {
 	notificationProtocol string // "unknown", "legacy", "raw"
 	turnStarted          bool
 	completedTurnIDs     map[string]bool
+	// pendingCommands maps itemId → command string captured from
+	// item/commandExecution/requestApproval, which is the only place
+	// Codex includes the raw command text in the raw v2 protocol.
+	pendingCommands map[string]string
 }
 
 type pendingRPC struct {
@@ -396,7 +401,23 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 
 	// Auto-approve all exec/patch requests in daemon mode
 	switch method {
-	case "item/commandExecution/requestApproval", "execCommandApproval":
+	case "item/commandExecution/requestApproval":
+		// The raw v2 protocol only includes the command text in the approval
+		// request params, not in the subsequent item/started notification.
+		// Capture it here so we can attach it to the tool_use message later.
+		var params map[string]any
+		if p, ok := raw["params"]; ok {
+			_ = json.Unmarshal(p, &params)
+		}
+		if itemID, _ := params["itemId"].(string); itemID != "" {
+			if command, _ := params["command"].(string); command != "" {
+				c.mu.Lock()
+				c.pendingCommands[itemID] = command
+				c.mu.Unlock()
+			}
+		}
+		c.respond(id, map[string]any{"decision": "accept"})
+	case "execCommandApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/fileChange/requestApproval", "applyPatchApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
@@ -565,7 +586,15 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 
 	switch {
 	case method == "item/started" && itemType == "commandExecution":
-		command, _ := item["command"].(string)
+		// Prefer the command captured from the approval request; fall back to
+		// item["command"] for any Codex versions that do include it directly.
+		c.mu.Lock()
+		command := c.pendingCommands[itemID]
+		delete(c.pendingCommands, itemID)
+		c.mu.Unlock()
+		if command == "" {
+			command, _ = item["command"].(string)
+		}
 		if c.onMessage != nil {
 			c.onMessage(Message{
 				Type:   MessageToolUse,

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -15,9 +15,10 @@ func newTestCodexClient(t *testing.T) (*codexClient, *fakeStdin, []Message) {
 	var messages []Message
 
 	c := &codexClient{
-		cfg:     Config{Logger: slog.Default()},
-		stdin:   fs,
-		pending: make(map[int]*pendingRPC),
+		cfg:             Config{Logger: slog.Default()},
+		stdin:           fs,
+		pending:         make(map[int]*pendingRPC),
+		pendingCommands: make(map[string]string),
 		onMessage: func(msg Message) {
 			mu.Lock()
 			messages = append(messages, msg)
@@ -352,7 +353,7 @@ func TestCodexRawTurnCompletedAborted(t *testing.T) {
 func TestCodexRawItemCommandExecution(t *testing.T) {
 	t.Parallel()
 
-	c, _, _ := newTestCodexClient(t)
+	c, stdin, _ := newTestCodexClient(t)
 	c.notificationProtocol = "raw"
 
 	var messages []Message
@@ -360,7 +361,15 @@ func TestCodexRawItemCommandExecution(t *testing.T) {
 		messages = append(messages, msg)
 	}
 
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/started","params":{"item":{"type":"commandExecution","id":"item-1","command":"git status"}}}`)
+	// Real Codex raw protocol: approval request arrives first with the command
+	// text; item/started only carries the item id and type, not the command.
+	c.handleLine(`{"jsonrpc":"2.0","id":1,"method":"item/commandExecution/requestApproval","params":{"itemId":"item-1","command":"git status","workingDirectory":"/repo"}}`)
+	// Verify an accept response was written to stdin.
+	if lines := stdin.Lines(); len(lines) == 0 {
+		t.Fatal("expected accept response on stdin")
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/started","params":{"item":{"type":"commandExecution","id":"item-1"}}}`)
 	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"commandExecution","id":"item-1","aggregatedOutput":"on branch main"}}}`)
 
 	if len(messages) != 2 {
@@ -371,6 +380,30 @@ func TestCodexRawItemCommandExecution(t *testing.T) {
 	}
 	if messages[1].Type != MessageToolResult || messages[1].Output != "on branch main" {
 		t.Fatalf("unexpected complete message: %+v", messages[1])
+	}
+}
+
+// TestCodexRawItemCommandExecutionFallback verifies that if item/started
+// includes the command field directly (older Codex versions), it still works.
+func TestCodexRawItemCommandExecutionFallback(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	var messages []Message
+	c.onMessage = func(msg Message) {
+		messages = append(messages, msg)
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/started","params":{"item":{"type":"commandExecution","id":"item-2","command":"ls -la"}}}`)
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"commandExecution","id":"item-2","aggregatedOutput":"total 0"}}}`)
+
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if messages[0].Input["command"] != "ls -la" {
+		t.Fatalf("unexpected command: %+v", messages[0])
 	}
 }
 


### PR DESCRIPTION
The Codex raw v2 protocol only includes the command text in the item/commandExecution/requestApproval server request params. The subsequent item/started notification contains only the item id and type, not the command string. The code was reading item["command"] from item/started which always returned an empty string, causing all exec_command tool_use messages in execution history to have an empty command field.

Fix by storing the command from the approval request params (keyed by itemId) and consuming it when item/started fires. Falls back to item["command"] for any Codex versions that do include it directly.