### PR TITLE
feat(web): Home page with chat-style create and cross-workspace recents

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -18,7 +18,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     <LoginPageClient
       cliCallback={firstParam(params.cli_callback)}
       cliState={firstParam(params.cli_state) ?? ""}
-      nextPath={firstParam(params.next) ?? "/issues"}
+      nextPath={firstParam(params.next) ?? "/home"}
     />
   );
 }

--- a/apps/web/app/(dashboard)/_components/app-sidebar.test.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.test.tsx
@@ -3,10 +3,14 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const pushMock = vi.fn();
+const listIssuesMock = vi.fn();
+let mockPathname = "/issues";
+let mockSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
-  usePathname: () => "/issues",
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("next/link", () => ({
@@ -23,6 +27,12 @@ vi.mock("next/link", () => ({
       {children}
     </a>
   ),
+}));
+
+vi.mock("@/shared/api", () => ({
+  api: {
+    listIssues: (...args: unknown[]) => listIssuesMock(...args),
+  },
 }));
 
 const authState = {
@@ -45,7 +55,10 @@ vi.mock("@/features/auth", () => ({
 
 const workspaceState = {
   workspace: { id: "ws-1", name: "Test Workspace", slug: "test" },
-  workspaces: [{ id: "ws-1", name: "Test Workspace", slug: "test" }],
+  workspaces: [
+    { id: "ws-1", name: "Test Workspace", slug: "test" },
+    { id: "ws-2", name: "Prod Debug", slug: "prod-debug" },
+  ],
   switchWorkspace: vi.fn(),
   clearWorkspace: vi.fn(),
 };
@@ -86,6 +99,30 @@ vi.mock("@/features/issues/stores/draft-store", () => ({
   ),
 }));
 
+const issueState = {
+  issues: [
+    {
+      id: "issue-1",
+      workspace_id: "ws-1",
+      identifier: "TES-1",
+      title: "Recent issue",
+      status: "todo",
+      priority: "medium",
+      creator_type: "member",
+      creator_id: "user-1",
+      updated_at: "2026-01-01T00:00:00Z",
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+vi.mock("@/features/issues/store", () => ({
+  useIssueStore: Object.assign(
+    (selector?: (s: typeof issueState) => unknown) =>
+      selector ? selector(issueState) : issueState,
+    { getState: () => issueState },
+  ),
+}));
+
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "./app-sidebar";
 
@@ -100,6 +137,29 @@ function renderSidebar() {
 describe("AppSidebar user menu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPathname = "/issues";
+    mockSearchParams = new URLSearchParams();
+    listIssuesMock.mockImplementation(({ workspace_id }: { workspace_id: string }) =>
+      Promise.resolve({
+        issues:
+          workspace_id === "ws-2"
+            ? [
+                {
+                  id: "issue-2",
+                  workspace_id: "ws-2",
+                  identifier: "PRD-2",
+                  title: "Other workspace issue",
+                  status: "todo",
+                  priority: "medium",
+                  creator_type: "member",
+                  creator_id: "user-1",
+                  updated_at: "2026-01-02T00:00:00Z",
+                  created_at: "2026-01-02T00:00:00Z",
+                },
+              ]
+            : issueState.issues,
+      })
+    );
   });
 
   it("opens the bottom user menu without throwing", async () => {
@@ -133,5 +193,18 @@ describe("AppSidebar user menu", () => {
     await user.click(await screen.findByText("My daemons"));
 
     expect(pushMock).toHaveBeenCalledWith("/account?tab=daemons");
+  });
+
+  it("shows only new issue and recents navigation on the home route", async () => {
+    mockPathname = "/home";
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+    expect(screen.getByText("Recents")).toBeInTheDocument();
+    expect(screen.getByText("Recent issue")).toBeInTheDocument();
+    expect(await screen.findByText("Prod Debug")).toBeInTheDocument();
+    expect(screen.getByText("Other workspace issue")).toBeInTheDocument();
+    expect(screen.queryByText("Inbox")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/(dashboard)/_components/app-sidebar.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -17,6 +18,7 @@ import {
   SquarePen,
   CircleUser,
   UserCog,
+  SlidersHorizontal,
 } from "lucide-react";
 import { WorkspaceAvatar } from "@/features/workspace";
 import { useIssueDraftStore } from "@/features/issues/stores/draft-store";
@@ -34,10 +36,13 @@ import {
 } from "@/components/ui/sidebar";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -46,6 +51,10 @@ import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore } from "@/features/workspace";
 import { useInboxStore } from "@/features/inbox";
 import { useModalStore } from "@/features/modals";
+import { useIssueStore } from "@/features/issues/store";
+import { StatusIcon } from "@/features/issues/components";
+import { api } from "@/shared/api";
+import type { Issue } from "@/shared/types";
 
 const primaryNav = [
   { href: "/inbox", label: "Inbox", icon: Inbox },
@@ -74,6 +83,12 @@ export function AppSidebar() {
   const workspace = useWorkspaceStore((s) => s.workspace);
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const switchWorkspace = useWorkspaceStore((s) => s.switchWorkspace);
+  const issues = useIssueStore((s) => s.issues);
+  const [recentIssues, setRecentIssues] = useState<Issue[]>(issues);
+  const [onlyMyIssues, setOnlyMyIssues] = useState(true);
+  const [hideCompleted, setHideCompleted] = useState(false);
+  const [groupByWorkspace, setGroupByWorkspace] = useState(true);
+  const [recentSortBy, setRecentSortBy] = useState<"updated" | "created">("updated");
 
   const unreadCount = useInboxStore((s) => s.unreadCount());
 
@@ -90,6 +105,285 @@ export function AppSidebar() {
     .join("")
     .toUpperCase()
     .slice(0, 2);
+
+  const isHome = pathname === "/home";
+  const workspaceIds = workspaces.map((ws) => ws.id).join(",");
+
+  useEffect(() => {
+    if (!isHome) return;
+
+    let cancelled = false;
+    setRecentIssues(issues);
+
+    if (workspaces.length === 0) return;
+
+    void Promise.all(
+      workspaces.map((ws) =>
+        api
+          .listIssues({ workspace_id: ws.id, limit: 50 })
+          .then((res) => res.issues)
+          .catch(() => [] as Issue[])
+      )
+    ).then((issueLists) => {
+      if (!cancelled) {
+        setRecentIssues(issueLists.flat());
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isHome, issues, workspaceIds]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const recentGroups = useMemo(() => {
+    const workspaceById = new Map(workspaces.map((ws) => [ws.id, ws]));
+    const filtered = recentIssues.filter((i) => {
+      if (onlyMyIssues) {
+        if (i.creator_type !== "member" || i.creator_id !== user?.id) return false;
+      }
+      if (hideCompleted && (i.status === "done" || i.status === "cancelled")) {
+        return false;
+      }
+      return true;
+    });
+    const sortField = recentSortBy === "created" ? "created_at" : "updated_at";
+    const sorted = [...filtered].sort((a, b) =>
+      b[sortField].localeCompare(a[sortField])
+    );
+    if (!groupByWorkspace) {
+      return new Map([["__all__", { workspaceName: "", issues: sorted }]]);
+    }
+    return sorted.reduce(
+      (groups, issue) => {
+        const group = groups.get(issue.workspace_id) ?? {
+          workspaceName:
+            workspaceById.get(issue.workspace_id)?.name ?? "Unknown workspace",
+          issues: [] as Issue[],
+        };
+        group.issues.push(issue);
+        groups.set(issue.workspace_id, group);
+        return groups;
+      },
+      new Map<string, { workspaceName: string; issues: Issue[] }>()
+    );
+  }, [
+    recentIssues,
+    workspaces,
+    onlyMyIssues,
+    user?.id,
+    hideCompleted,
+    recentSortBy,
+    groupByWorkspace,
+  ]);
+
+  if (isHome) {
+    return (
+      <Sidebar variant="inset">
+        <SidebarHeader className="py-3">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                render={
+                  <button
+                    type="button"
+                    onClick={() => router.push("/home?new=1")}
+                  />
+                }
+                className="font-medium"
+              >
+                <SquarePen />
+                <span>New</span>
+                <DraftDot />
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
+
+        <SidebarContent>
+          <SidebarGroup>
+            <div className="flex items-center justify-between px-2 pb-2">
+              <span className="text-xs font-medium text-muted-foreground">
+                Recents
+              </span>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label="Filter recents"
+                      className="rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                    >
+                      <SlidersHorizontal className="size-3.5" />
+                    </button>
+                  }
+                />
+                <DropdownMenuContent align="end" className="w-52">
+                  <DropdownMenuCheckboxItem
+                    checked={onlyMyIssues}
+                    onCheckedChange={setOnlyMyIssues}
+                  >
+                    Only my issues
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={hideCompleted}
+                    onCheckedChange={setHideCompleted}
+                  >
+                    Hide completed
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={groupByWorkspace}
+                    onCheckedChange={setGroupByWorkspace}
+                  >
+                    Group by workspace
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel className="text-xs text-muted-foreground">
+                      Sort by
+                    </DropdownMenuLabel>
+                    <DropdownMenuRadioGroup
+                      value={recentSortBy}
+                      onValueChange={(v) =>
+                        setRecentSortBy(v as "updated" | "created")
+                      }
+                    >
+                      <DropdownMenuRadioItem value="updated">
+                        Last updated
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="created">
+                        Last created
+                      </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <SidebarGroupContent>
+              <SidebarMenu className="gap-1">
+                {[...recentGroups.entries()].map(([workspaceId, group]) => (
+                  <div key={workspaceId} className="space-y-0.5">
+                    {group.workspaceName && (
+                      <div className="px-2 pt-2 text-xs text-muted-foreground">
+                        {group.workspaceName}
+                      </div>
+                    )}
+                    {group.issues.map((issue) => {
+                      const isAgentRunning =
+                        issue.assignee_type === "agent" &&
+                        issue.status === "in_progress";
+                      return (
+                        <SidebarMenuItem key={issue.id}>
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <SidebarMenuButton
+                                  size="sm"
+                                  onClick={async () => {
+                                    if (issue.workspace_id !== workspace?.id) {
+                                      await switchWorkspace(issue.workspace_id);
+                                    }
+                                    router.push(`/home?issue=${issue.id}`);
+                                  }}
+                                >
+                                  <span className="relative inline-flex shrink-0">
+                                    <StatusIcon
+                                      status={issue.status}
+                                      className="size-4"
+                                    />
+                                    {isAgentRunning && (
+                                      <span
+                                        aria-hidden
+                                        className="absolute -top-0.5 -right-0.5 flex size-1.5"
+                                      >
+                                        <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary opacity-75" />
+                                        <span className="relative inline-flex size-1.5 rounded-full bg-primary" />
+                                      </span>
+                                    )}
+                                  </span>
+                                  <span className="truncate">{issue.title}</span>
+                                </SidebarMenuButton>
+                              }
+                            />
+                            <TooltipContent side="right">
+                              {issue.identifier}
+                            </TooltipContent>
+                          </Tooltip>
+                        </SidebarMenuItem>
+                      );
+                    })}
+                  </div>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <SidebarMenuButton size="lg" className="gap-2">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+                        {user?.avatar_url ? (
+                          <img
+                            src={user.avatar_url}
+                            alt={user.name}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          userInitials || "?"
+                        )}
+                      </span>
+                      <span className="flex min-w-0 flex-1 flex-col text-left">
+                        <span className="truncate text-sm font-medium">
+                          {user?.name ?? "Account"}
+                        </span>
+                        <span className="truncate text-xs text-muted-foreground">
+                          {user?.email}
+                        </span>
+                      </span>
+                      <ChevronsUpDown className="size-3.5 text-muted-foreground" />
+                    </SidebarMenuButton>
+                  }
+                />
+                <DropdownMenuContent
+                  className="w-(--radix-dropdown-menu-trigger-width) min-w-56"
+                  align="start"
+                  side="top"
+                  sideOffset={4}
+                >
+                  <div className="px-1.5 py-1 text-xs text-muted-foreground">
+                    {user?.email}
+                  </div>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem onClick={() => router.push("/account")}>
+                      <UserCog className="h-3.5 w-3.5" />
+                      Account settings
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => router.push("/account?tab=daemons")}
+                    >
+                      <Monitor className="h-3.5 w-3.5" />
+                      My daemons
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem variant="destructive" onClick={logout}>
+                    <LogOut className="h-3.5 w-3.5" />
+                    Log out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+    );
+  }
 
   return (
       <Sidebar variant="inset">

--- a/apps/web/app/(dashboard)/home/page.tsx
+++ b/apps/web/app/(dashboard)/home/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { RecentIssuesPage } from "@/features/issues/components/recent-issues-page";
+
+export default function HomePage() {
+  return <RecentIssuesPage />;
+}

--- a/apps/web/features/issues/components/create-issue-toolbar.tsx
+++ b/apps/web/features/issues/components/create-issue-toolbar.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+import { useState } from "react";
+import {
+  CalendarDays,
+  Check,
+  CornerDownLeft,
+  Loader2,
+  Monitor,
+  ShieldCheck,
+  ShieldOff,
+  Tag,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { Button } from "@/components/ui/button";
+import { FileUploadButton } from "@/components/common/file-upload-button";
+import { ActorAvatar } from "@/components/common/actor-avatar";
+import type {
+  IssueAssigneeType,
+  IssuePriority,
+  IssueStatus,
+  Label,
+  UpdateIssueRequest,
+} from "@/shared/types";
+import { useAuthStore } from "@/features/auth";
+import { useWorkspaceStore, useActorName } from "@/features/workspace";
+import { useLabelStore } from "@/features/labels";
+import { useRuntimeStore } from "@/features/runtimes";
+import { canAssignAgent, AssigneePicker } from "./pickers/assignee-picker";
+import { StatusIcon } from "./status-icon";
+import { PriorityIcon } from "./priority-icon";
+import {
+  ALL_STATUSES,
+  STATUS_CONFIG,
+  PRIORITY_ORDER,
+  PRIORITY_CONFIG,
+} from "@/features/issues/config";
+
+export function CreateIssuePillButton({
+  children,
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
+        "hover:bg-accent/60 transition-colors cursor-pointer",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+function DispatchDaemonLabel({ daemonId }: { daemonId: string }) {
+  const daemons = useRuntimeStore((s) => s.daemons);
+  const daemon = daemons.find((d) => d.id === daemonId);
+  if (!daemon) return null;
+  return <span className="truncate">{daemon.device_name || daemon.daemon_id}</span>;
+}
+
+export function CreateIssueToolbar({
+  assigneeType,
+  assigneeId,
+  verifierAgentId,
+  maxVerificationRounds,
+  dispatchProvider,
+  dispatchDaemonId,
+  status,
+  priority,
+  selectedLabels,
+  dueDate,
+  uploading,
+  submitting,
+  onAssigneeUpdate,
+  onVerifierChange,
+  onMaxVerificationRoundsChange,
+  onStatusChange,
+  onPriorityChange,
+  onLabelsChange,
+  onDueDateChange,
+  onUploadFile,
+  onSubmit,
+  submitDisabled,
+  submitLabel = "Create Issue",
+  submitVariant = "default",
+  showAssignee = true,
+  hideSubmit = false,
+}: {
+  assigneeType: IssueAssigneeType | null | undefined;
+  assigneeId: string | null | undefined;
+  verifierAgentId?: string | null;
+  maxVerificationRounds?: number;
+  dispatchProvider?: string | null;
+  dispatchDaemonId?: string | null;
+  status: IssueStatus;
+  priority: IssuePriority;
+  selectedLabels: Label[];
+  dueDate: string | null;
+  uploading?: boolean;
+  submitting?: boolean;
+  onAssigneeUpdate: (patch: Partial<UpdateIssueRequest>) => void;
+  onVerifierChange?: (id?: string) => void;
+  onMaxVerificationRoundsChange?: (rounds?: number) => void;
+  onStatusChange: (status: IssueStatus) => void;
+  onPriorityChange: (priority: IssuePriority) => void;
+  onLabelsChange: (labels: Label[]) => void;
+  onDueDateChange: (value: string | null) => void;
+  onUploadFile: (file: File) => void;
+  onSubmit: () => void;
+  submitDisabled?: boolean;
+  submitLabel?: string;
+  submitVariant?: "default" | "icon";
+  showAssignee?: boolean;
+  hideSubmit?: boolean;
+}) {
+  const members = useWorkspaceStore((s) => s.members);
+  const agents = useWorkspaceStore((s) => s.agents);
+  const allLabels = useLabelStore((s) => s.labels);
+  const user = useAuthStore((s) => s.user);
+  const { getActorName } = useActorName();
+
+  const [labelOpen, setLabelOpen] = useState(false);
+  const [labelFilter, setLabelFilter] = useState("");
+  const [dueDateOpen, setDueDateOpen] = useState(false);
+  const [verifierOpen, setVerifierOpen] = useState(false);
+  const [verifierFilter, setVerifierFilter] = useState("");
+
+  const currentMember = members.find((m) => m.user_id === user?.id);
+  const memberRole = currentMember?.role;
+  const selectedAgent =
+    assigneeType === "agent" && assigneeId
+      ? agents.find((a) => a.id === assigneeId)
+      : null;
+  const assigneeLabel =
+    assigneeType && assigneeId ? getActorName(assigneeType, assigneeId) : "Assignee";
+  const verifierLabel = verifierAgentId
+    ? getActorName("agent", verifierAgentId)
+    : "Verifier";
+  const dueDateObj = dueDate ? new Date(dueDate) : undefined;
+  const verifierQuery = verifierFilter.toLowerCase();
+  const filteredVerifierAgents = agents.filter(
+    (a) =>
+      !a.archived_at &&
+      a.name.toLowerCase().includes(verifierQuery) &&
+      a.id !== assigneeId,
+  );
+  const isCompactSubmit = submitVariant === "icon";
+  const isSubmitDisabled = submitting || submitDisabled;
+  const canShowVerifierPicker = Boolean(
+    selectedAgent && onVerifierChange && onMaxVerificationRoundsChange
+  );
+  const hasTopRow =
+    showAssignee || canShowVerifierPicker || (!isCompactSubmit && !hideSubmit);
+  const submitButton = isCompactSubmit ? (
+    <button
+      type="button"
+      aria-label={submitting ? "Creating issue" : "Create issue"}
+      onClick={onSubmit}
+      disabled={isSubmitDisabled}
+      className="ml-auto inline-flex h-7 w-7 items-center justify-center rounded-lg border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-45"
+    >
+      {submitting ? (
+        <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+      ) : (
+        <CornerDownLeft className="size-3.5" aria-hidden="true" />
+      )}
+    </button>
+  ) : (
+    <Button size="sm" onClick={onSubmit} disabled={isSubmitDisabled}>
+      {submitting ? "Creating..." : submitLabel}
+    </Button>
+  );
+
+  return (
+    <div className="shrink-0">
+      {hasTopRow && (
+        <div className="flex items-center justify-between px-4 py-2">
+          <div className="flex items-center gap-1.5">
+          {showAssignee ? (
+            <AssigneePicker
+              assigneeType={assigneeType ?? null}
+              assigneeId={assigneeId ?? null}
+              verifierAgentId={verifierAgentId ?? null}
+              onUpdate={onAssigneeUpdate}
+              align="start"
+              triggerRender={<CreateIssuePillButton aria-label="Assign" />}
+              trigger={
+                assigneeType && assigneeId ? (
+                  <>
+                    <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={16} />
+                    <span className="truncate">{assigneeLabel}</span>
+                    {selectedAgent && (dispatchProvider || dispatchDaemonId) && (
+                      <span className="flex items-center gap-1 text-[10px] text-muted-foreground min-w-0">
+                        <span className="text-muted-foreground/70">·</span>
+                        {dispatchProvider && (
+                          <span className="capitalize shrink-0">{dispatchProvider}</span>
+                        )}
+                        {dispatchProvider && dispatchDaemonId && (
+                          <span className="shrink-0">·</span>
+                        )}
+                        {dispatchDaemonId && (
+                          <span className="inline-flex items-center gap-0.5 min-w-0">
+                            <Monitor className="h-2.5 w-2.5 shrink-0" />
+                            <DispatchDaemonLabel daemonId={dispatchDaemonId} />
+                          </span>
+                        )}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="text-muted-foreground">Assignee</span>
+                )
+              }
+            />
+          ) : null}
+
+          {selectedAgent && onVerifierChange && onMaxVerificationRoundsChange && (
+            <Popover
+              open={verifierOpen}
+              onOpenChange={(v) => {
+                setVerifierOpen(v);
+                if (!v) setVerifierFilter("");
+              }}
+            >
+              <PopoverTrigger
+                render={
+                  <CreateIssuePillButton>
+                    {verifierAgentId ? (
+                      <>
+                        <ShieldCheck className="size-3.5 text-primary" />
+                        <span>{verifierLabel}</span>
+                      </>
+                    ) : (
+                      <>
+                        <ShieldOff className="size-3.5 text-muted-foreground" />
+                        <span className="text-muted-foreground">Verifier</span>
+                      </>
+                    )}
+                  </CreateIssuePillButton>
+                }
+              />
+              <PopoverContent align="start" className="w-52 p-0">
+                <div className="px-2 py-1.5 border-b">
+                  <input
+                    type="text"
+                    value={verifierFilter}
+                    onChange={(e) => setVerifierFilter(e.target.value)}
+                    placeholder="Select verifier..."
+                    className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+                  />
+                </div>
+                <div className="p-1 max-h-60 overflow-y-auto">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onVerifierChange(undefined);
+                      onMaxVerificationRoundsChange(undefined);
+                      setVerifierOpen(false);
+                    }}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                  >
+                    <ShieldOff className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="text-muted-foreground">No verifier</span>
+                  </button>
+                  {filteredVerifierAgents.length > 0 && (
+                    <>
+                      <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                        Agents
+                      </div>
+                      {filteredVerifierAgents.map((agent) => {
+                        const allowed = canAssignAgent(agent, user?.id, memberRole);
+                        return (
+                          <button
+                            type="button"
+                            key={agent.id}
+                            disabled={!allowed}
+                            onClick={() => {
+                              if (!allowed) return;
+                              onVerifierChange(agent.id);
+                              setVerifierOpen(false);
+                            }}
+                            className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${allowed ? "hover:bg-accent" : "opacity-50 cursor-not-allowed"}`}
+                          >
+                            <ActorAvatar actorType="agent" actorId={agent.id} size={16} />
+                            <span>{agent.name}</span>
+                          </button>
+                        );
+                      })}
+                    </>
+                  )}
+                </div>
+                {verifierAgentId && (
+                  <div className="border-t px-3 py-2">
+                    <label className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>Max rounds</span>
+                      <input
+                        type="number"
+                        min={1}
+                        max={20}
+                        value={maxVerificationRounds ?? ""}
+                        placeholder="5"
+                        onChange={(e) => {
+                          const value = e.target.value
+                            ? parseInt(e.target.value, 10)
+                            : undefined;
+                          onMaxVerificationRoundsChange(
+                            value && value > 0 ? value : undefined
+                          );
+                        }}
+                        className="w-14 rounded border px-1.5 py-0.5 text-xs text-right bg-transparent outline-none focus:ring-1 focus:ring-ring"
+                      />
+                    </label>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          )}
+          </div>
+
+          {!isCompactSubmit && !hideSubmit ? submitButton : null}
+        </div>
+      )}
+
+      <div className={cn("flex items-center gap-1 px-4 py-1.5", hasTopRow && "border-t")}>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <CreateIssuePillButton className="border-none px-1.5">
+                <StatusIcon status={status} className="size-4" />
+              </CreateIssuePillButton>
+            }
+          />
+          <DropdownMenuContent align="start" className="w-44">
+            {ALL_STATUSES.map((nextStatus) => (
+              <DropdownMenuItem
+                key={nextStatus}
+                onClick={() => onStatusChange(nextStatus)}
+              >
+                <StatusIcon status={nextStatus} className="size-3.5" />
+                <span>{STATUS_CONFIG[nextStatus].label}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <CreateIssuePillButton
+                className={cn("border-none px-1.5", priority !== "none" && "px-2.5")}
+              >
+                <PriorityIcon priority={priority} className="size-4" />
+                {priority !== "none" && <span>{PRIORITY_CONFIG[priority].label}</span>}
+              </CreateIssuePillButton>
+            }
+          />
+          <DropdownMenuContent align="start" className="w-44">
+            {PRIORITY_ORDER.map((nextPriority) => (
+              <DropdownMenuItem
+                key={nextPriority}
+                onClick={() => onPriorityChange(nextPriority)}
+              >
+                <span
+                  className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[nextPriority].badgeBg} ${PRIORITY_CONFIG[nextPriority].badgeText}`}
+                >
+                  <PriorityIcon priority={nextPriority} className="h-3 w-3" inheritColor />
+                  {PRIORITY_CONFIG[nextPriority].label}
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Popover
+          open={labelOpen}
+          onOpenChange={(v) => {
+            setLabelOpen(v);
+            if (!v) setLabelFilter("");
+          }}
+        >
+          <PopoverTrigger
+            render={
+              <CreateIssuePillButton
+                className={cn("border-none", selectedLabels.length > 0 ? "px-2.5" : "px-1.5")}
+              >
+                {selectedLabels.length > 0 ? (
+                  <div className="flex items-center gap-1 overflow-hidden">
+                    {selectedLabels.slice(0, 2).map((label) => (
+                      <span
+                        key={label.id}
+                        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-xs truncate"
+                        style={{ backgroundColor: label.color + "15" }}
+                      >
+                        <span
+                          className="h-2 w-2 rounded-full shrink-0"
+                          style={{ backgroundColor: label.color }}
+                        />
+                        <span className="truncate max-w-[60px]">{label.name}</span>
+                      </span>
+                    ))}
+                    {selectedLabels.length > 2 && (
+                      <span className="text-muted-foreground">+{selectedLabels.length - 2}</span>
+                    )}
+                  </div>
+                ) : (
+                  <Tag className="size-4 text-muted-foreground" />
+                )}
+              </CreateIssuePillButton>
+            }
+          />
+          <PopoverContent align="start" className="w-52 p-0">
+            <div className="px-2 py-1.5 border-b">
+              <input
+                type="text"
+                value={labelFilter}
+                onChange={(e) => setLabelFilter(e.target.value)}
+                placeholder="Filter labels..."
+                className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+              />
+            </div>
+            <div className="p-1 max-h-60 overflow-y-auto">
+              {allLabels
+                .filter((label) =>
+                  label.name.toLowerCase().includes(labelFilter.toLowerCase())
+                )
+                .map((label) => (
+                  <button
+                    key={label.id}
+                    type="button"
+                    onClick={() =>
+                      onLabelsChange(
+                        selectedLabels.some((item) => item.id === label.id)
+                          ? selectedLabels.filter((item) => item.id !== label.id)
+                          : [...selectedLabels, label]
+                      )
+                    }
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                  >
+                    <span
+                      className="h-3 w-3 rounded-full shrink-0"
+                      style={{ backgroundColor: label.color }}
+                    />
+                    <span className="flex-1 text-left truncate">{label.name}</span>
+                    {selectedLabels.some((item) => item.id === label.id) && (
+                      <Check className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                    )}
+                  </button>
+                ))}
+              {allLabels.length === 0 && (
+                <div className="px-2 py-3 text-center text-sm text-muted-foreground">
+                  No labels yet
+                </div>
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        <Popover open={dueDateOpen} onOpenChange={setDueDateOpen}>
+          <PopoverTrigger
+            render={
+              <CreateIssuePillButton
+                className={cn("border-none", dueDateObj ? "px-2.5" : "px-1.5")}
+              >
+                <CalendarDays className="size-4 text-muted-foreground" />
+                {dueDateObj && (
+                  <span>
+                    {dueDateObj.toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                )}
+              </CreateIssuePillButton>
+            }
+          />
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={dueDateObj}
+              onSelect={(date: Date | undefined) => {
+                onDueDateChange(date ? date.toISOString() : null);
+                setDueDateOpen(false);
+              }}
+            />
+            {dueDateObj && (
+              <div className="border-t px-3 py-2">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => {
+                    onDueDateChange(null);
+                    setDueDateOpen(false);
+                  }}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  Clear date
+                </Button>
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+
+        <FileUploadButton busy={uploading} onSelect={onUploadFile} />
+        {isCompactSubmit && !hideSubmit ? submitButton : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/issues/components/index.ts
+++ b/apps/web/features/issues/components/index.ts
@@ -4,6 +4,7 @@ export { StatusPicker, PriorityPicker, AssigneePicker, canAssignAgent, AgentDisp
 export type { AgentPickerValue } from "./pickers";
 export { IssueDetail } from "./issue-detail";
 export { IssuesPage } from "./issues-page";
+export { RecentIssuesPage } from "./recent-issues-page";
 export { SplitView } from "./split-view";
 export { CommentCard } from "./comment-card";
 export { CommentInput } from "./comment-input";

--- a/apps/web/features/issues/components/recent-issues-page.test.tsx
+++ b/apps/web/features/issues/components/recent-issues-page.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Issue, Workspace } from "@/shared/types";
+
+const mockCreateIssue = vi.fn();
+const mockSetWorkspaceId = vi.fn();
+const mockSetIssueLabels = vi.fn();
+const mockPush = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@/shared/api", () => ({
+  api: {
+    createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+    setWorkspaceId: (...args: unknown[]) => mockSetWorkspaceId(...args),
+    setIssueLabels: (...args: unknown[]) => mockSetIssueLabels(...args),
+  },
+}));
+
+vi.mock("./issue-detail", () => ({
+  IssueDetail: ({ issueId }: { issueId: string }) => (
+    <div data-testid="issue-detail">Issue detail {issueId}</div>
+  ),
+}));
+
+import { useIssueStore } from "@/features/issues/store";
+import { useWorkspaceStore } from "@/features/workspace/store";
+import { RecentIssuesPage } from "./recent-issues-page";
+
+function makeWorkspace(id: string, name: string): Workspace {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase().replaceAll(" ", "-"),
+    description: null,
+    context: null,
+    settings: {},
+    repos: [],
+    issue_prefix: name.slice(0, 3).toUpperCase(),
+    github_connected: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeIssue(
+  id: string,
+  workspaceId: string,
+  identifier: string,
+  title: string,
+  updatedAt: string
+): Issue {
+  return {
+    id,
+    workspace_id: workspaceId,
+    number: Number(identifier.replace(/\D/g, "")),
+    identifier,
+    title,
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: null,
+    assignee_id: null,
+    verifier_agent_id: null,
+    max_verification_rounds: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    acceptance_criteria: [],
+    criteria_status: null,
+    position: 0,
+    due_date: null,
+    dispatch_provider: null,
+    dispatch_daemon_id: null,
+    dispatch_daemon_label: null,
+    labels: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: updatedAt,
+  };
+}
+
+describe("RecentIssuesPage", () => {
+  const qwip = makeWorkspace("ws-qwip", "Qwip");
+  const prod = makeWorkspace("ws-prod", "Prod Debug");
+  const issues = [
+    makeIssue("issue-1", qwip.id, "CON-486", "Fix side effects", "2026-01-03T00:00:00Z"),
+    makeIssue("issue-2", prod.id, "CON-522", "Fix PWA login", "2026-01-02T00:00:00Z"),
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    useIssueStore.setState({ issues, loading: false, activeIssueId: null });
+    useWorkspaceStore.setState({
+      workspace: qwip,
+      workspaces: [qwip, prod],
+      members: [
+        {
+          id: "member-1",
+          workspace_id: qwip.id,
+          user_id: "user-1",
+          role: "member",
+          created_at: "2026-01-01T00:00:00Z",
+          name: "Test User",
+          email: "test@example.com",
+          avatar_url: null,
+          kind: "human",
+        },
+      ],
+      agents: [],
+      skills: [],
+    });
+  });
+
+  it("opens the selected issue detail from the URL", () => {
+    mockSearchParams = new URLSearchParams("issue=issue-2");
+    render(<RecentIssuesPage />);
+
+    expect(screen.getByTestId("issue-detail")).toHaveTextContent("issue-2");
+  });
+
+  it("shows the chat-style create form by default and submits with cmd enter", async () => {
+    mockCreateIssue.mockResolvedValueOnce({
+      ...issues[0],
+      id: "issue-new",
+      identifier: "CON-999",
+      title: "Investigate local login",
+    });
+    const user = userEvent.setup();
+    render(<RecentIssuesPage />);
+
+    expect(screen.queryByLabelText("Title")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Workspace" })).toHaveTextContent("Qwip");
+    expect(screen.getByRole("button", { name: "Assign" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Assign" })).toHaveTextContent("Assignee");
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Attach file" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create issue" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Issue" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Assign" }));
+    expect(await screen.findByText("Unassigned")).toBeInTheDocument();
+    await user.click(await screen.findByText("Test User"));
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+
+    await user.type(
+      screen.getByPlaceholderText("Describe the issue..."),
+      "Investigate local login\nSteps are flaky"
+    );
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+    await waitFor(() => {
+      expect(mockSetWorkspaceId).toHaveBeenCalledWith(qwip.id);
+      expect(mockCreateIssue).toHaveBeenCalledWith({
+        title: "Investigate local login",
+        description: "Investigate local login\nSteps are flaky",
+        status: "backlog",
+        priority: "medium",
+        assignee_type: "member",
+        assignee_id: "user-1",
+        dispatch_provider: undefined,
+        dispatch_daemon_id: undefined,
+        dispatch_daemon_label: undefined,
+        due_date: undefined,
+      });
+      expect(mockPush).toHaveBeenCalledWith("/home?issue=issue-new");
+    });
+  });
+});

--- a/apps/web/features/issues/components/recent-issues-page.tsx
+++ b/apps/web/features/issues/components/recent-issues-page.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import { CornerDownLeft, Loader2 } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  Issue,
+  IssueAssigneeType,
+  IssuePriority,
+  IssueStatus,
+  Label,
+  UpdateIssueRequest,
+} from "@/shared/types";
+import { api } from "@/shared/api";
+import { useIssueStore } from "@/features/issues/store";
+import { useActorName, useWorkspaceStore, WorkspaceAvatar } from "@/features/workspace";
+import { ActorAvatar } from "@/components/common/actor-avatar";
+import { useFileUpload } from "@/shared/hooks/use-file-upload";
+import {
+  CreateIssuePillButton,
+  CreateIssueToolbar,
+} from "./create-issue-toolbar";
+import { AssigneePicker, PickerItem, PropertyPicker } from "./pickers";
+import { IssueDetail } from "./issue-detail";
+
+function titleFromDescription(value: string): string {
+  const firstLine = value.trim().split(/\r?\n/).find(Boolean) ?? "";
+  return firstLine.slice(0, 80) || "Untitled issue";
+}
+
+function CreateIssuePanel({
+  selectedWorkspaceId,
+  onWorkspaceChange,
+  onCreated,
+}: {
+  selectedWorkspaceId: string;
+  onWorkspaceChange: (workspaceId: string) => void;
+  onCreated: (issue: Issue) => void;
+}) {
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const { getActorName } = useActorName();
+  const selectedWorkspace = workspaces.find(
+    (workspace) => workspace.id === selectedWorkspaceId
+  );
+  const [description, setDescription] = useState("");
+  const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [assigneeType, setAssigneeType] = useState<IssueAssigneeType | null>(null);
+  const [assigneeId, setAssigneeId] = useState<string | null>(null);
+  const [dispatchProvider, setDispatchProvider] = useState<string | null>(null);
+  const [dispatchDaemonId, setDispatchDaemonId] = useState<string | null>(null);
+  const [dispatchDaemonLabel, setDispatchDaemonLabel] = useState<string | null>(null);
+  const [status, setStatus] = useState<IssueStatus>("backlog");
+  const [priority, setPriority] = useState<IssuePriority>("medium");
+  const [dueDate, setDueDate] = useState<string | null>(null);
+  const [selectedLabels, setSelectedLabels] = useState<Label[]>([]);
+  const { uploadWithToast, uploading } = useFileUpload();
+  const assigneeLabel =
+    assigneeType && assigneeId ? getActorName(assigneeType, assigneeId) : "Assignee";
+
+  const applyAssigneePatch = (patch: Partial<UpdateIssueRequest>) => {
+    if ("assignee_type" in patch) {
+      setAssigneeType(patch.assignee_type ?? null);
+    }
+    if ("assignee_id" in patch) {
+      setAssigneeId(patch.assignee_id ?? null);
+    }
+    if ("dispatch_provider" in patch) {
+      setDispatchProvider(patch.dispatch_provider ?? null);
+    }
+    if ("dispatch_daemon_id" in patch) {
+      setDispatchDaemonId(patch.dispatch_daemon_id ?? null);
+    }
+    if ("dispatch_daemon_label" in patch) {
+      setDispatchDaemonLabel(patch.dispatch_daemon_label ?? null);
+    }
+  };
+
+  const applyIssuePatch = (patch: Partial<UpdateIssueRequest>) => {
+    if ("status" in patch && patch.status) {
+      setStatus(patch.status);
+    }
+    if ("priority" in patch && patch.priority) {
+      setPriority(patch.priority);
+    }
+    if ("due_date" in patch) {
+      setDueDate(patch.due_date ?? null);
+    }
+  };
+
+  const handleUpload = async (file: File) => {
+    const uploaded = await uploadWithToast(file);
+    if (!uploaded) return;
+    const attachmentMarkdown = `[${uploaded.filename}](${uploaded.link})`;
+    setDescription((current) =>
+      current.trim()
+        ? `${current.trimEnd()}\n\n${attachmentMarkdown}`
+        : attachmentMarkdown
+    );
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = description.trim();
+    if (!trimmed || submitting) return;
+
+    setSubmitting(true);
+    try {
+      api.setWorkspaceId(selectedWorkspaceId);
+      let issue = await api.createIssue({
+        title: titleFromDescription(trimmed),
+        description: trimmed,
+        status,
+        priority,
+        due_date: dueDate || undefined,
+        assignee_type: assigneeType ?? undefined,
+        assignee_id: assigneeId ?? undefined,
+        dispatch_provider: dispatchProvider ?? undefined,
+        dispatch_daemon_id: dispatchDaemonId ?? undefined,
+        dispatch_daemon_label: dispatchDaemonLabel ?? undefined,
+      });
+      if (selectedLabels.length > 0) {
+        const labels = await api.setIssueLabels(
+          issue.id,
+          selectedLabels.map((label) => label.id)
+        );
+        issue = { ...issue, labels };
+      }
+      useIssueStore.getState().addIssue(issue);
+      setDescription("");
+      onCreated(issue);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to create issue");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const submitDisabled = submitting || !description.trim();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex flex-1 items-end px-5 pb-5">
+        <div className="mx-auto w-full max-w-4xl">
+          <div className="flex items-center gap-1.5 px-2 pb-2">
+            <div className="shrink-0">
+              <PropertyPicker
+                open={workspaceOpen}
+                onOpenChange={setWorkspaceOpen}
+                width="w-56"
+                align="start"
+                triggerRender={<CreateIssuePillButton aria-label="Workspace" />}
+                trigger={
+                  <>
+                    <WorkspaceAvatar name={selectedWorkspace?.name ?? "W"} size="sm" />
+                    <span>{selectedWorkspace?.name ?? "Workspace"}</span>
+                  </>
+                }
+              >
+                {workspaces.map((workspace) => (
+                  <PickerItem
+                    key={workspace.id}
+                    selected={workspace.id === selectedWorkspaceId}
+                    onClick={() => {
+                      onWorkspaceChange(workspace.id);
+                      setWorkspaceOpen(false);
+                    }}
+                  >
+                    <WorkspaceAvatar name={workspace.name} size="sm" />
+                    <span className="truncate">{workspace.name}</span>
+                  </PickerItem>
+                ))}
+              </PropertyPicker>
+            </div>
+            <AssigneePicker
+              assigneeType={assigneeType}
+              assigneeId={assigneeId}
+              onUpdate={applyAssigneePatch}
+              triggerRender={<CreateIssuePillButton aria-label="Assign" />}
+              trigger={
+                assigneeType && assigneeId ? (
+                  <>
+                    <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={16} />
+                    <span>{assigneeLabel}</span>
+                  </>
+                ) : (
+                  <span className="text-muted-foreground">Assignee</span>
+                )
+              }
+              align="start"
+            />
+          </div>
+          <div className="relative overflow-hidden rounded-2xl border bg-card shadow-sm">
+            <Textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+              placeholder="Describe the issue..."
+              className="min-h-32 resize-none border-0 bg-transparent px-4 py-3 pr-14 text-base shadow-none focus-visible:ring-0"
+            />
+            <button
+              type="button"
+              aria-label={submitting ? "Creating issue" : "Create issue"}
+              onClick={handleSubmit}
+              disabled={submitDisabled}
+              className="absolute bottom-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-lg border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-45"
+            >
+              {submitting ? (
+                <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+              ) : (
+                <CornerDownLeft className="size-3.5" aria-hidden="true" />
+              )}
+            </button>
+          </div>
+          <div className="pt-1">
+            <CreateIssueToolbar
+              assigneeType={assigneeType}
+              assigneeId={assigneeId}
+              dispatchProvider={dispatchProvider}
+              dispatchDaemonId={dispatchDaemonId}
+              status={status}
+              priority={priority}
+              selectedLabels={selectedLabels}
+              dueDate={dueDate}
+              uploading={uploading}
+              submitting={submitting}
+              submitDisabled={!description.trim()}
+              onAssigneeUpdate={applyAssigneePatch}
+              onStatusChange={setStatus}
+              onPriorityChange={setPriority}
+              onLabelsChange={setSelectedLabels}
+              onDueDateChange={setDueDate}
+              onUploadFile={handleUpload}
+              onSubmit={handleSubmit}
+              submitVariant="icon"
+              showAssignee={false}
+              hideSubmit
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RecentIssuesPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const issues = useIssueStore((s) => s.issues);
+  const currentWorkspace = useWorkspaceStore((s) => s.workspace);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(
+    currentWorkspace?.id ?? workspaces[0]?.id ?? ""
+  );
+
+  const issueIdFromUrl = searchParams.get("issue");
+  const showCreate = searchParams.get("new") === "1" || !issueIdFromUrl;
+  const activeIssue = issues.find((issue) => issue.id === issueIdFromUrl) ?? issues[0] ?? null;
+  const detailIssueId = activeIssue?.id ?? null;
+
+  return (
+    <div className="flex flex-1 min-h-0 bg-background">
+      <main className="min-w-0 flex-1">
+        {showCreate ? (
+          <CreateIssuePanel
+            selectedWorkspaceId={selectedWorkspaceId}
+            onWorkspaceChange={setSelectedWorkspaceId}
+            onCreated={(issue) => {
+              router.push(`/home?issue=${issue.id}`);
+            }}
+          />
+        ) : detailIssueId ? (
+          <IssueDetail issueId={detailIssueId} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Select an issue or create a new one.
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/features/modals/create-issue.tsx
+++ b/apps/web/features/modals/create-issue.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { CalendarDays, Check, ChevronRight, Monitor, Maximize2, Minimize2, ShieldCheck, ShieldOff, Tag, X as XIcon } from "lucide-react";
+import { Check, ChevronRight, Maximize2, Minimize2, X as XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import type { IssueStatus, IssuePriority, IssueAssigneeType, Label, UpdateIssueRequest } from "@/shared/types";
@@ -11,26 +11,12 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover";
-import { Calendar } from "@/components/ui/calendar";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { RichTextEditor, type RichTextEditorRef } from "@/components/common/rich-text-editor";
 import { TitleEditor } from "@/components/common/title-editor";
-import { StatusIcon, PriorityIcon, AssigneePicker, canAssignAgent } from "@/features/issues/components";
+import { StatusIcon } from "@/features/issues/components";
 import { useRuntimeStore } from "@/features/runtimes";
-import { ALL_STATUSES, STATUS_CONFIG, PRIORITY_ORDER, PRIORITY_CONFIG } from "@/features/issues/config";
-import { useLabelStore } from "@/features/labels";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore, useActorName } from "@/features/workspace";
 import { useIssueStore } from "@/features/issues";
@@ -40,39 +26,7 @@ import { issueUrl } from "@/features/issues/utils/url";
 import { getAgentDispatchDefaults } from "@/features/issues/utils/dispatch";
 import { api } from "@/shared/api";
 import { useFileUpload } from "@/shared/hooks/use-file-upload";
-import { FileUploadButton } from "@/components/common/file-upload-button";
-import { ActorAvatar } from "@/components/common/actor-avatar";
-
-// ---------------------------------------------------------------------------
-// Pill trigger — shared rounded-full button style for toolbar
-// ---------------------------------------------------------------------------
-
-function PillButton({
-  children,
-  className,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
-        "hover:bg-accent/60 transition-colors cursor-pointer",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}
-
-function DispatchDaemonLabel({ daemonId }: { daemonId: string }) {
-  const daemons = useRuntimeStore((s) => s.daemons);
-  const daemon = daemons.find((d) => d.id === daemonId);
-  if (!daemon) return null;
-  return <span className="truncate">{daemon.device_name || daemon.daemon_id}</span>;
-}
+import { CreateIssueToolbar } from "@/features/issues/components/create-issue-toolbar";
 
 // ---------------------------------------------------------------------------
 // CreateIssueModal
@@ -110,11 +64,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   const [maxVerificationRounds, setMaxVerificationRounds] = useState<number | undefined>(draft.maxVerificationRounds);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Labels
   const [selectedLabels, setSelectedLabels] = useState<Label[]>([]);
-  const allLabels = useLabelStore((s) => s.labels);
-  const [labelOpen, setLabelOpen] = useState(false);
-  const [labelFilter, setLabelFilter] = useState("");
 
   const initDispatch = (() => {
     if (initAssigneeType !== "agent" || !initAssigneeId) return {};
@@ -145,36 +95,8 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
     return () => clearTimeout(t);
   }, []);
 
-  // Verifier popover
-  const [verifierOpen, setVerifierOpen] = useState(false);
-  const [verifierFilter, setVerifierFilter] = useState("");
-
-  // Due date popover
-  const [dueDateOpen, setDueDateOpen] = useState(false);
-
-  // File upload
   const { uploadWithToast, uploading } = useFileUpload();
   const handleUpload = (file: File) => uploadWithToast(file);
-
-  const user = useAuthStore((s) => s.user);
-  const currentMember = members.find((m) => m.user_id === user?.id);
-  const memberRole = currentMember?.role;
-
-  const verifierQuery = verifierFilter.toLowerCase();
-  const filteredVerifierAgents = agents.filter(
-    (a) => !a.archived_at && a.name.toLowerCase().includes(verifierQuery) && a.id !== assigneeId,
-  );
-
-  const assigneeLabel =
-    assigneeType && assigneeId
-      ? getActorName(assigneeType, assigneeId)
-      : "Assignee";
-
-  const verifierLabel = verifierAgentId
-    ? getActorName("agent", verifierAgentId)
-    : "Verifier";
-
-  const dueDateObj = dueDate ? new Date(dueDate) : undefined;
 
   // Sync field changes to draft store
   const updateTitle = (v: string) => { setTitle(v); setDraft({ title: v }); };
@@ -355,311 +277,29 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         </div>
 
         {/* Bottom bar */}
-        <div className="shrink-0">
-          {/* Row 1: Assignee + agent dispatch options + Create button */}
-          <div className="flex items-center justify-between px-4 py-2">
-            <div className="flex items-center gap-1.5">
-              {/* Assignee — uses the shared picker so the agent dispatch
-                  confirmation step matches the issue detail entry points.
-                  Provider/environment render as secondary text alongside the
-                  agent name to keep this row uncluttered. */}
-              <AssigneePicker
-                assigneeType={assigneeType ?? null}
-                assigneeId={assigneeId ?? null}
-                verifierAgentId={verifierAgentId ?? null}
-                onUpdate={applyAssigneePatch}
-                align="start"
-                triggerRender={<PillButton />}
-                trigger={
-                  assigneeType && assigneeId ? (
-                    <>
-                      <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={16} />
-                      <span className="truncate">{assigneeLabel}</span>
-                      {selectedAgent && (dispatchProvider || dispatchDaemonId) && (
-                        <span className="flex items-center gap-1 text-[10px] text-muted-foreground min-w-0">
-                          <span className="text-muted-foreground/70">·</span>
-                          {dispatchProvider && (
-                            <span className="capitalize shrink-0">{dispatchProvider}</span>
-                          )}
-                          {dispatchProvider && dispatchDaemonId && (
-                            <span className="shrink-0">·</span>
-                          )}
-                          {dispatchDaemonId && (
-                            <span className="inline-flex items-center gap-0.5 min-w-0">
-                              <Monitor className="h-2.5 w-2.5 shrink-0" />
-                              <DispatchDaemonLabel daemonId={dispatchDaemonId} />
-                            </span>
-                          )}
-                        </span>
-                      )}
-                    </>
-                  ) : (
-                    <span className="text-muted-foreground">Assignee</span>
-                  )
-                }
-              />
-
-              {/* Agent-only fields beyond dispatch (verifier) */}
-              {selectedAgent && (
-                <>
-                  {/* Verifier */}
-                  <Popover open={verifierOpen} onOpenChange={(v) => { setVerifierOpen(v); if (!v) setVerifierFilter(""); }}>
-                    <PopoverTrigger
-                      render={
-                        <PillButton>
-                          {verifierAgentId ? (
-                            <>
-                              <ShieldCheck className="size-3.5 text-primary" />
-                              <span>{verifierLabel}</span>
-                            </>
-                          ) : (
-                            <>
-                              <ShieldOff className="size-3.5 text-muted-foreground" />
-                              <span className="text-muted-foreground">Verifier</span>
-                            </>
-                          )}
-                        </PillButton>
-                      }
-                    />
-                    <PopoverContent align="start" className="w-52 p-0">
-                      <div className="px-2 py-1.5 border-b">
-                        <input
-                          type="text"
-                          value={verifierFilter}
-                          onChange={(e) => setVerifierFilter(e.target.value)}
-                          placeholder="Select verifier..."
-                          className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
-                        />
-                      </div>
-                      <div className="p-1 max-h-60 overflow-y-auto">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            updateVerifier(undefined);
-                            updateMaxRounds(undefined);
-                            setVerifierOpen(false);
-                          }}
-                          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                        >
-                          <ShieldOff className="h-3.5 w-3.5 text-muted-foreground" />
-                          <span className="text-muted-foreground">No verifier</span>
-                        </button>
-
-                        {filteredVerifierAgents.length > 0 && (
-                          <>
-                            <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">Agents</div>
-                            {filteredVerifierAgents.map((a) => {
-                              const allowed = canAssignAgent(a, user?.id, memberRole);
-                              return (
-                                <button
-                                  type="button"
-                                  key={a.id}
-                                  disabled={!allowed}
-                                  onClick={() => {
-                                    if (!allowed) return;
-                                    updateVerifier(a.id);
-                                    setVerifierOpen(false);
-                                  }}
-                                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${allowed ? "hover:bg-accent" : "opacity-50 cursor-not-allowed"}`}
-                                >
-                                  <ActorAvatar actorType="agent" actorId={a.id} size={16} />
-                                  <span>{a.name}</span>
-                                </button>
-                              );
-                            })}
-                          </>
-                        )}
-
-                        {filteredVerifierAgents.length === 0 && verifierFilter && (
-                          <div className="px-2 py-3 text-center text-sm text-muted-foreground">No results</div>
-                        )}
-                      </div>
-
-                      {verifierAgentId && (
-                        <div className="border-t px-3 py-2">
-                          <label className="flex items-center justify-between text-xs text-muted-foreground">
-                            <span>Max rounds</span>
-                            <input
-                              type="number"
-                              min={1}
-                              max={20}
-                              value={maxVerificationRounds ?? ""}
-                              placeholder="5"
-                              onChange={(e) => {
-                                const v = e.target.value ? parseInt(e.target.value, 10) : undefined;
-                                updateMaxRounds(v && v > 0 ? v : undefined);
-                              }}
-                              className="w-14 rounded border px-1.5 py-0.5 text-xs text-right bg-transparent outline-none focus:ring-1 focus:ring-ring"
-                            />
-                          </label>
-                        </div>
-                      )}
-                    </PopoverContent>
-                  </Popover>
-                </>
-              )}
-            </div>
-
-            <Button size="sm" onClick={handleSubmit} disabled={submitting}>
-              {submitting ? "Creating..." : "Create Issue"}
-            </Button>
-          </div>
-
-          {/* Row 2: Status, Priority, Labels, Due date, File upload — icon-only, show value when set */}
-          <div className="flex items-center gap-1 px-4 py-1.5 border-t">
-            {/* Status */}
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <PillButton className="border-none px-1.5">
-                    <StatusIcon status={status} className="size-4" />
-                  </PillButton>
-                }
-              />
-              <DropdownMenuContent align="start" className="w-44">
-                {ALL_STATUSES.map((s) => (
-                  <DropdownMenuItem key={s} onClick={() => updateStatus(s)}>
-                    <StatusIcon status={s} className="size-3.5" />
-                    <span>{STATUS_CONFIG[s].label}</span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            {/* Priority */}
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <PillButton className={cn("border-none px-1.5", priority !== "none" && "px-2.5")}>
-                    <PriorityIcon priority={priority} className="size-4" />
-                    {priority !== "none" && <span>{PRIORITY_CONFIG[priority].label}</span>}
-                  </PillButton>
-                }
-              />
-              <DropdownMenuContent align="start" className="w-44">
-                {PRIORITY_ORDER.map((p) => (
-                  <DropdownMenuItem key={p} onClick={() => updatePriority(p)}>
-                    <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}>
-                      <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
-                      {PRIORITY_CONFIG[p].label}
-                    </span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            {/* Labels */}
-            <Popover open={labelOpen} onOpenChange={(v) => { setLabelOpen(v); if (!v) setLabelFilter(""); }}>
-              <PopoverTrigger
-                render={
-                  <PillButton className={cn("border-none", selectedLabels.length > 0 ? "px-2.5" : "px-1.5")}>
-                    {selectedLabels.length > 0 ? (
-                      <div className="flex items-center gap-1 overflow-hidden">
-                        {selectedLabels.slice(0, 2).map((l) => (
-                          <span
-                            key={l.id}
-                            className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-xs truncate"
-                            style={{ backgroundColor: l.color + "15" }}
-                          >
-                            <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: l.color }} />
-                            <span className="truncate max-w-[60px]">{l.name}</span>
-                          </span>
-                        ))}
-                        {selectedLabels.length > 2 && (
-                          <span className="text-muted-foreground">+{selectedLabels.length - 2}</span>
-                        )}
-                      </div>
-                    ) : (
-                      <Tag className="size-4 text-muted-foreground" />
-                    )}
-                  </PillButton>
-                }
-              />
-              <PopoverContent align="start" className="w-52 p-0">
-                <div className="px-2 py-1.5 border-b">
-                  <input
-                    type="text"
-                    value={labelFilter}
-                    onChange={(e) => setLabelFilter(e.target.value)}
-                    placeholder="Filter labels..."
-                    className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
-                  />
-                </div>
-                <div className="p-1 max-h-60 overflow-y-auto">
-                  {allLabels
-                    .filter((l) => l.name.toLowerCase().includes(labelFilter.toLowerCase()))
-                    .map((label) => (
-                      <button
-                        key={label.id}
-                        type="button"
-                        onClick={() => {
-                          setSelectedLabels((prev) =>
-                            prev.some((l) => l.id === label.id)
-                              ? prev.filter((l) => l.id !== label.id)
-                              : [...prev, label],
-                          );
-                        }}
-                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                      >
-                        <span className="h-3 w-3 rounded-full shrink-0" style={{ backgroundColor: label.color }} />
-                        <span className="flex-1 text-left truncate">{label.name}</span>
-                        {selectedLabels.some((l) => l.id === label.id) && (
-                          <Check className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                        )}
-                      </button>
-                    ))}
-                  {allLabels.length === 0 && (
-                    <div className="px-2 py-3 text-center text-sm text-muted-foreground">No labels yet</div>
-                  )}
-                </div>
-              </PopoverContent>
-            </Popover>
-
-            {/* Due date */}
-            <Popover open={dueDateOpen} onOpenChange={setDueDateOpen}>
-              <PopoverTrigger
-                render={
-                  <PillButton className={cn("border-none", dueDateObj ? "px-2.5" : "px-1.5")}>
-                    <CalendarDays className="size-4 text-muted-foreground" />
-                    {dueDateObj && (
-                      <span>{dueDateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}</span>
-                    )}
-                  </PillButton>
-                }
-              />
-              <PopoverContent className="w-auto p-0" align="start">
-                <Calendar
-                  mode="single"
-                  selected={dueDateObj}
-                  onSelect={(d: Date | undefined) => {
-                    updateDueDate(d ? d.toISOString() : null);
-                    setDueDateOpen(false);
-                  }}
-                />
-                {dueDateObj && (
-                  <div className="border-t px-3 py-2">
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      onClick={() => {
-                        updateDueDate(null);
-                        setDueDateOpen(false);
-                      }}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      Clear date
-                    </Button>
-                  </div>
-                )}
-              </PopoverContent>
-            </Popover>
-
-            <FileUploadButton
-              busy={uploading}
-              onSelect={(file) => descEditorRef.current?.uploadFile(file)}
-            />
-          </div>
-        </div>
+        <CreateIssueToolbar
+          assigneeType={assigneeType ?? null}
+          assigneeId={assigneeId ?? null}
+          verifierAgentId={verifierAgentId ?? null}
+          maxVerificationRounds={maxVerificationRounds}
+          dispatchProvider={dispatchProvider ?? null}
+          dispatchDaemonId={dispatchDaemonId ?? null}
+          status={status}
+          priority={priority}
+          selectedLabels={selectedLabels}
+          dueDate={dueDate}
+          uploading={uploading}
+          submitting={submitting}
+          onAssigneeUpdate={applyAssigneePatch}
+          onVerifierChange={updateVerifier}
+          onMaxVerificationRoundsChange={updateMaxRounds}
+          onStatusChange={updateStatus}
+          onPriorityChange={updatePriority}
+          onLabelsChange={setSelectedLabels}
+          onDueDateChange={updateDueDate}
+          onUploadFile={(file) => descEditorRef.current?.uploadFile(file)}
+          onSubmit={handleSubmit}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

- Adds a new `/home` route with a ChatGPT-style create panel — pickers above, bordered textarea with inline ⌘/Ctrl+Enter submit, toolbar below. Login lands here by default.
- Replaces the sidebar with a Home variant on `/home`: a **New** entry plus a cross-workspace **Recents** list with StatusIcon, hover-identifier tooltip, and an animated dot when an agent is actively running on the issue.
- Recents filter menu (sliders icon) with **Only my issues** (default on), **Hide completed**, **Group by workspace**, and Sort by **updated / created**.
- Clicking a Recents item from another workspace silently switches workspace before navigating, so `IssueDetail` and `useIssueStore` stay consistent.
- Extracts the toolbar from the create-issue modal into a reusable `CreateIssueToolbar` so both the modal and the new Home input share the same component (with a `hideSubmit` prop for the Home variant which renders its own inline submit button).

## Test plan

- [ ] `make test-ts` — sidebar + recent-issues-page unit tests pass
- [ ] Visit `/login` while signed out → land on `/home` after login
- [ ] On `/home`, sidebar shows New + Recents (cross-workspace)
- [ ] Type description, ⌘/Ctrl+Enter submits, Enter newlines
- [ ] Filter button toggles Only my issues / Hide completed / Group by workspace / Sort by — list updates immediately
- [ ] Click a recent from current workspace → IssueDetail renders
- [ ] Click a recent from another workspace → workspace switches, IssueDetail renders
- [ ] Hover a recent → identifier tooltip appears on the right
- [ ] Assign an issue to an agent and start it → status icon shows the pulsing dot
- [ ] Existing create-issue modal still works (Cmd+K or sidebar New on other routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)