### PR TITLE
feat(server): support S3-compatible object storage (GCS, R2, MinIO)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,18 @@ NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 # S3 / CloudFront
 S3_BUCKET=
 S3_REGION=us-west-2
+# S3-compatible endpoint (leave empty for AWS S3).
+# GCS:  https://storage.googleapis.com   (use HMAC keys via AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+# R2:   https://<account>.r2.cloudflarestorage.com
+S3_ENDPOINT=
+# Path-style addressing. Defaults to true when S3_ENDPOINT is set
+# (required by GCS / MinIO), false for AWS S3.
+S3_USE_PATH_STYLE=
+# Optional explicit public URL prefix used for object URLs returned by Upload.
+# Defaults to CLOUDFRONT_DOMAIN, then to <S3_ENDPOINT>/<bucket>, then to
+# https://<bucket> (legacy AWS behavior).
+# Example for GCS: https://storage.googleapis.com/<bucket>
+S3_PUBLIC_URL_BASE=
 CLOUDFRONT_KEY_PAIR_ID=
 CLOUDFRONT_PRIVATE_KEY_SECRET=multica/cloudfront-signing-key
 CLOUDFRONT_PRIVATE_KEY=

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -107,16 +107,38 @@ server-side project ID and the public Firebase app settings used by the web UI.
 
 ### File Storage (Optional)
 
-For file uploads and attachments, configure S3 and CloudFront:
+For file uploads and attachments, configure an S3 (or S3-compatible) bucket.
+CloudFront-related variables only apply when fronting AWS S3 with CloudFront
+signed URLs/cookies; leave them empty for GCS, R2, MinIO, or a public bucket.
 
 | Variable | Description |
 |----------|-------------|
-| `S3_BUCKET` | S3 bucket name |
-| `S3_REGION` | AWS region (default: `us-west-2`) |
-| `CLOUDFRONT_DOMAIN` | CloudFront distribution domain |
-| `CLOUDFRONT_KEY_PAIR_ID` | CloudFront key pair ID for signed URLs |
-| `CLOUDFRONT_PRIVATE_KEY` | CloudFront private key (PEM format) |
-| `COOKIE_DOMAIN` | Domain for CloudFront auth cookies |
+| `S3_BUCKET` | Bucket name |
+| `S3_REGION` | Region (default: `us-west-2`) |
+| `S3_ENDPOINT` | S3-compatible API endpoint. Leave empty for AWS S3. |
+| `S3_USE_PATH_STYLE` | `true` / `false`. Defaults to `true` when `S3_ENDPOINT` is set, `false` otherwise. |
+| `S3_PUBLIC_URL_BASE` | Optional explicit prefix for public object URLs. Defaults to `CLOUDFRONT_DOMAIN`, then to `<S3_ENDPOINT>/<bucket>`, then to `https://<bucket>`. |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Credentials. For GCS use HMAC keys; for R2 use the R2 access key pair. |
+| `CLOUDFRONT_DOMAIN` | CloudFront distribution domain (AWS only) |
+| `CLOUDFRONT_KEY_PAIR_ID` | CloudFront key pair ID for signed URLs (AWS only) |
+| `CLOUDFRONT_PRIVATE_KEY` | CloudFront private key in PEM format (AWS only) |
+| `COOKIE_DOMAIN` | Domain for CloudFront auth cookies (AWS only) |
+
+**Google Cloud Storage via S3 compatibility**
+
+```bash
+S3_BUCKET=my-multica-bucket
+S3_REGION=auto
+S3_ENDPOINT=https://storage.googleapis.com
+S3_PUBLIC_URL_BASE=https://storage.googleapis.com/my-multica-bucket
+AWS_ACCESS_KEY_ID=<HMAC access key>
+AWS_SECRET_ACCESS_KEY=<HMAC secret>
+```
+
+Generate the HMAC key pair from the GCP console
+(IAM & Admin → Service Accounts → *service account* → Keys → HMAC keys) and
+make sure the bucket grants public read on uploaded objects if you want the
+returned URLs to be directly accessible.
 
 ### Server
 

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -16,9 +16,9 @@ import (
 )
 
 type S3Storage struct {
-	client    *s3.Client
-	bucket    string
-	cdnDomain string // if set, returned URLs use this instead of bucket name
+	client     *s3.Client
+	bucket     string
+	publicBase string // public URL prefix, always ends with "/"
 }
 
 // NewS3StorageFromEnv creates an S3Storage from environment variables.
