### PR TITLE
fix(github): grant write agents pull_requests=write to enable PR crea…

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -153,9 +153,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 			b.WriteString("Do not attempt to push commits or merge pull requests. ")
 			b.WriteString("You can create issues and comment on issues/PRs.\n\n")
 		case "write":
-			b.WriteString("You can push branches to repositories. ")
-			b.WriteString("You **cannot** open, merge, or close pull requests — your installation token does not carry pull_request write access. ")
-			b.WriteString("After pushing, ask a human reviewer or an admin agent to open the PR.\n\n")
+			b.WriteString("You can push branches and create pull requests. ")
+			b.WriteString("You **MUST NOT** merge or close pull requests — merging is reserved for admin agents after review.\n\n")
 		case "admin":
 			b.WriteString("You have full access: push code, create pull requests, and merge them.\n\n")
 		}

--- a/server/internal/github/permissions.go
+++ b/server/internal/github/permissions.go
@@ -15,12 +15,6 @@ const (
 
 // basePermissions returns the permissions every agent token receives
 // regardless of code access level.
-//
-// Note: pull_requests defaults to read here. Only the admin tier upgrades
-// it to write in PermissionsForCodeAccess. GitHub bundles PR
-// create/update/merge/close under a single "write" permission, so giving
-// the write tier pull_requests=write would also let it merge — see
-// PermissionsForCodeAccess for the full matrix.
 func basePermissions() map[string]string {
 	return map[string]string{
 		"issues":        PermWrite,
@@ -38,13 +32,13 @@ func basePermissions() map[string]string {
 //
 //	level   contents  pull_requests  issues  checks  statuses  metadata
 //	read    read      read           write   read    read      read
-//	write   write     read           write   read    read      read
+//	write   write     write          write   read    read      read
 //	admin   write     write          write   read    read      read
 //
 // pull_requests=write covers PR create / update / merge / close at the
-// GitHub API level; it is intentionally restricted to admin so that
-// read/write agents cannot merge or close PRs even by calling the API
-// directly with their installation token.
+// GitHub API level. Both write and admin agents receive this permission so
+// they can open PRs. Merge is further restricted to admin-only via
+// MergeAllowed() as a server-side guard.
 func PermissionsForCodeAccess(level string) map[string]string {
 	perms := basePermissions()
 	switch level {
@@ -52,6 +46,7 @@ func PermissionsForCodeAccess(level string) map[string]string {
 		perms["contents"] = PermRead
 	case CodeAccessWrite:
 		perms["contents"] = PermWrite
+		perms["pull_requests"] = PermWrite
 	case CodeAccessAdmin:
 		perms["contents"] = PermWrite
 		perms["pull_requests"] = PermWrite

--- a/server/internal/github/permissions_test.go
+++ b/server/internal/github/permissions_test.go
@@ -3,8 +3,7 @@ package github
 import "testing"
 
 // TestPermissionsForCodeAccess_Matrix asserts the full permission matrix
-// for every supported code access level. See PermissionsForCodeAccess for
-// the rationale; pull_requests=write is intentionally admin-only.
+// for every supported code access level.
 func TestPermissionsForCodeAccess_Matrix(t *testing.T) {
 	cases := []struct {
 		level string
@@ -25,7 +24,7 @@ func TestPermissionsForCodeAccess_Matrix(t *testing.T) {
 			level: CodeAccessWrite,
 			want: map[string]string{
 				"contents":      PermWrite,
-				"pull_requests": PermRead,
+				"pull_requests": PermWrite,
 				"issues":        PermWrite,
 				"checks":        PermRead,
 				"statuses":      PermRead,


### PR DESCRIPTION
…tion

Dev and Debuger agents (write level) were getting pull_requests=read, blocking automated PR creation with "Resource not accessible by integration". Merge is still restricted to admin via MergeAllowed().