### PR TITLE
fix(daemon): use task GitHub token for repo checkout, fail hard on fetch errors

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -37,6 +37,7 @@ type Daemon struct {
 	workspaces      map[string]*workspaceState
 	runtimeIndex    map[string]Runtime            // runtimeID -> Runtime for provider lookups
 	taskBranches    map[string]string             // taskID -> latest checked out branch
+	taskTokens      map[string]string             // taskID -> GitHub installation token (cleared on task end)
 	providerConfigs map[string]ProviderConfig     // provider -> workspace-level config (API keys, etc.)
 	reloading       sync.Mutex                    // prevents concurrent reloadWorkspaces
 
@@ -57,6 +58,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		workspaces:      make(map[string]*workspaceState),
 		runtimeIndex:    make(map[string]Runtime),
 		taskBranches:    make(map[string]string),
+		taskTokens:      make(map[string]string),
 		providerConfigs: make(map[string]ProviderConfig),
 	}
 }
@@ -209,13 +211,6 @@ func (d *Daemon) loadWatchedWorkspaces(ctx context.Context) error {
 			d.runtimeIndex[rt.ID] = rt
 		}
 		d.mu.Unlock()
-
-		// Sync workspace repos to local cache.
-		if d.repoCache != nil && len(resp.Repos) > 0 {
-			if err := d.repoCache.Sync(ws.ID, repoDataToInfo(resp.Repos)); err != nil {
-				d.logger.Warn("repo cache sync failed", "workspace_id", ws.ID, "error", err)
-			}
-		}
 
 		d.logger.Info("watching workspace", "workspace_id", ws.ID, "name", ws.Name, "runtimes", len(resp.Runtimes), "repos", len(resp.Repos))
 	}
@@ -667,13 +662,6 @@ func (d *Daemon) reloadWorkspaces(ctx context.Context) {
 				d.runtimeIndex[rt.ID] = rt
 			}
 			d.mu.Unlock()
-
-			// Sync workspace repos to local cache.
-			if d.repoCache != nil && len(resp.Repos) > 0 {
-				if err := d.repoCache.Sync(id, repoDataToInfo(resp.Repos)); err != nil {
-					d.logger.Warn("repo cache sync failed", "workspace_id", id, "error", err)
-				}
-			}
 
 			d.logger.Info("now watching workspace", "workspace_id", id, "name", name)
 		}
@@ -1135,6 +1123,13 @@ func (d *Daemon) pollLoop(ctx context.Context) error {
 func (d *Daemon) handleTask(ctx context.Context, task Task) {
 	defer d.clearTaskBranch(task.ID)
 
+	// Make the task's GitHub token discoverable by the daemon's own git
+	// operations (e.g. /repo/checkout) for the duration of this task. The
+	// token never leaves the daemon process — agents and the CLI just send
+	// task_id, and the daemon looks the token up internally.
+	d.rememberTaskToken(task.ID, task.GitHubToken)
+	defer d.clearTaskToken(task.ID)
+
 	d.mu.Lock()
 	rt := d.runtimeIndex[task.RuntimeID]
 	d.mu.Unlock()
@@ -1531,15 +1526,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		}
 		return TaskResult{Status: "blocked", Comment: errMsg}, nil
 	}
-}
-
-// repoDataToInfo converts daemon RepoData to repocache RepoInfo.
-func repoDataToInfo(repos []RepoData) []repocache.RepoInfo {
-	info := make([]repocache.RepoInfo, len(repos))
-	for i, r := range repos {
-		info[i] = repocache.RepoInfo{URL: r.URL, Description: r.Description}
-	}
-	return info
 }
 
 func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -115,6 +115,7 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 			WorkDir:     req.WorkDir,
 			AgentName:   req.AgentName,
 			TaskID:      req.TaskID,
