### PR TITLE
test(execenv): update GitHubCodeAccess write level assertions to matc…

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -906,12 +906,12 @@ func TestInjectRuntimeConfig_GitHubCodeAccess(t *testing.T) {
 		{
 			level:    "write",
 			contains: []string{"push branches", "create pull requests", "MUST NOT"},
-			absent:   []string{"full access"},
+			absent:   []string{"full access", "cannot"},
 		},
 		{
 			level:    "admin",
 			contains: []string{"full access", "merge"},
-			absent:   []string{"read-only", "cannot"},
+			absent:   []string{"read-only", "cannot", "MUST NOT"},
 		},
 	}
 


### PR DESCRIPTION
…h new wording

The write case in runtime_config.go was updated in #67 to say "MUST NOT" instead of "cannot", but the test was not updated in sync, causing CI failure.