### PR TITLE
feat(webhooks): link GitHub PRs to referenced issues

### DIFF
--- a/server/internal/handler/github_event_test.go
+++ b/server/internal/handler/github_event_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/nullne/multica/server/internal/auth"
@@ -223,6 +224,200 @@ func TestReceiveGitHubEvent_PullRequestCreatesIssueAndLink(t *testing.T) {
 		testHandler.Queries.DeleteIssue(ctx, link.IssueID)
 		testHandler.Queries.DeleteIssueLink(ctx, link.ID)
 	})
+}
+
+func TestReceiveGitHubEvent_PullRequestReusesLinkedGitHubIssue(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+	ctx := context.Background()
+	secret := []byte("test-secret")
+
+	app, err := gh.NewApp(12345, testRSAKeyPEM)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	app.SetWebhookSecret(secret)
+	prev := testHandler.GitHubApp
+	testHandler.GitHubApp = app
+	t.Cleanup(func() { testHandler.GitHubApp = prev })
+
+	installationID := int64(424243)
+	webhookID := setupGitHubWebhookFixture(t, installationID)
+
+	var agentIDStr string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentIDStr); err != nil {
+		t.Fatalf("find agent: %v", err)
+	}
+
+	cfgJSON, _ := json.Marshal(CreateIssueActionConfig{
+		AgentID:       agentIDStr,
+		TitleTemplate: "PR: {{.title}}",
+	})
+	if _, err := testHandler.Queries.CreateWebhookAction(ctx, db.CreateWebhookActionParams{
+		WebhookID:  webhookID,
+		ActionType: "create_issue",
+		Config:     cfgJSON,
+		Enabled:    true,
+		Position:   0,
+	}); err != nil {
+		t.Fatalf("create action: %v", err)
+	}
+
+	linkedIssueID := createTestIssue(t, "Existing GitHub issue")
+	linkedIssueURL := fmt.Sprintf("https://github.com/acme/widgets/issues/%d", time.Now().UnixNano())
+	if _, err := testHandler.Queries.CreateIssueLink(ctx, db.CreateIssueLinkParams{
+		IssueID:     parseUUID(linkedIssueID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+		SourceType:  "github",
+		Kind:        "issue",
+		Direction:   "source",
+		Url:         linkedIssueURL,
+		ExternalID:  "acme/widgets#123",
+	}); err != nil {
+		t.Fatalf("create linked issue link: %v", err)
+	}
+
+	var beforeCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM issue WHERE workspace_id = $1`,
+		testWorkspaceID,
+	).Scan(&beforeCount); err != nil {
+		t.Fatalf("count issues before webhook: %v", err)
+	}
+
+	prURL := fmt.Sprintf("https://github.com/acme/widgets/pull/%d", time.Now().UnixNano())
+	body := []byte(fmt.Sprintf(`{
+		"action":"opened",
+		"installation":{"id":%d},
+		"pull_request":{"number":778,"title":"Fix existing issue","html_url":%q,"user":{"login":"alice"},"head":{"ref":"feat"},"base":{"ref":"main"},"body":"Fixes %s"},
+		"repository":{"full_name":"acme/widgets"}
+	}`, installationID, prURL, linkedIssueURL))
+
+	req := httptest.NewRequest("POST", "/api/github/events", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", signGitHubBody(secret, body))
+	w := httptest.NewRecorder()
+	testHandler.ReceiveGitHubEvent(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("PR opened: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	prLink, err := testHandler.Queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Url:         prURL,
+	})
+	if err != nil {
+		t.Fatalf("PR issue_link not found: %v", err)
+	}
+	if got := uuidToString(prLink.IssueID); got != linkedIssueID {
+		t.Fatalf("PR link issue_id = %s, want existing issue %s", got, linkedIssueID)
+	}
+
+	issueLink, err := testHandler.Queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Url:         linkedIssueURL,
+	})
+	if err != nil {
+		t.Fatalf("linked GitHub issue link not found: %v", err)
+	}
+	if issueLink.ExternalID != "acme/widgets#123" {
+		t.Fatalf("linked GitHub issue external_id = %q, want acme/widgets#123", issueLink.ExternalID)
+	}
+
+	var afterCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM issue WHERE workspace_id = $1`,
+		testWorkspaceID,
+	).Scan(&afterCount); err != nil {
+		t.Fatalf("count issues after webhook: %v", err)
+	}
+	if afterCount != beforeCount {
+		t.Fatalf("issue count after webhook = %d, want %d", afterCount, beforeCount)
+	}
+}
+
+func TestReceiveGitHubEvent_MultipleCreateActionsStillCreateSeparateIssues(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+	ctx := context.Background()
+	secret := []byte("test-secret")
+
+	app, err := gh.NewApp(12345, testRSAKeyPEM)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	app.SetWebhookSecret(secret)
+	prev := testHandler.GitHubApp
+	testHandler.GitHubApp = app
+	t.Cleanup(func() { testHandler.GitHubApp = prev })
+
+	installationID := time.Now().UnixNano()
+	webhookID := setupGitHubWebhookFixture(t, installationID)
+
+	var agentIDStr string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentIDStr); err != nil {
+		t.Fatalf("find agent: %v", err)
+	}
+
+	for i, titleTemplate := range []string{"A: {{.title}}", "B: {{.title}}"} {
+		cfgJSON, _ := json.Marshal(CreateIssueActionConfig{
+			AgentID:       agentIDStr,
+			TitleTemplate: titleTemplate,
+		})
+		if _, err := testHandler.Queries.CreateWebhookAction(ctx, db.CreateWebhookActionParams{
+			WebhookID:  webhookID,
+			ActionType: "create_issue",
+			Config:     cfgJSON,
+			Enabled:    true,
+			Position:   int32(i),
+		}); err != nil {
+			t.Fatalf("create action %d: %v", i, err)
+		}
+	}
+
+	var beforeCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM issue WHERE workspace_id = $1`,
+		testWorkspaceID,
+	).Scan(&beforeCount); err != nil {
+		t.Fatalf("count issues before webhook: %v", err)
+	}
+
+	prURL := fmt.Sprintf("https://github.com/acme/widgets/pull/%d", time.Now().UnixNano())
+	body := []byte(fmt.Sprintf(`{
+		"action":"opened",
+		"installation":{"id":%d},
+		"pull_request":{"number":779,"title":"Create two issues","html_url":%q,"user":{"login":"alice"},"head":{"ref":"feat"},"base":{"ref":"main"},"body":"no linked issue"},
+		"repository":{"full_name":"acme/widgets"}
+	}`, installationID, prURL))
+
+	req := httptest.NewRequest("POST", "/api/github/events", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", signGitHubBody(secret, body))
+	w := httptest.NewRecorder()
+	testHandler.ReceiveGitHubEvent(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("PR opened: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var afterCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM issue WHERE workspace_id = $1`,
+		testWorkspaceID,
+	).Scan(&afterCount); err != nil {
+		t.Fatalf("count issues after webhook: %v", err)
+	}
+	if afterCount != beforeCount+2 {
+		t.Fatalf("issue count after webhook = %d, want %d", afterCount, beforeCount+2)
+	}
 }
 
 // uniqueIssueNumber yields a value unlikely to collide across parallel test

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1590,7 +1590,7 @@ func TestWebhookCreateIssueSubscribers(t *testing.T) {
 		Type: "standard",
 		Data: map[string]string{"title": "Sub test issue"},
 	}