+			Token:       d.lookupTaskToken(req.TaskID),
 		})
 		if err != nil {
 			d.logger.Error("repo checkout failed", "url", req.URL, "error", err)

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -1,5 +1,9 @@
 // Package repocache manages bare git clone caches for workspace repositories.
 // The daemon uses these caches as the source for creating per-task worktrees.
+//
+// All cache population is lazy: the bare clone for a repo is created the first
+// time a task asks to check it out (CreateWorktree), using the GitHub token
+// scoped to that task. Subsequent tasks reuse the cache and only fetch.
 package repocache
 
 import (
@@ -15,19 +19,6 @@ import (
 	"time"
 )
 
-// RepoInfo describes a repository to cache.
-type RepoInfo struct {
-	URL         string
-	Description string
-}
-
-// CachedRepo describes a cached bare clone ready for worktree creation.
-type CachedRepo struct {
-	URL         string // remote URL
-	Description string // human-readable description
-	LocalPath   string // absolute path to the bare clone
-}
-
 // Cache manages bare git clones for workspace repositories.
 type Cache struct {
 	root   string // base directory for all caches (e.g. ~/multica_workspaces/.repos)
@@ -40,69 +31,20 @@ func New(root string, logger *slog.Logger) *Cache {
 	return &Cache{root: root, logger: logger}
 }
 
-// Sync ensures all repos for a workspace are cloned (or fetched if already cached).
-// Repos no longer in the list are left in place (cheap to keep, avoids re-cloning
-// if a repo is temporarily removed and re-added).
-func (c *Cache) Sync(workspaceID string, repos []RepoInfo) error {
-	return c.SyncWithToken(workspaceID, repos, "")
-}
-
-// SyncWithToken is like Sync but uses the given GitHub token for authentication.
-func (c *Cache) SyncWithToken(workspaceID string, repos []RepoInfo, token string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	wsDir := filepath.Join(c.root, workspaceID)
-	if err := os.MkdirAll(wsDir, 0o755); err != nil {
-		return fmt.Errorf("create workspace cache dir: %w", err)
-	}
-
-	var firstErr error
-	for _, repo := range repos {
-		if repo.URL == "" {
-			continue
-		}
-		barePath := filepath.Join(wsDir, bareDirName(repo.URL))
-
-		if isBareRepo(barePath) {
-			c.logger.Info("repo cache: fetching", "url", repo.URL, "path", barePath)
-			if err := gitFetchWithToken(barePath, token); err != nil {
-				c.logger.Warn("repo cache: fetch failed", "url", repo.URL, "error", err)
-				if firstErr == nil {
-					firstErr = err
-				}
-			}
-		} else {
-			c.logger.Info("repo cache: cloning", "url", repo.URL, "path", barePath)
-			if err := gitCloneBareWithToken(repo.URL, barePath, token); err != nil {
-				c.logger.Error("repo cache: clone failed", "url", repo.URL, "error", err)
-				if firstErr == nil {
-					firstErr = err
-				}
-			}
-		}
-	}
-	return firstErr
-}
-
 // Lookup returns the local bare clone path for a repo URL within a workspace.
 // Returns "" if not cached.
 func (c *Cache) Lookup(workspaceID, url string) string {
-	barePath := filepath.Join(c.root, workspaceID, bareDirName(url))
+	barePath := c.barePathFor(workspaceID, url)
 	if isBareRepo(barePath) {
 		return barePath
 	}
 	return ""
 }
 
-// Fetch runs `git fetch origin` on a cached bare clone to get latest refs.
-func (c *Cache) Fetch(barePath string) error {
-	return gitFetch(barePath)
-}
-
-// FetchWithToken runs `git fetch origin` with a GitHub token for auth.
-func (c *Cache) FetchWithToken(barePath, token string) error {
-	return gitFetchWithToken(barePath, token)
+// barePathFor computes the on-disk path where a repo's bare clone would live.
+// It does not check whether the clone actually exists.
+func (c *Cache) barePathFor(workspaceID, url string) string {
+	return filepath.Join(c.root, workspaceID, bareDirName(url))
 }
 
 // bareDirName derives a directory name from a repo URL.
@@ -136,10 +78,6 @@ func isBareRepo(path string) bool {
 	return err == nil
 }
 
-func gitCloneBare(url, dest string) error {
-	return gitCloneBareWithToken(url, dest, "")
-}
-
 func gitCloneBareWithToken(url, dest, token string) error {
 	args := []string{"clone", "--bare"}
 	if token != "" {
@@ -161,10 +99,6 @@ func gitCloneBareWithToken(url, dest, token string) error {
 		return fmt.Errorf("configure fetch refspec: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
-}
-
-func gitFetch(barePath string) error {
-	return gitFetchWithToken(barePath, "")
 }
 
 func gitFetchWithToken(barePath, token string) error {
@@ -197,6 +131,7 @@ type WorktreeParams struct {
 	WorkDir     string // parent directory for the worktree (e.g. task workdir)
 	AgentName   string // for branch naming
 	TaskID      string // for branch naming uniqueness
+	Token       string // GitHub installation token (optional; required for private repos)
 }
 
 // WorktreeResult describes a successfully created worktree.
@@ -205,18 +140,19 @@ type WorktreeResult struct {
 	BranchName string `json:"branch_name"` // git branch created for this worktree
 }
 
-// CreateWorktree looks up the bare cache for a repo, fetches latest, and creates
-// a git worktree in the agent's working directory.
+// CreateWorktree ensures the bare cache for a repo is present and up-to-date,
+// then creates a git worktree in the agent's working directory.
+//
+// If the bare cache does not exist yet, it is cloned on the spot using
+// params.Token. If the cache already exists, a fetch is performed first to
+// pick up new commits. A fetch failure is treated as a hard error — we never
+// fall back to stale cache state, because the resulting worktree (and any PR
+// derived from it) would silently be based on outdated code.
 func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
-	barePath := c.Lookup(params.WorkspaceID, params.RepoURL)
-	if barePath == "" {
-		return nil, fmt.Errorf("repo not found in cache: %s (workspace: %s)", params.RepoURL, params.WorkspaceID)
+	if err := c.ensureBareCache(params.WorkspaceID, params.RepoURL, params.Token); err != nil {
+		return nil, err
 	}
-
-	// Fetch latest from origin.
-	if err := gitFetch(barePath); err != nil {
-		c.logger.Warn("repo checkout: fetch failed (continuing with cached state)", "url", params.RepoURL, "error", err)
-	}
+	barePath := c.barePathFor(params.WorkspaceID, params.RepoURL)
 
 	// Determine the default branch to base the worktree on.
 	baseRef := getRemoteDefaultBranch(barePath)
@@ -249,6 +185,36 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		Path:       worktreePath,
 		BranchName: branchName,
 	}, nil
+}
+
+// ensureBareCache makes sure a bare clone for (workspaceID, url) exists and is
+// up to date. The mutex serializes lazy clones / fetches across concurrent
+// CreateWorktree calls so two tasks racing on the same repo do not corrupt
+// each other's git state.
+func (c *Cache) ensureBareCache(workspaceID, url, token string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	wsDir := filepath.Join(c.root, workspaceID)
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		return fmt.Errorf("create workspace cache dir: %w", err)
+	}
+
+	barePath := filepath.Join(wsDir, bareDirName(url))
+
+	if !isBareRepo(barePath) {
+		c.logger.Info("repo cache: cloning", "url", url, "path", barePath, "with_token", token != "")
+		if err := gitCloneBareWithToken(url, barePath, token); err != nil {
+			return fmt.Errorf("clone bare cache: %w", err)
+		}
+		return nil
+	}
+
+	c.logger.Info("repo cache: fetching", "url", url, "path", barePath, "with_token", token != "")
+	if err := gitFetchWithToken(barePath, token); err != nil {
+		return fmt.Errorf("fetch latest: %w", err)
+	}
+	return nil
 }
 
 // createWorktree creates a git worktree at the given path with a new branch.

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -36,14 +36,12 @@ func TestBareDirName(t *testing.T) {
 func TestIsBareRepo(t *testing.T) {
 	t.Parallel()
 
-	// A directory with a HEAD file should be detected as bare.
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644)
 	if !isBareRepo(dir) {
 		t.Error("expected bare repo to be detected")
 	}
 
-	// An empty directory should not.
 	emptyDir := t.TempDir()
 	if isBareRepo(emptyDir) {
 		t.Error("expected empty dir to not be detected as bare repo")
@@ -70,86 +68,6 @@ func createTestRepo(t *testing.T) string {
 	return dir
 }
 
-func TestSyncAndLookup(t *testing.T) {
-	t.Parallel()
-	sourceRepo := createTestRepo(t)
-	cacheRoot := t.TempDir()
-
-	cache := New(cacheRoot, testLogger())
-
-	// Sync should clone the repo.
-	err := cache.Sync("ws-123", []RepoInfo{
-		{URL: sourceRepo, Description: "test repo"},
-	})
-	if err != nil {
-		t.Fatalf("Sync failed: %v", err)
-	}
-
-	// Lookup should find the cached repo.
-	path := cache.Lookup("ws-123", sourceRepo)
-	if path == "" {
-		t.Fatal("expected to find cached repo")
-	}
-	if !isBareRepo(path) {
-		t.Fatalf("expected bare repo at %s", path)
-	}
-
-	// Lookup for unknown URL should return empty.
-	if got := cache.Lookup("ws-123", "https://github.com/org/unknown"); got != "" {
-		t.Fatalf("expected empty for unknown URL, got %q", got)
-	}
-
-	// Lookup for unknown workspace should return empty.
-	if got := cache.Lookup("ws-999", sourceRepo); got != "" {
-		t.Fatalf("expected empty for unknown workspace, got %q", got)
-	}
-}
-
-func TestSyncFetchesExisting(t *testing.T) {
-	t.Parallel()
-	sourceRepo := createTestRepo(t)
-	cacheRoot := t.TempDir()
-
-	cache := New(cacheRoot, testLogger())
-
-	// First sync: clone.
-	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
-		t.Fatalf("first sync failed: %v", err)
-	}
-
-	// Record the HEAD commit hash in the cache.
-	barePath := cache.Lookup("ws-1", sourceRepo)
-	oldHead := gitHead(t, barePath)
-
-	// Add a commit to source.
-	cmd := exec.Command("git", "-C", sourceRepo, "commit", "--allow-empty", "-m", "second")
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
-	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("add commit failed: %s: %v", out, err)
-	}
-	sourceHead := gitHead(t, sourceRepo)
-	if sourceHead == oldHead {
-		t.Fatal("source HEAD should differ after new commit")
-	}
-
-	// Second sync: should fetch (not re-clone).
-	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
-		t.Fatalf("second sync failed: %v", err)
-	}
-
-	// Verify the cache HEAD was updated.
-	newHead := gitHead(t, barePath)
-	if newHead == oldHead {
-		t.Fatal("expected cache HEAD to be updated after fetch")
-	}
-	if newHead != sourceHead {
-		t.Fatalf("expected cache HEAD %s to match source HEAD %s", newHead, sourceHead)
-	}
-}
-
 func gitHead(t *testing.T, repoPath string) string {
 	t.Helper()
 	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD")
@@ -160,49 +78,13 @@ func gitHead(t *testing.T, repoPath string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func TestWorktreeFromCache(t *testing.T) {
-	t.Parallel()
-	sourceRepo := createTestRepo(t)
-	cacheRoot := t.TempDir()
-
-	cache := New(cacheRoot, testLogger())
-	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
-		t.Fatalf("sync failed: %v", err)
-	}
-
-	barePath := cache.Lookup("ws-1", sourceRepo)
-	if barePath == "" {
-		t.Fatal("expected cached repo")
-	}
-
-	// Create a worktree from the bare cache — this is the actual use case.
-	worktreeDir := filepath.Join(t.TempDir(), "work")
-	cmd := exec.Command("git", "-C", barePath, "worktree", "add", "-b", "test-branch", worktreeDir, "HEAD")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("worktree add failed: %s: %v", out, err)
-	}
-	defer exec.Command("git", "-C", barePath, "worktree", "remove", "--force", worktreeDir).Run()
-
-	// Verify worktree exists and is on the right branch.
-	cmd = exec.Command("git", "-C", worktreeDir, "branch", "--show-current")
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("show branch failed: %v", err)
-	}
-	if got := trimLine(string(out)); got != "test-branch" {
-		t.Fatalf("expected branch 'test-branch', got %q", got)
-	}
-}
-
+// TestCreateWorktree exercises the happy path: bare cache does not exist, so
+// CreateWorktree lazily clones, then materializes a worktree on the agent
+// branch.
 func TestCreateWorktree(t *testing.T) {
 	t.Parallel()
 	sourceRepo := createTestRepo(t)
-	cacheRoot := t.TempDir()
-
-	cache := New(cacheRoot, testLogger())
-	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
-		t.Fatalf("sync failed: %v", err)
-	}
+	cache := New(t.TempDir(), testLogger())
 
 	workDir := t.TempDir()
 	result, err := cache.CreateWorktree(WorktreeParams{
@@ -216,17 +98,14 @@ func TestCreateWorktree(t *testing.T) {
 		t.Fatalf("CreateWorktree failed: %v", err)
 	}
 
-	// Verify the worktree was created.
 	if _, err := os.Stat(result.Path); os.IsNotExist(err) {
 		t.Fatalf("worktree path does not exist: %s", result.Path)
 	}
 
-	// Verify branch name format.
 	if !strings.HasPrefix(result.BranchName, "agent/code-reviewer/") {
 		t.Errorf("expected branch to start with 'agent/code-reviewer/', got %q", result.BranchName)
 	}
 
-	// Verify the worktree is on the correct branch.
 	cmd := exec.Command("git", "-C", result.Path, "branch", "--show-current")
 	out, err := cmd.Output()
 	if err != nil {
@@ -237,26 +116,162 @@ func TestCreateWorktree(t *testing.T) {
 	}
 }
 
-func TestCreateWorktreeNotCached(t *testing.T) {
+// TestCreateWorktreeLazyClonePopulatesCache verifies the bare cache is
+// populated as a side effect of the first CreateWorktree call (no separate
+// sync step needed).
+func TestCreateWorktreeLazyClonePopulatesCache(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cache := New(t.TempDir(), testLogger())
+
+	if got := cache.Lookup("ws-1", sourceRepo); got != "" {
+		t.Fatalf("expected empty cache before first checkout, got %q", got)
+	}
+
+	if _, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		AgentName:   "agent",
+		TaskID:      "task-1",
+	}); err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	barePath := cache.Lookup("ws-1", sourceRepo)
+	if barePath == "" {
+		t.Fatal("expected cache to be populated after lazy clone")
+	}
+	if !isBareRepo(barePath) {
+		t.Fatalf("expected bare repo at %s", barePath)
+	}
+}
+
+// TestCreateWorktreeFetchesLatest verifies that a second CreateWorktree call
+// picks up new commits from origin (i.e. CreateWorktree fetches before
+// branching, not just on first clone).
+func TestCreateWorktreeFetchesLatest(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cache := New(t.TempDir(), testLogger())
+
+	if _, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		AgentName:   "agent",
+		TaskID:      "task-1",
+	}); err != nil {
+		t.Fatalf("first CreateWorktree failed: %v", err)
+	}
+
+	barePath := cache.Lookup("ws-1", sourceRepo)
+	oldHead := gitHead(t, barePath)
+
+	// Add a new commit to the source.
+	cmd := exec.Command("git", "-C", sourceRepo, "commit", "--allow-empty", "-m", "second")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("add commit failed: %s: %v", out, err)
+	}
+	sourceHead := gitHead(t, sourceRepo)
+	if sourceHead == oldHead {
+		t.Fatal("source HEAD should differ after new commit")
+	}
+
+	// Second CreateWorktree should fetch the new commit.
+	if _, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		AgentName:   "agent",
+		TaskID:      "task-2",
+	}); err != nil {
+		t.Fatalf("second CreateWorktree failed: %v", err)
+	}
+
+	newHead := gitHead(t, barePath)
+	if newHead != sourceHead {
+		t.Fatalf("expected cache HEAD %s to match source HEAD %s after fetch", newHead, sourceHead)
+	}
+}
+
+// TestCreateWorktreeFetchFailureHardErrors is the key regression guard for
+// this fix: when fetch fails (origin gone, network error, bad token, ...),
+// CreateWorktree must NOT silently fall back to the stale cached state and
+// produce a worktree based on outdated code. It must return an error and not
+// leave a worktree behind.
+func TestCreateWorktreeFetchFailureHardErrors(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cache := New(t.TempDir(), testLogger())
+
+	if _, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		AgentName:   "agent",
+		TaskID:      "task-1",
+	}); err != nil {
+		t.Fatalf("initial CreateWorktree failed: %v", err)
+	}
+
+	// Make origin unreachable.
+	if err := os.RemoveAll(sourceRepo); err != nil {
+		t.Fatalf("remove source repo failed: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     workDir,
+		AgentName:   "agent",
+		TaskID:      "task-2",
+	})
+	if err == nil {
+		t.Fatalf("expected fetch failure to produce error, got worktree at %q", result.Path)
+	}
+	if !strings.Contains(err.Error(), "fetch") {
+		t.Errorf("expected fetch error, got: %v", err)
+	}
+
+	// No worktree should have been created.
+	entries, _ := os.ReadDir(workDir)
+	if len(entries) != 0 {
+		t.Errorf("expected empty workDir after fetch failure, got entries: %v", entries)
+	}
+}
+
+// TestCreateWorktreeLazyCloneFailure verifies that a non-existent source URL
+// fails the lazy clone with a clear error (and does not leave a half-baked
+// cache directory).
+func TestCreateWorktreeLazyCloneFailure(t *testing.T) {
 	t.Parallel()
 	cacheRoot := t.TempDir()
 	cache := New(cacheRoot, testLogger())
 
+	bogusURL := filepath.Join(t.TempDir(), "does-not-exist")
+
 	_, err := cache.CreateWorktree(WorktreeParams{
 		WorkspaceID: "ws-1",
-		RepoURL:     "https://github.com/org/nonexistent",
+		RepoURL:     bogusURL,
 		WorkDir:     t.TempDir(),
-		AgentName:   "Agent",
-		TaskID:      "test-task-id",
+		AgentName:   "agent",
+		TaskID:      "task-1",
 	})
 	if err == nil {
-		t.Fatal("expected error for uncached repo")
+		t.Fatal("expected error cloning a nonexistent repo")
 	}
-	if !strings.Contains(err.Error(), "not found in cache") {
-		t.Errorf("expected 'not found in cache' error, got: %v", err)
+	if !strings.Contains(err.Error(), "clone") {
+		t.Errorf("expected clone error, got: %v", err)
 	}
-}
 
-func trimLine(s string) string {
-	return strings.TrimSpace(s)
+	// The bare cache should not be left as a half-baked directory.
+	if got := cache.Lookup("ws-1", bogusURL); got != "" {
+		t.Errorf("expected no cache entry after failed clone, got %q", got)
+	}
 }

--- a/server/internal/daemon/task_tokens.go
+++ b/server/internal/daemon/task_tokens.go
@@ -1,0 +1,28 @@
+package daemon
+
+func (d *Daemon) rememberTaskToken(taskID, token string) {
+	if taskID == "" || token == "" {
+		return
+	}
+	d.mu.Lock()
+	d.taskTokens[taskID] = token
+	d.mu.Unlock()
+}
+
+func (d *Daemon) lookupTaskToken(taskID string) string {
+	if taskID == "" {
+		return ""
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.taskTokens[taskID]
+}
+
+func (d *Daemon) clearTaskToken(taskID string) {
+	if taskID == "" {
+		return
+	}
+	d.mu.Lock()
+	delete(d.taskTokens, taskID)
+	d.mu.Unlock()
+}

--- a/server/internal/daemon/task_tokens_test.go
+++ b/server/internal/daemon/task_tokens_test.go
@@ -1,0 +1,32 @@
+package daemon
+
+import "testing"
+
+func TestTaskTokenTracking(t *testing.T) {
+	t.Parallel()
+
+	d := &Daemon{taskTokens: make(map[string]string)}
+
+	d.rememberTaskToken("task-1", "ghs_secret123")
+	if got := d.lookupTaskToken("task-1"); got != "ghs_secret123" {
+		t.Fatalf("unexpected token: %q", got)
+	}
+
+	d.clearTaskToken("task-1")
+	if got := d.lookupTaskToken("task-1"); got != "" {
+		t.Fatalf("expected token to be cleared, got %q", got)
+	}
+
+	// Empty taskID and empty token should both be no-ops.
+	d.rememberTaskToken("", "ghs_other")
+	if got := d.lookupTaskToken(""); got != "" {
+		t.Fatalf("expected empty taskID lookup to return empty, got %q", got)
+	}
+
+	d.rememberTaskToken("task-2", "")
+	if got := d.lookupTaskToken("task-2"); got != "" {
+		t.Fatalf("expected empty token to be skipped, got %q", got)
+	}
+
+	d.clearTaskToken("") // should not panic
+}


### PR DESCRIPTION
## Summary

The daemon's repo cache was doing **anonymous** git fetch / clone, so private repos either never made it into the bare cache (startup `Sync` silently failed) or were stuck on stale commits (fetch silently failed and the worktree was created from cached refs anyway). Agents then opened PRs based on outdated code.

## Root cause

The server-side `claim task` flow already generates a GitHub installation token and ships it back to the daemon via `task.GitHubToken`. The daemon injects that token into the spawned **agent** process env (`GITHUB_TOKEN` / `GIT_ASKPASS`), so the agent's own ` git push` / `gh pr create` work fine.

But the chain `agent → multica repo checkout (CLI) → daemon /repo/checkout → repocache.CreateWorktree` never carried the token to the daemon's own git operations. Worse, `CreateWorktree` had a silent fallback:

```go
if err := gitFetch(barePath); err != nil {
    c.logger.Warn("repo checkout: fetch failed (continuing with cached state)", ...)
}
```

— so a failed fetch produced a worktree based on whatever stale commit happened to be cached. PRs ended up branched off old code.

## Changes

- **daemon: per-task token map.** New `taskTokens map[string]string` populated at `handleTask` entry, cleared on exit. Token never leaves the daemon process; the CLI / HTTP body only carry `task_id` (already do).
- **/repo/checkout handler** looks up the token by `task_id` and passes it into `WorktreeParams`.
- **repocache fully lazy.** `CreateWorktree` clones the bare cache on first checkout (using the task token) and fetches with the token on subsequent ones. A new `ensureBareCache` helper serializes concurrent same-repo checkouts under a mutex.
- **Fetch failure is now a hard error** — never fall back to stale cached state. Better to fail the task and retry than to silently base a PR on outdated code.
- **Removed dead code**: startup / heartbeat `repoCache.Sync` calls (always anonymous, useless for private repos), and the now-unused `Sync` / `SyncWithToken` / `RepoInfo` / `gitCloneBare` / `repoDataToInfo` APIs.

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Private repo first checkout | startup Sync silently fails → ` repo not found in cache` | lazy clone with task token → worktree |
| Private repo subsequent task | anonymous fetch fails silently → **stale worktree, PR on old code** | fetch with token → worktree on latest commit |
| token expiry / network failure | silently uses stale cache | hard error → task fails → retry |
| agent's own `git push` / `gh pr create` | works (env injection) | unchanged, still works |

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test-go` — all 23 packages pass
- [x] New regression test `TestCreateWorktreeFetchFailureHardErrors` guards against the silent stale-cache path coming back
- [x] New `TestCreateWorktreeLazyClonePopulatesCache` / `TestCreateWorktreeFetchesLatest` cover the lazy clone + refetch flow
- [x] New `TestTaskTokenTracking` covers the per-task token map
- [ ] Manual verification with a private workspace repo (suggested before merge): kick off a task assigned to an agent and confirm the resulting PR is branched off `main`'s latest commit, not a stale one

Made with [Cursor](https://cursor.com)