### PR TITLE
feat(web): add personal daemon management

### DIFF
--- a/apps/web/app/(account)/account/_components/my-daemons-tab.test.tsx
+++ b/apps/web/app/(account)/account/_components/my-daemons-tab.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MyDaemonsTab } from "./my-daemons-tab";
+
+const listMyDaemons = vi.fn();
+const listMyDaemonWorkspaces = vi.fn();
+const setMyDaemonWorkspaceEnabled = vi.fn();
+
+vi.mock("@/shared/api", () => ({
+  api: {
+    listMyDaemons: (...args: unknown[]) => listMyDaemons(...args),
+    listMyDaemonWorkspaces: (...args: unknown[]) => listMyDaemonWorkspaces(...args),
+    setMyDaemonWorkspaceEnabled: (...args: unknown[]) =>
+      setMyDaemonWorkspaceEnabled(...args),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("MyDaemonsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listMyDaemons.mockResolvedValue([
+      {
+        id: "daemon-1",
+        user_id: "user-1",
+        daemon_id: "host-a",
+        status: "online",
+        cli_version: "0.2.71",
+        device_name: "Lex Studio",
+        device_info: "Lex Studio",
+        labels: [],
+        metadata: {},
+        last_seen_at: "2026-05-12T08:00:00Z",
+        created_at: "2026-05-12T08:00:00Z",
+        updated_at: "2026-05-12T08:00:00Z",
+        archived_at: null,
+      },
+    ]);
+    listMyDaemonWorkspaces.mockResolvedValue([
+      { workspace_id: "ws-1", workspace_name: "Lex", enabled: true },
+      { workspace_id: "ws-2", workspace_name: "Side Project", enabled: false },
+    ]);
+    setMyDaemonWorkspaceEnabled.mockResolvedValue(undefined);
+  });
+
+  it("loads the user's daemons and workspace assignments", async () => {
+    render(<MyDaemonsTab />);
+
+    expect((await screen.findAllByText("Lex Studio")).length).toBeGreaterThanOrEqual(
+      1,
+    );
+    expect(screen.getByText("host-a")).toBeInTheDocument();
+    expect(await screen.findByText("Lex")).toBeInTheDocument();
+    expect(screen.getByText("Side Project")).toBeInTheDocument();
+
+    expect(listMyDaemons).toHaveBeenCalledTimes(1);
+    expect(listMyDaemonWorkspaces).toHaveBeenCalledWith("daemon-1");
+  });
+
+  it("updates a daemon workspace assignment", async () => {
+    const user = userEvent.setup();
+    render(<MyDaemonsTab />);
+
+    const sideProjectSwitch = await screen.findByRole("switch", {
+      name: /enable side project/i,
+    });
+    await user.click(sideProjectSwitch);
+
+    expect(setMyDaemonWorkspaceEnabled).toHaveBeenCalledWith("daemon-1", "ws-2", true);
+    await waitFor(() => {
+      expect(listMyDaemonWorkspaces).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/app/(account)/account/_components/my-daemons-tab.tsx
+++ b/apps/web/app/(account)/account/_components/my-daemons-tab.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Monitor, Server, Wifi, WifiOff } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { api } from "@/shared/api";
+import type { Daemon, DaemonWorkspaceAssignment } from "@/shared/types";
+
+function formatLastSeen(value: string | null): string {
+  if (!value) return "Never seen";
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) return "Unknown";
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return "Just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function DaemonStatusBadge({ daemon }: { daemon: Daemon }) {
+  const online = daemon.status === "online";
+  return (
+    <Badge variant={online ? "default" : "secondary"} className="capitalize">
+      {online ? <Wifi className="h-3 w-3" /> : <WifiOff className="h-3 w-3" />}
+      {daemon.status}
+    </Badge>
+  );
+}
+
+export function MyDaemonsTab() {
+  const [daemons, setDaemons] = useState<Daemon[]>([]);
+  const [selectedDaemonId, setSelectedDaemonId] = useState("");
+  const [assignments, setAssignments] = useState<DaemonWorkspaceAssignment[]>([]);
+  const [loadingDaemons, setLoadingDaemons] = useState(true);
+  const [loadingAssignments, setLoadingAssignments] = useState(false);
+  const [updatingWorkspaceId, setUpdatingWorkspaceId] = useState<string | null>(null);
+
+  const selectedDaemon = useMemo(
+    () => daemons.find((daemon) => daemon.id === selectedDaemonId) ?? null,
+    [daemons, selectedDaemonId],
+  );
+
+  const loadAssignments = useCallback(async (daemonId: string) => {
+    setLoadingAssignments(true);
+    try {
+      setAssignments(await api.listMyDaemonWorkspaces(daemonId));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to load daemon workspaces");
+    } finally {
+      setLoadingAssignments(false);
+    }
+  }, []);
+
+  const loadDaemons = useCallback(async () => {
+    setLoadingDaemons(true);
+    try {
+      const list = await api.listMyDaemons();
+      setDaemons(list);
+      setSelectedDaemonId((current) =>
+        current && list.some((daemon) => daemon.id === current)
+          ? current
+          : list[0]?.id ?? "",
+      );
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to load daemons");
+    } finally {
+      setLoadingDaemons(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDaemons();
+  }, [loadDaemons]);
+
+  useEffect(() => {
+    if (!selectedDaemonId) {
+      setAssignments([]);
+      return;
+    }
+    loadAssignments(selectedDaemonId);
+  }, [selectedDaemonId, loadAssignments]);
+
+  const handleToggleWorkspace = async (
+    assignment: DaemonWorkspaceAssignment,
+    enabled: boolean,
+  ) => {
+    if (!selectedDaemon) return;
+    setUpdatingWorkspaceId(assignment.workspace_id);
+    try {
+      await api.setMyDaemonWorkspaceEnabled(
+        selectedDaemon.id,
+        assignment.workspace_id,
+        enabled,
+      );
+      await loadAssignments(selectedDaemon.id);
+      toast.success(
+        enabled
+          ? `Enabled ${selectedDaemon.device_name || selectedDaemon.daemon_id} for ${assignment.workspace_name}`
+          : `Disabled ${selectedDaemon.device_name || selectedDaemon.daemon_id} for ${assignment.workspace_name}`,
+      );
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update workspace assignment");
+    } finally {
+      setUpdatingWorkspaceId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Monitor className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">My Daemons</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Manage local daemon machines owned by your account and choose which workspaces
+          each daemon is allowed to serve.
+        </p>
+      </section>
+
+      {loadingDaemons ? (
+        <div className="grid gap-3 md:grid-cols-[240px_1fr]">
+          <Skeleton className="h-32 rounded-xl" />
+          <Skeleton className="h-32 rounded-xl" />
+        </div>
+      ) : daemons.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-10 text-center">
+            <Server className="h-8 w-8 text-muted-foreground/40" />
+            <p className="mt-3 text-sm font-medium">No daemons registered</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Run <code className="rounded bg-muted px-1 py-0.5">multica daemon start</code>{" "}
+              after logging in to register this machine to your account.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-[240px_1fr]">
+          <div className="space-y-2">
+            {daemons.map((daemon) => {
+              const selected = daemon.id === selectedDaemonId;
+              return (
+                <button
+                  key={daemon.id}
+                  type="button"
+                  onClick={() => setSelectedDaemonId(daemon.id)}
+                  className={cn(
+                    "flex w-full items-start gap-3 rounded-xl border p-3 text-left transition-colors",
+                    selected ? "border-primary bg-primary/5" : "hover:bg-accent",
+                    daemon.archived_at && "opacity-60",
+                  )}
+                >
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                    <Monitor className="h-4 w-4 text-muted-foreground" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">
+                      {daemon.device_name || daemon.daemon_id}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {daemon.daemon_id}
+                    </span>
+                    <span className="mt-2 flex items-center gap-2">
+                      <DaemonStatusBadge daemon={daemon} />
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <Card>
+            <CardContent className="space-y-5">
+              {selectedDaemon && (
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="truncate text-sm font-semibold">
+                      {selectedDaemon.device_name || selectedDaemon.daemon_id}
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      multica {selectedDaemon.cli_version || "unknown"} · {formatLastSeen(selectedDaemon.last_seen_at)}
+                    </p>
+                  </div>
+                  <DaemonStatusBadge daemon={selectedDaemon} />
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <div>
+                  <h4 className="text-xs font-medium text-muted-foreground">
+                    Workspace Access
+                  </h4>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Enabled workspaces can dispatch local agent work to this daemon.
+                  </p>
+                </div>
+
+                {loadingAssignments ? (
+                  <div className="space-y-2">
+                    {Array.from({ length: 2 }).map((_, index) => (
+                      <Skeleton key={index} className="h-14 rounded-lg" />
+                    ))}
+                  </div>
+                ) : assignments.length === 0 ? (
+                  <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                    This daemon has no eligible workspaces. Join or create a workspace,
+                    then re-register the daemon.
+                  </div>
+                ) : (
+                  <div className="divide-y rounded-lg border">
+                    {assignments.map((assignment) => (
+                      <div
+                        key={assignment.workspace_id}
+                        className="flex items-center justify-between gap-3 px-3 py-3"
+                      >
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium">
+                            {assignment.workspace_name}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {assignment.enabled ? "Enabled for dispatch" : "Disabled"}
+                          </div>
+                        </div>
+                        <Switch
+                          aria-label={`Enable ${assignment.workspace_name}`}
+                          checked={assignment.enabled}
+                          disabled={updatingWorkspaceId === assignment.workspace_id}
+                          onCheckedChange={(enabled) =>
+                            handleToggleWorkspace(assignment, enabled)
+                          }
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+                CLI: use <code>multica daemon assignments</code> to inspect the same
+                workspace access from your terminal.
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(account)/account/page.tsx
+++ b/apps/web/app/(account)/account/page.tsx
@@ -1,22 +1,29 @@
 "use client";
 
-import { Bell, Key, Palette, User } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { Bell, Key, Monitor, Palette, User } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { ProfileTab } from "./_components/profile-tab";
 import { AppearanceTab } from "./_components/appearance-tab";
 import { TokensTab } from "./_components/tokens-tab";
 import { NotificationsTab } from "./_components/notifications-tab";
+import { MyDaemonsTab } from "./_components/my-daemons-tab";
 
 const accountTabs = [
   { value: "profile", label: "Profile", icon: User },
+  { value: "daemons", label: "My Daemons", icon: Monitor },
   { value: "appearance", label: "Appearance", icon: Palette },
   { value: "notifications", label: "Notifications", icon: Bell },
   { value: "tokens", label: "API Tokens", icon: Key },
 ];
 
 export default function AccountPage() {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get("tab");
+  const defaultTab = accountTabs.some((item) => item.value === tab) ? tab! : "profile";
+
   return (
-    <Tabs defaultValue="profile" orientation="vertical" className="flex-1 min-h-0 gap-0">
+    <Tabs defaultValue={defaultTab} orientation="vertical" className="flex-1 min-h-0 gap-0">
       {/* Left nav */}
       <div className="w-52 shrink-0 border-r overflow-y-auto p-4">
         <h1 className="text-sm font-semibold mb-4 px-2">Account</h1>
@@ -34,6 +41,7 @@ export default function AccountPage() {
       <div className="flex-1 min-w-0 overflow-y-auto">
         <div className="w-full max-w-3xl mx-auto p-6">
           <TabsContent value="profile"><ProfileTab /></TabsContent>
+          <TabsContent value="daemons"><MyDaemonsTab /></TabsContent>
           <TabsContent value="appearance"><AppearanceTab /></TabsContent>
           <TabsContent value="notifications"><NotificationsTab /></TabsContent>
           <TabsContent value="tokens"><TokensTab /></TabsContent>

--- a/apps/web/app/(dashboard)/_components/app-sidebar.test.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.test.tsx
@@ -124,4 +124,14 @@ describe("AppSidebar user menu", () => {
 
     expect(pushMock).toHaveBeenCalledWith("/account");
   });
+
+  it("navigates to personal daemon management from the user menu", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    await user.click(screen.getByRole("button", { name: /Test User/i }));
+    await user.click(await screen.findByText("My daemons"));
+
+    expect(pushMock).toHaveBeenCalledWith("/account?tab=daemons");
+  });
 });

--- a/apps/web/app/(dashboard)/_components/app-sidebar.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.tsx
@@ -265,6 +265,12 @@ export function AppSidebar() {
                       <UserCog className="h-3.5 w-3.5" />
                       Account settings
                     </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => router.push("/account?tab=daemons")}
+                    >
+                      <Monitor className="h-3.5 w-3.5" />
+                      My daemons
+                    </DropdownMenuItem>
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem variant="destructive" onClick={logout}>

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -17,6 +17,7 @@ import type {
   AgentTask,
   AgentRuntime,
   Daemon,
+  DaemonWorkspaceAssignment,
   InboxItem,
   IssueSubscriber,
   Comment,
@@ -412,6 +413,25 @@ export class ApiClient {
 
   async listDaemons(): Promise<Daemon[]> {
     return this.fetch("/api/daemons");
+  }
+
+  async listMyDaemons(): Promise<Daemon[]> {
+    return this.fetch("/api/me/daemons");
+  }
+
+  async listMyDaemonWorkspaces(daemonId: string): Promise<DaemonWorkspaceAssignment[]> {
+    return this.fetch(`/api/me/daemons/${daemonId}/workspaces`);
+  }
+
+  async setMyDaemonWorkspaceEnabled(
+    daemonId: string,
+    workspaceId: string,
+    enabled: boolean,
+  ): Promise<DaemonWorkspaceAssignment> {
+    return this.fetch(`/api/me/daemons/${daemonId}/workspaces/${workspaceId}`, {
+      method: "PUT",
+      body: JSON.stringify({ enabled }),
+    });
   }
 
   async updateDaemon(daemonId: string, data: { device_name?: string; labels?: string[] }): Promise<Daemon> {

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -26,6 +26,12 @@ export interface Daemon {
   archived_at: string | null;
 }
 
+export interface DaemonWorkspaceAssignment {
+  workspace_id: string;
+  workspace_name: string;
+  enabled: boolean;
+}
+
 export type ProviderAuthStatus = "unknown" | "not_installed" | "unauthenticated" | "ready";
 
 export type RuntimeStatus = "online" | "offline" | "updating";

--- a/apps/web/shared/types/index.ts
+++ b/apps/web/shared/types/index.ts
@@ -10,6 +10,7 @@ export type {
   AgentTask,
   AgentRuntime,
   Daemon,
+  DaemonWorkspaceAssignment,
   RuntimeDevice,
   CreateAgentRequest,
   UpdateAgentRequest,

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { loginAsDefault, openWorkspaceMenu } from "./helpers";
+import { loginAsDefault } from "./helpers";
 
 test.describe("Authentication", () => {
   test("login page renders correctly", async ({ page }) => {
@@ -37,10 +37,10 @@ test.describe("Authentication", () => {
   test("logout clears auth and exits dashboard", async ({ page }) => {
     await loginAsDefault(page);
 
-    // Open the workspace dropdown menu
-    await openWorkspaceMenu(page);
+    // Open the user menu in the sidebar footer.
+    await page.getByRole("button", { name: /e2e@multica\.ai/i }).click();
 
-    // Click "Log out" in the workspace dropdown.
+    // Click "Log out" in the user menu.
     await page.locator("text=Log out").click();
 
     // After logout the dashboard layout pushes us to / (landing).


### PR DESCRIPTION
## Summary
- Add a My Daemons entry to the user menu that opens Account settings on the daemon management tab.
- Add an Account > My Daemons tab for user-owned daemons and per-workspace enable/disable assignments.
- Add frontend API/types coverage plus unit and E2E coverage for the new account entry.

## Test plan
- pnpm --filter @multica/web exec vitest run "app/(dashboard)/_components/app-sidebar.test.tsx" "app/(account)/account/_components/my-daemons-tab.test.tsx"
- make test


Made with [Cursor](https://cursor.com)