### PR TITLE
fix(storage): support GCS HMAC uploads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,11 @@ jobs:
           RESEND_FROM_EMAIL=${{ secrets.RESEND_FROM_EMAIL }}
           COOKIE_DOMAIN=${{ secrets.COOKIE_DOMAIN }}
           S3_BUCKET=${{ secrets.S3_BUCKET }}
-          S3_REGION=${{ vars.S3_REGION || 'us-west-2' }}
+          S3_REGION=${{ secrets.S3_REGION || vars.S3_REGION || 'us-west-2' }}
+          S3_ENDPOINT=${{ secrets.S3_ENDPOINT }}
+          S3_PUBLIC_URL_BASE=${{ secrets.S3_PUBLIC_URL_BASE }}
+          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CLOUDFRONT_DOMAIN=${{ secrets.CLOUDFRONT_DOMAIN }}
           CLOUDFRONT_KEY_PAIR_ID=${{ secrets.CLOUDFRONT_KEY_PAIR_ID }}
           CLOUDFRONT_PRIVATE_KEY=${{ secrets.CLOUDFRONT_PRIVATE_KEY }}

--- a/e2e/comments.spec.ts
+++ b/e2e/comments.spec.ts
@@ -17,7 +17,7 @@ test.describe("Comments", () => {
 
   test("can navigate to issue detail and see comment editor", async ({ page }) => {
     // Wait for issues to load and click first one.
-    const issueLink = page.locator('a[href^="/issues/"]').first();
+    const issueLink = page.locator('a[href*="/issues/"]').first();
     await expect(issueLink).toBeVisible({ timeout: 10000 });
     await issueLink.click();
     await page.waitForURL(/\/issues\/[\w-]+/);

--- a/e2e/issues.spec.ts
+++ b/e2e/issues.spec.ts
@@ -30,7 +30,7 @@ test.describe("Issues", () => {
     await expect(page.locator(`text=${title}`).first()).toBeVisible({ timeout: 10000 });
 
     // Drill into detail page.
-    await page.locator(`a[href="/issues/${issue.id}"]`).first().click();
+    await page.locator(`a[href$="/issues/${issue.id}"]`).first().click();
     await page.waitForURL(/\/issues\/[\w-]+/);
     await expect(page.locator("text=Properties").first()).toBeVisible({ timeout: 10000 });
   });

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -3,10 +3,17 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -16,9 +23,14 @@ import (
 )
 
 type S3Storage struct {
-	client     *s3.Client
-	bucket     string
-	publicBase string // public URL prefix, always ends with "/"
+	client       *s3.Client
+	bucket       string
+	publicBase   string // public URL prefix, always ends with "/"
+	gcsEndpoint  string
+	gcsAccessKey string
+	gcsSecretKey string
+	httpClient   *http.Client
+	useGCSXML    bool
 }
 
 // NewS3StorageFromEnv creates an S3Storage from environment variables.
@@ -74,6 +86,7 @@ func NewS3StorageFromEnv() *S3Storage {
 	endpoint := strings.TrimRight(os.Getenv("S3_ENDPOINT"), "/")
 	pathStyle := resolvePathStyle(endpoint, os.Getenv("S3_USE_PATH_STYLE"))
 
+	useGCSXML := isGCSEndpoint(endpoint) && accessKey != "" && secretKey != ""
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		if endpoint != "" {
 			o.BaseEndpoint = aws.String(endpoint)
@@ -97,10 +110,21 @@ func NewS3StorageFromEnv() *S3Storage {
 		"public_base", publicBase,
 	)
 	return &S3Storage{
-		client:     client,
-		bucket:     bucket,
-		publicBase: publicBase,
+		client:       client,
+		bucket:       bucket,
+		publicBase:   publicBase,
+		gcsEndpoint:  endpoint,
+		gcsAccessKey: accessKey,
+		gcsSecretKey: secretKey,
+		httpClient:   http.DefaultClient,
+		useGCSXML:    useGCSXML,
 	}
+}
+
+func isGCSEndpoint(endpoint string) bool {
+	host := strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://")
+	host = strings.TrimSuffix(host, "/")
+	return host == "storage.googleapis.com"
 }
 
 // resolvePathStyle returns whether the S3 client should use path-style
@@ -192,6 +216,12 @@ func (s *S3Storage) Delete(ctx context.Context, key string) {
 	if key == "" {
 		return
 	}
+	if s.useGCSXML {
+		if err := s.deleteGCSObject(ctx, key); err != nil {
+			slog.Error("gcs DeleteObject failed", "key", key, "error", err)
+		}
+		return
+	}
 	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
@@ -210,18 +240,96 @@ func (s *S3Storage) DeleteKeys(ctx context.Context, keys []string) {
 
 func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {
 	safe := sanitizeFilename(filename)
-	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+	if s.useGCSXML {
+		if err := s.uploadGCSObject(ctx, key, data, contentType, safe); err != nil {
+			return "", err
+		}
+		return s.publicBase + key, nil
+	}
+
+	input := &s3.PutObjectInput{
 		Bucket:             aws.String(s.bucket),
 		Key:                aws.String(key),
 		Body:               bytes.NewReader(data),
 		ContentType:        aws.String(contentType),
 		ContentDisposition: aws.String(fmt.Sprintf(`inline; filename="%s"`, safe)),
 		CacheControl:       aws.String("max-age=432000,public"),
-		StorageClass:       types.StorageClassIntelligentTiering,
-	})
+	}
+	if s.gcsEndpoint == "" {
+		input.StorageClass = types.StorageClassIntelligentTiering
+	}
+
+	_, err := s.client.PutObject(ctx, input)
 	if err != nil {
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}
 
 	return s.publicBase + key, nil
+}
+
+func (s *S3Storage) uploadGCSObject(ctx context.Context, key string, data []byte, contentType string, safeFilename string) error {
+	req, err := s.newGCSXMLRequest(ctx, http.MethodPut, key, bytes.NewReader(data), contentType)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, safeFilename))
+	req.Header.Set("Cache-Control", "max-age=432000,public")
+	return s.doGCSXML(req)
+}
+
+func (s *S3Storage) deleteGCSObject(ctx context.Context, key string) error {
+	req, err := s.newGCSXMLRequest(ctx, http.MethodDelete, key, nil, "")
+	if err != nil {
+		return err
+	}
+	return s.doGCSXML(req)
+}
+
+func (s *S3Storage) newGCSXMLRequest(ctx context.Context, method string, key string, body io.Reader, contentType string) (*http.Request, error) {
+	endpoint := strings.TrimRight(s.gcsEndpoint, "/")
+	objectPath := escapedObjectPath(s.bucket, key)
+	req, err := http.NewRequestWithContext(ctx, method, endpoint+objectPath, body)
+	if err != nil {
+		return nil, err
+	}
+	date := time.Now().UTC().Format(http.TimeFormat)
+	req.Header.Set("Date", date)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	signature := s.gcsXMLSignature(method, contentType, date, objectPath)
+	req.Header.Set("Authorization", "AWS "+s.gcsAccessKey+":"+signature)
+	return req, nil
+}
+
+func escapedObjectPath(bucket, key string) string {
+	segments := append([]string{bucket}, strings.Split(key, "/")...)
+	for i, segment := range segments {
+		segments[i] = url.PathEscape(segment)
+	}
+	return "/" + strings.Join(segments, "/")
+}
+
+func (s *S3Storage) gcsXMLSignature(method, contentType, date, objectPath string) string {
+	stringToSign := method + "\n\n" + contentType + "\n" + date + "\n" + objectPath
+	mac := hmac.New(sha1.New, []byte(s.gcsSecretKey))
+	mac.Write([]byte(stringToSign))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (s *S3Storage) doGCSXML(req *http.Request) error {
+	client := s.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("gcs xml %s: %w", req.Method, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("gcs xml %s: status %d: %s", req.Method, resp.StatusCode, strings.TrimSpace(string(body)))
 }

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGCSXMLUploadUsesHMACRequestWithoutAWSStorageClass(t *testing.T) {
+	var sawPut bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPut = true
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/test-bucket/path/to/object.txt" {
+			t.Fatalf("path = %s, want /test-bucket/path/to/object.txt", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "AWS test-access:") {
+			t.Fatalf("authorization header = %q, want AWS HMAC header", got)
+		}
+		if got := r.Header.Get("X-Amz-Storage-Class"); got != "" {
+			t.Fatalf("X-Amz-Storage-Class = %q, want empty", got)
+		}
+		if got := r.Header.Get("Content-Disposition"); got != `inline; filename="bad_name.txt"` {
+			t.Fatalf("Content-Disposition = %q, want sanitized filename", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if string(body) != "hello" {
+			t.Fatalf("body = %q, want hello", string(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	storage := &S3Storage{
+		bucket:       "test-bucket",
+		publicBase:   "https://cdn.example/",
+		gcsEndpoint:  server.URL,
+		gcsAccessKey: "test-access",
+		gcsSecretKey: "test-secret",
+		httpClient:   server.Client(),
+		useGCSXML:    true,
+	}
+
+	url, err := storage.Upload(context.Background(), "path/to/object.txt", []byte("hello"), "text/plain", "bad\nname.txt")
+	if err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if !sawPut {
+		t.Fatal("server did not receive PUT request")
+	}
+	if url != "https://cdn.example/path/to/object.txt" {
+		t.Fatalf("url = %q, want public URL", url)
+	}
+}


### PR DESCRIPTION
## Summary
- Route `storage.googleapis.com` uploads/deletes through GCS XML HMAC requests so GCS interoperability keys work.
- Avoid AWS-only intelligent tiering storage class outside native AWS S3 uploads.
- Add deploy env wiring for S3 endpoint/public URL/HMAC secrets and update E2E issue link selectors for workspace-scoped issue URLs.

## Test plan
- `go test ./internal/storage`
- `make test-e2e`
- `make test`

## Deployment notes
- Added repository Actions secrets: `S3_BUCKET`, `S3_REGION`, `S3_ENDPOINT`, `S3_PUBLIC_URL_BASE`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.