@@ -27,7 +27,20 @@ type S3Storage struct {
 // Environment variables:
 //   - S3_BUCKET (required)
 //   - S3_REGION (default: us-west-2)
-//   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (optional; falls back to default credential chain)
+//   - S3_ENDPOINT (optional) — custom S3-compatible API endpoint
+//     (e.g. https://storage.googleapis.com for GCS,
+//     https://<account>.r2.cloudflarestorage.com for Cloudflare R2)
+//   - S3_USE_PATH_STYLE (optional) — "true"/"false". Defaults to true when
+//     S3_ENDPOINT is set (required by GCS / MinIO), false otherwise.
+//   - S3_PUBLIC_URL_BASE (optional) — explicit prefix used to build public
+//     URLs returned by Upload. Falls back to CLOUDFRONT_DOMAIN, then to a
+//     value derived from S3_ENDPOINT and the bucket name, then to the bucket
+//     name (legacy AWS behavior).
+//   - CLOUDFRONT_DOMAIN (optional) — used as the public URL host when
+//     S3_PUBLIC_URL_BASE is empty.
+//   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (optional; falls back to
+//     default credential chain). For GCS use HMAC keys; for R2 use the R2
+//     access key pair.
 func NewS3StorageFromEnv() *S3Storage {
 	bucket := os.Getenv("S3_BUCKET")
 	if bucket == "" {
@@ -58,14 +71,92 @@ func NewS3StorageFromEnv() *S3Storage {
 		return nil
 	}
 
-	cdnDomain := os.Getenv("CLOUDFRONT_DOMAIN")
+	endpoint := strings.TrimRight(os.Getenv("S3_ENDPOINT"), "/")
+	pathStyle := resolvePathStyle(endpoint, os.Getenv("S3_USE_PATH_STYLE"))
 
-	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+		o.UsePathStyle = pathStyle
+	})
+
+	publicBase := resolvePublicBase(
+		os.Getenv("S3_PUBLIC_URL_BASE"),
+		os.Getenv("CLOUDFRONT_DOMAIN"),
+		endpoint,
+		bucket,
+		pathStyle,
+	)
+
+	slog.Info("S3 storage initialized",
+		"bucket", bucket,
+		"region", region,
+		"endpoint", endpoint,
+		"path_style", pathStyle,
+		"public_base", publicBase,
+	)
 	return &S3Storage{
-		client:    s3.NewFromConfig(cfg),
-		bucket:    bucket,
-		cdnDomain: cdnDomain,
+		client:     client,
+		bucket:     bucket,
+		publicBase: publicBase,
 	}
+}
+
+// resolvePathStyle returns whether the S3 client should use path-style
+// addressing. When the user sets S3_USE_PATH_STYLE explicitly we honor it;
+// otherwise we default to true if a custom endpoint is configured (most
+// S3-compatible services require it) and false for AWS S3 itself.
+func resolvePathStyle(endpoint, raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	}
+	return endpoint != ""
+}
+
+// resolvePublicBase computes the URL prefix used to build object URLs.
+// The returned value always ends with "/" so callers can simply append the
+// object key.
+func resolvePublicBase(explicit, cdnDomain, endpoint, bucket string, pathStyle bool) string {
+	if explicit != "" {
+		return ensureTrailingSlash(explicit)
+	}
+	if cdnDomain != "" {
+		return ensureTrailingSlash("https://" + cdnDomain)
+	}
+	if endpoint != "" {
+		if pathStyle {
+			return ensureTrailingSlash(endpoint + "/" + bucket)
+		}
+		return ensureTrailingSlash(injectBucketIntoHost(endpoint, bucket))
+	}
+	return ensureTrailingSlash("https://" + bucket)
+}
+
+func ensureTrailingSlash(s string) string {
+	if strings.HasSuffix(s, "/") {
+		return s
+	}
+	return s + "/"
+}
+
+// injectBucketIntoHost rewrites "https://host[/path]" into
+// "https://bucket.host[/path]" for virtual-hosted addressing against a
+// custom endpoint.
+func injectBucketIntoHost(endpoint, bucket string) string {
+	scheme := "https://"
+	rest := endpoint
+	switch {
+	case strings.HasPrefix(rest, "https://"):
+		rest = strings.TrimPrefix(rest, "https://")
+	case strings.HasPrefix(rest, "http://"):
+		scheme = "http://"
+		rest = strings.TrimPrefix(rest, "http://")
+	}
+	return scheme + bucket + "." + rest
 }
 
 // sanitizeFilename removes characters that could cause header injection in Content-Disposition.
