### PR TITLE
fix(ci): include changelog in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ server/bin
 server/tmp
 e2e
 *.md
+!CHANGELOG.md
 !apps/web/README.md
 .env*
 !.env.example


### PR DESCRIPTION
## Summary
- Allow `CHANGELOG.md` through `.dockerignore` so the frontend Dockerfile can copy it during release image builds.
- Keep the existing broad Markdown ignore rule for the rest of the Docker context.

## Test plan
- `git diff --check -- .dockerignore`
- Attempted `docker build -f apps/web/Dockerfile .`, but local Docker daemon is not running in this environment.


Made with [Cursor](https://cursor.com)