-	issueUUID, err := testHandler.executeCreateIssueAction(ctx, wkRow, cfg, evt)
+	issueUUID, err := testHandler.executeCreateIssueAction(ctx, wkRow, cfg, evt, db.IssueLink{}, false)
 	if err != nil {
 		t.Fatalf("executeCreateIssueAction: %v", err)
 	}

--- a/server/internal/handler/webhook.go
+++ b/server/internal/handler/webhook.go
@@ -893,9 +893,15 @@ func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, bod
 			}
 		}
 
+		preexistingLink, hasPreexistingLink, linkErr := h.findIssueLinkForEvent(ctx, webhook.WorkspaceID, evt)
+		if linkErr != nil {
+			h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "error", pgtype.UUID{}, "lookup issue_link: "+linkErr.Error())
+			continue
+		}
+
 		processed := false
 		for _, action := range actions {
-			ranOK, issueID, runErr := h.runWebhookAction(ctx, webhook, action, evt)
+			ranOK, issueID, runErr := h.runWebhookAction(ctx, webhook, action, evt, preexistingLink, hasPreexistingLink)
 			if runErr != nil {
 				h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "error", pgtype.UUID{}, fmt.Sprintf("%s: %s", action.ActionType, runErr.Error()))
 				continue
@@ -919,7 +925,7 @@ func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, bod
 // (ran, issueID, error). ran=false means the action's filters did not match
 // (no error, just skipped). ran=true with a nil error means the action
 // produced a side effect; issueID points at the issue if applicable.
-func (h *Handler) runWebhookAction(ctx context.Context, webhook db.Webhook, action db.WebhookAction, evt wh.Event) (bool, pgtype.UUID, error) {
+func (h *Handler) runWebhookAction(ctx context.Context, webhook db.Webhook, action db.WebhookAction, evt wh.Event, preexistingLink db.IssueLink, hasPreexistingLink bool) (bool, pgtype.UUID, error) {
 	switch action.ActionType {
 	case "create_issue":
 		var cfg CreateIssueActionConfig
@@ -929,7 +935,7 @@ func (h *Handler) runWebhookAction(ctx context.Context, webhook db.Webhook, acti
 		if !actionMatchesFilters(cfg.EventTypes, cfg.Repos, evt) {
 			return false, pgtype.UUID{}, nil
 		}
-		issueID, err := h.executeCreateIssueAction(ctx, webhook, cfg, evt)
+		issueID, err := h.executeCreateIssueAction(ctx, webhook, cfg, evt, preexistingLink, hasPreexistingLink)
 		if err != nil {
 			return true, pgtype.UUID{}, err
 		}
@@ -957,9 +963,16 @@ func (h *Handler) runWebhookAction(ctx context.Context, webhook db.Webhook, acti
 	}
 }
 
-func (h *Handler) executeCreateIssueAction(ctx context.Context, webhook db.Webhook, cfg CreateIssueActionConfig, evt wh.Event) (pgtype.UUID, error) {
+func (h *Handler) executeCreateIssueAction(ctx context.Context, webhook db.Webhook, cfg CreateIssueActionConfig, evt wh.Event, preexistingLink db.IssueLink, hasPreexistingLink bool) (pgtype.UUID, error) {
 	if cfg.AgentID == "" {
 		return pgtype.UUID{}, fmt.Errorf("action config missing agent_id")
+	}
+
+	if hasPreexistingLink {
+		if err := h.persistEventSourceLinks(ctx, h.Queries, webhook, preexistingLink.IssueID, evt); err != nil {
+			return pgtype.UUID{}, err
+		}
+		return preexistingLink.IssueID, nil
 	}
 
 	title := renderTemplate(cfg.TitleTemplate, evt.Data)
@@ -1038,25 +1051,8 @@ func (h *Handler) executeCreateIssueAction(ctx context.Context, webhook db.Webho
 		}
 	}
 
-	// Persist the source link so subsequent events for the same external
-	// resource (PR / issue) can find this issue via comment_issue actions.
-	if sourceURL := evt.Data["source_url"]; sourceURL != "" {
-		kind := evt.Data["source_kind"]
-		if kind == "" {
-			kind = "issue"
-		}
-		_, linkErr := qtx.CreateIssueLink(ctx, db.CreateIssueLinkParams{
-			IssueID:     issue.ID,
-			WorkspaceID: webhook.WorkspaceID,
-			SourceType:  webhook.SourceType,
-			Kind:        kind,
-			Direction:   "source",
-			Url:         sourceURL,
-			ExternalID:  evt.Data["external_id"],
-		})
-		if linkErr != nil {
-			slog.Warn("create issue_link failed", "issue_id", uuidToString(issue.ID), "url", sourceURL, "error", linkErr)
-		}
+	if err := h.persistEventSourceLinks(ctx, qtx, webhook, issue.ID, evt); err != nil {
+		return pgtype.UUID{}, err
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -1093,22 +1089,12 @@ func (h *Handler) executeCommentIssueAction(ctx context.Context, webhook db.Webh
 		return pgtype.UUID{}, false, fmt.Errorf("webhook has no bot_user_id")
 	}
 
-	sourceURL := evt.Data["source_url"]
-	if sourceURL == "" {
-		return pgtype.UUID{}, false, nil
-	}
-
-	link, err := h.Queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{
-		WorkspaceID: webhook.WorkspaceID,
-		Url:         sourceURL,
-	})
+	link, ok, err := h.findIssueLinkForEvent(ctx, webhook.WorkspaceID, evt)
 	if err != nil {
-		// Not finding a matching link is normal — a Multica issue was never
-		// created for this PR. Treat as "no action".
-		if isNotFound(err) {
-			return pgtype.UUID{}, false, nil
-		}
-		return pgtype.UUID{}, false, fmt.Errorf("lookup issue_link: %w", err)
+		return pgtype.UUID{}, false, err
+	}
+	if !ok {
+		return pgtype.UUID{}, false, nil
 	}
 
 	issue, err := h.Queries.GetIssue(ctx, link.IssueID)
@@ -1176,6 +1162,97 @@ func (h *Handler) executeCommentIssueAction(ctx context.Context, webhook db.Webh
 	return issue.ID, true, nil
 }
 
+func (h *Handler) findIssueLinkForEvent(ctx context.Context, workspaceID pgtype.UUID, evt wh.Event) (db.IssueLink, bool, error) {
+	for _, sourceURL := range eventSourceURLs(evt) {
+		link, err := h.Queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{
+			WorkspaceID: workspaceID,
+			Url:         sourceURL,
+		})
+		if err == nil {
+			return link, true, nil
+		}
+		if isNotFound(err) {
+			continue
+		}
+		return db.IssueLink{}, false, fmt.Errorf("lookup issue_link: %w", err)
+	}
+	return db.IssueLink{}, false, nil
+}
+
+func (h *Handler) persistEventSourceLinks(ctx context.Context, queries *db.Queries, webhook db.Webhook, issueID pgtype.UUID, evt wh.Event) error {
+	for _, sourceURL := range eventSourceURLs(evt) {
+		if _, err := queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{
+			WorkspaceID: webhook.WorkspaceID,
+			Url:         sourceURL,
+		}); err == nil {
+			continue
+		} else if !isNotFound(err) {
+			return fmt.Errorf("lookup issue_link: %w", err)
+		}
+
+		_, linkErr := queries.CreateIssueLink(ctx, db.CreateIssueLinkParams{
+			IssueID:     issueID,
+			WorkspaceID: webhook.WorkspaceID,
+			SourceType:  webhook.SourceType,
+			Kind:        eventSourceKind(evt, sourceURL),
+			Direction:   "source",
+			Url:         sourceURL,
+			ExternalID:  eventExternalID(evt, sourceURL),
+		})
+		if linkErr != nil {
+			slog.Warn("create issue_link failed", "issue_id", uuidToString(issueID), "url", sourceURL, "error", linkErr)
+			return linkErr
+		}
+	}
+	return nil
+}
+
+func eventSourceURLs(evt wh.Event) []string {
+	seen := make(map[string]bool)
+	var urls []string
+	add := func(url string) {
+		url = strings.TrimSpace(url)
+		if url == "" || seen[url] {
+			return
+		}
+		seen[url] = true
+		urls = append(urls, url)
+	}
+
+	for _, sourceURL := range strings.Split(evt.Data["source_urls"], "\n") {
+		add(sourceURL)
+	}
+	add(evt.Data["source_url"])
+	return urls
+}
+
+func eventSourceKind(evt wh.Event, sourceURL string) string {
+	if sourceURL == evt.Data["source_url"] && evt.Data["source_kind"] != "" {
+		return evt.Data["source_kind"]
+	}
+	if strings.Contains(sourceURL, "/pull/") {
+		return "pr"
+	}
+	if strings.Contains(sourceURL, "/issues/") {
+		return "issue"
+	}
+	if evt.Data["source_kind"] != "" {
+		return evt.Data["source_kind"]
+	}
+	return "issue"
+}
+
+func eventExternalID(evt wh.Event, sourceURL string) string {
+	const githubPrefix = "https://github.com/"
+	if strings.HasPrefix(sourceURL, githubPrefix) {
+		parts := strings.Split(strings.TrimPrefix(sourceURL, githubPrefix), "/")
+		if len(parts) >= 4 && (parts[2] == "issues" || parts[2] == "pull") {
+			return parts[0] + "/" + parts[1] + "#" + parts[3]
+		}
+	}
+	return evt.Data["external_id"]
+}
+
 // commentForBroadcast builds the lightweight payload published over WS for
 // new comments. We avoid pulling reactions/attachments here since webhook
 // comments never have either at creation time.
@@ -1223,4 +1300,3 @@ func (h *Handler) logWebhookEvent(ctx context.Context, webhook db.Webhook, dedup
 		slog.Warn("failed to log webhook event", "webhook_id", uuidToString(webhook.ID), "error", err)
 	}
 }
-

--- a/server/internal/webhook/github.go
+++ b/server/internal/webhook/github.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -190,6 +192,7 @@ func parseGitHubPullRequest(body []byte) map[string]string {
 	if action == "closed" && pr.Merged {
 		action = "merged"
 	}
+	sourceURLs := githubPRSourceURLs(ev.Repository.FullName, pr.Body, pr.HTMLURL)
 
 	return map[string]string{
 		"action":      action,
@@ -201,10 +204,63 @@ func parseGitHubPullRequest(body []byte) map[string]string {
 		"head_branch": pr.Head.Ref,
 		"base_branch": pr.Base.Ref,
 		"source_url":  pr.HTMLURL,
+		"source_urls": strings.Join(sourceURLs, "\n"),
 		"source_kind": "pr",
 		"external_id": fmt.Sprintf("%s#%d", ev.Repository.FullName, pr.Number),
 		"body":        fmt.Sprintf("**PR [#%d](%s): %s**\n**Author:** %s\n**Branch:** `%s` → `%s`\n**Action:** %s\n\n%s", pr.Number, pr.HTMLURL, pr.Title, pr.User.Login, pr.Head.Ref, pr.Base.Ref, action, pr.Body),
 	}
+}
+
+var (
+	githubIssueURLRe   = regexp.MustCompile(`https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/([0-9]+)`)
+	githubClosingRefRe = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+)`)
+)
+
+func githubPRSourceURLs(repo, body, prURL string) []string {
+	var urls []string
+	seen := make(map[string]bool)
+	type candidate struct {
+		index int
+		url   string
+	}
+	var candidates []candidate
+	add := func(url string) {
+		if url == "" || seen[url] {
+			return
+		}
+		seen[url] = true
+		urls = append(urls, url)
+	}
+
+	for _, match := range githubIssueURLRe.FindAllStringSubmatchIndex(body, -1) {
+		candidates = append(candidates, candidate{
+			index: match[0],
+			url:   fmt.Sprintf("https://github.com/%s/issues/%s", body[match[2]:match[3]], body[match[4]:match[5]]),
+		})
+	}
+	for _, match := range githubClosingRefRe.FindAllStringSubmatchIndex(body, -1) {
+		ref := body[match[2]:match[3]]
+		hash := strings.LastIndex(ref, "#")
+		if hash < 0 {
+			continue
+		}
+		refRepo := ref[:hash]
+		if refRepo == "" {
+			refRepo = repo
+		}
+		candidates = append(candidates, candidate{
+			index: match[0],
+			url:   fmt.Sprintf("https://github.com/%s/issues/%s", refRepo, ref[hash+1:]),
+		})
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].index < candidates[j].index
+	})
+	for _, candidate := range candidates {
+		add(candidate.url)
+	}
+	add(prURL)
+	return urls
 }
 
 func parseGitHubIssues(body []byte) map[string]string {
@@ -314,6 +370,7 @@ func (a *githubAdapter) Keys() []AdapterKey {
 		{Key: "base_branch", Description: "PR base branch", Required: false},
 		{Key: "html_url", Description: "Direct URL to the PR / issue / comment", Required: false},
 		{Key: "source_url", Description: "Stable URL of the parent resource — used by issue_link reverse lookup", Required: true},
+		{Key: "source_urls", Description: "Ordered newline-separated candidate source URLs for reverse lookup", Required: false},
 		{Key: "source_kind", Description: "'pr' | 'issue' | 'commit'", Required: true},
 		{Key: "external_id", Description: "Compact id like 'owner/repo#123'", Required: false},
 		{Key: "comment_body", Description: "Full comment body (issue_comment only)", Required: false},

--- a/server/internal/webhook/github_test.go
+++ b/server/internal/webhook/github_test.go
@@ -49,6 +49,43 @@ func TestGitHubAdapter_PullRequestOpened(t *testing.T) {
 	}
 }
 
+func TestGitHubAdapter_PullRequestIssueCandidates(t *testing.T) {
+	a := &githubAdapter{}
+	body := []byte(`{
+		"action": "opened",
+		"pull_request": {
+			"number": 42,
+			"title": "Add login feature",
+			"body": "Fixes #7 and closes other/repo#8. See https://github.com/org/repo/issues/9",
+			"html_url": "https://github.com/org/repo/pull/42",
+			"user": {"login": "alice"},
+			"head": {"ref": "feat/login"},
+			"base": {"ref": "main"}
+		},
+		"repository": {"full_name": "org/repo"}
+	}`)
+	headers := http.Header{}
+	headers.Set("X-GitHub-Event", "pull_request")
+
+	events, err := a.Parse(body, headers)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	want := strings.Join([]string{
+		"https://github.com/org/repo/issues/7",
+		"https://github.com/other/repo/issues/8",
+		"https://github.com/org/repo/issues/9",
+		"https://github.com/org/repo/pull/42",
+	}, "\n")
+	if got := events[0].Data["source_urls"]; got != want {
+		t.Errorf("source_urls = %q, want %q", got, want)
+	}
+}
+
 func TestGitHubAdapter_PullRequestMerged(t *testing.T) {
 	a := &githubAdapter{}
 	body := []byte(`{


### PR DESCRIPTION
## Summary
- Parse GitHub issue references from PR webhook bodies and prioritize those links before falling back to the PR URL.
- Reuse existing Multica issues linked to referenced GitHub issues, while preserving PR source links for future lookups.
- Add regression coverage for linked issue reuse, candidate ordering, metadata preservation, and multi-action create behavior.

## Test plan
- [x] `cd server && go test ./...`
- [x] `git diff --check`
- [ ] `make test` (blocked locally: Docker daemon is not running; cannot connect to `/Users/agi/.docker/run/docker.sock`)


Made with [Cursor](https://cursor.com)