@@ -83,26 +174,20 @@ func sanitizeFilename(name string) string {
 	return b.String()
 }
 
-// KeyFromURL extracts the S3 object key from a CDN or bucket URL.
-// e.g. "https://multica-static.copilothub.ai/abc123.png" → "abc123.png"
+// KeyFromURL extracts the object key from a public URL produced by Upload.
+// Falls back to the substring after the last "/" when the prefix does not
+// match (e.g. URLs produced by an older configuration).
 func (s *S3Storage) KeyFromURL(rawURL string) string {
-	// Strip the "https://domain/" prefix.
-	for _, prefix := range []string{
-		"https://" + s.cdnDomain + "/",
-		"https://" + s.bucket + "/",
-	} {
-		if strings.HasPrefix(rawURL, prefix) {
-			return strings.TrimPrefix(rawURL, prefix)
-		}
+	if s.publicBase != "" && strings.HasPrefix(rawURL, s.publicBase) {
+		return strings.TrimPrefix(rawURL, s.publicBase)
 	}
-	// Fallback: take everything after the last "/".
 	if i := strings.LastIndex(rawURL, "/"); i >= 0 {
 		return rawURL[i+1:]
 	}
 	return rawURL
 }
 
-// Delete removes an object from S3. Errors are logged but not fatal.
+// Delete removes an object from the bucket. Errors are logged but not fatal.
 func (s *S3Storage) Delete(ctx context.Context, key string) {
 	if key == "" {
 		return
@@ -116,7 +201,7 @@ func (s *S3Storage) Delete(ctx context.Context, key string) {
 	}
 }
 
-// DeleteKeys removes multiple objects from S3. Best-effort, errors are logged.
+// DeleteKeys removes multiple objects. Best-effort, errors are logged.
 func (s *S3Storage) DeleteKeys(ctx context.Context, keys []string) {
 	for _, key := range keys {
 		s.Delete(ctx, key)
@@ -138,10 +223,5 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}
 
-	domain := s.bucket
-	if s.cdnDomain != "" {
-		domain = s.cdnDomain
-	}
-	link := fmt.Sprintf("https://%s/%s", domain, key)
-	return link, nil
+	return s.publicBase + key, nil
 }


### PR DESCRIPTION
## Summary

- Adds `S3_ENDPOINT`, `S3_USE_PATH_STYLE`, and `S3_PUBLIC_URL_BASE` env vars so the existing S3 backend can talk to any S3-compatible object store (GCS via HMAC keys, Cloudflare R2, MinIO, etc.) — no parallel storage implementation.
- Folds CDN / endpoint / bucket URL derivation into a single `publicBase` prefix used by both `Upload` and `KeyFromURL`; behavior for existing AWS S3 + CloudFront deployments is unchanged.
- Documents the new variables and a GCS configuration example in `.env.example` and `SELF_HOSTING.md`.

## Configuration examples

AWS S3 (default, unchanged): leave `S3_ENDPOINT` empty.

GCS via S3 compatibility:
```
S3_BUCKET=my-bucket
S3_REGION=auto
S3_ENDPOINT=https://storage.googleapis.com
S3_PUBLIC_URL_BASE=https://storage.googleapis.com/my-bucket
AWS_ACCESS_KEY_ID=<HMAC access key>
AWS_SECRET_ACCESS_KEY=<HMAC secret>
```

CloudFront-related vars only apply to AWS S3 + CloudFront and can be left empty for other providers; the signing branch in the file handler is already gated on `if h.CFSigner != nil`.

## Test plan

- [x] `make check`
- [x] `make test-go`
- [ ] Manual upload + delete against a real GCS bucket using HMAC keys


Made with [Cursor](https://cursor.com)