### PR TITLE
docs: reverse-engineered product spec for Multica

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,32 @@
+# Multica Product Specification
+
+This directory is the product specification for Multica. It is reverse-engineered from the current codebase (`server/` and `apps/web/`) and is intended to describe **what is built today** plus the immediate roadmap implied by the code.
+
+When code and spec disagree, the code is the source of truth — please update the spec.
+
+## How to read this
+
+- Start with **[multica.md](multica.md)** — the product-level PRD: vision, personas, capabilities, success metrics, non-goals.
+- The per-feature appendices in **[features/](features/)** drill into each domain with detailed user stories, requirements, data model, APIs, and open questions.
+
+## Index
+
+| Document | Scope |
+|---|---|
+| [multica.md](multica.md) | Product-level PRD |
+| [features/workspaces-and-auth.md](features/workspaces-and-auth.md) | Workspaces, members, auth, personal access tokens |
+| [features/issues.md](features/issues.md) | Issues, comments, labels, reactions, attachments, mention chain |
+| [features/agents.md](features/agents.md) | Agents, providers, triggers, instructions, bot users |
+| [features/tasks-and-verification.md](features/tasks-and-verification.md) | Task lifecycle, dispatch, verification loop |
+| [features/runtimes-and-daemons.md](features/runtimes-and-daemons.md) | Daemons, runtimes, CLI |
+| [features/realtime-and-inbox.md](features/realtime-and-inbox.md) | WebSocket events, inbox, activity log, notifications |
+| [features/skills.md](features/skills.md) | Reusable skills |
+| [features/webhooks-and-integrations.md](features/webhooks-and-integrations.md) | Webhook ingest, GitHub App, Telegram |
+| [features/recurring-templates.md](features/recurring-templates.md) | Cron-scheduled recurring issues |
+
+## Conventions
+
+- **P0 / P1 / P2** in requirements mean: must-have (shipped or required for the feature to function), nice-to-have (observable gaps or close fast-follow), future consideration (out of scope today, but documented to guide architecture).
+- **Status: Shipped / Partial / Planned** is annotated on each requirement based on inspection of the current code.
+- "Member" = human user with workspace membership. "Agent" = AI worker. "Actor" = either, when the distinction does not matter.
+- Field names match the database (`snake_case`); API request/response fields match the handlers.

--- a/docs/spec/features/agents.md
+++ b/docs/spec/features/agents.md
@@ -1,0 +1,118 @@
+# Agents
+
+## Problem
+
+The core differentiator of Multica is the **agent as teammate** model. Agents must look and behave enough like a member to be assignable from the board, but they also need fields a human doesn't have — instructions, providers, triggers, skills, concurrency limits, archival state.
+
+## Goals
+
+1. **Symmetric with members** on the board, in comments, in reactions, in the inbox.
+2. **Provider-agnostic** — an agent declares "I run on `claude_code` or `codex`", not "I run on daemon X." Dispatch finds an available runtime at task time (see [decouple-agent-runtime.md](../../decouple-agent-runtime.md)).
+3. **Triggers** are first-class — assignment, comment, mention each map to a configurable trigger.
+4. **Loop-safe** — mention-chain accounting prevents two agents from ping-ponging forever.
+5. **Reversible lifecycle** — agents can be archived and restored without losing history.
+
+## Non-Goals
+
+- A marketplace of pre-built agents.
+- Agent-to-agent direct messaging outside an issue thread.
+- Per-agent rate limits beyond `max_concurrent_tasks`.
+- A visual workflow editor for triggers.
+
+## Personas & user stories
+
+- *As a tech lead*, I want to create an agent named "Lambda" that uses Claude Code and has read access to our GitHub.
+- *As an admin*, I want to attach the "deploy" skill to Lambda so she knows our release runbook.
+- *As an engineer*, I want to assign issues to Lambda and have her pick them up on whichever of my daemons is online.
+- *As a reviewer*, I want to `@Lambda` in a comment thread and have her respond by working in that thread.
+- *As an owner*, I want to archive an agent without breaking its old issues.
+
+## Requirements
+
+### Agent entity
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Workspace-scoped | `workspace_id` FK | P0 | Shipped |
+| Name, description, avatar | Standard profile fields | P0 | Shipped |
+| Providers (multi) | `providers TEXT[]` (e.g. `["claude_code", "codex"]`) | P0 | Shipped |
+| Default provider | `default_provider` (nullable) — pinned per agent | P0 | Shipped |
+| Default daemon | `default_daemon_id` (nullable) — optional preferred runtime owner | P0 | Shipped |
+| Instructions | `instructions TEXT` — system prompt prepended to every run (migration 021) | P0 | Shipped |
+| Tools | `tools JSONB` — per-agent allow/deny list for CLI tool use | P0 | Shipped |
+| Triggers | `triggers JSONB` — `on_assign`, `on_comment`, `on_mention` configuration | P0 | Shipped |
+| Concurrency | `max_concurrent_tasks INT` (default 6 since migration 023/052) | P0 | Shipped |
+| Visibility | `workspace | private` (default `private` since migration 030) | P0 | Shipped |
+| Status | `idle | working | blocked | error | offline` | P0 | Shipped |
+| GitHub code access | `github_code_access ∈ {read, write, admin}` (migration 032) | P0 | Shipped |
+| Owner | `owner_id` FK to user | P0 | Shipped |
+| Archive / restore | `archived_at`, `archived_by`; `POST .../archive` and `.../restore` (migration 031) | P0 | Shipped |
+| Bot users | Separate `kind='bot'` users (not agents) for system-authored comments — see workspaces appendix | P0 | Shipped |
+
+### Triggers
+
+| Trigger | What fires | Where to configure | Notes |
+|---|---|---|---|
+| `on_assign` | Agent receives an issue assignment | `triggers.on_assign` | Dispatches an executor task immediately (or a criteria task if a verifier is configured and criteria are empty). |
+| `on_comment` | New comment on an issue the agent is subscribed to | `triggers.on_comment` | Used for agents that should react to thread activity even without a direct mention. |
+| `on_mention` | Agent is `@mentioned` in a comment | `triggers.on_mention` | Bounded by the mention-chain cap on the issue. |
+
+> Scheduled triggers are not part of agent configuration — use **recurring templates** (see [recurring-templates.md](recurring-templates.md)) which assign an agent on creation.
+
+### CRUD & lifecycle
+
+| Req | Endpoint | Priority | Status |
+|---|---|---|---|
+| List agents | `GET /api/agents` | P0 | Shipped |
+| Create agent | `POST /api/agents` (admin/owner) | P0 | Shipped |
+| Get agent | `GET /api/agents/{id}` | P0 | Shipped |
+| Update agent | `PUT /api/agents/{id}` | P0 | Shipped |
+| Archive | `POST /api/agents/{id}/archive` | P0 | Shipped |
+| Restore | `POST /api/agents/{id}/restore` | P0 | Shipped |
+| List tasks | `GET /api/agents/{id}/tasks` | P0 | Shipped |
+| Get skills | `GET /api/agents/{id}/skills` | P0 | Shipped |
+| Set skills | `PUT /api/agents/{id}/skills` | P0 | Shipped |
+
+### Dispatch rules
+
+1. On task enqueue, the dispatcher reads `agent.providers` (or `default_provider`).
+2. It finds online runtimes in the same workspace whose `provider` is in that list.
+3. It picks the runtime with the **fewest active tasks** (queued + dispatched + running) — simple least-loaded.
+4. If `agent.default_daemon_id` is set, prefer runtimes on that daemon when otherwise equal.
+5. If no runtime is online, the task stays `queued` until one comes online.
+
+### Visibility
+
+- `private`: only the agent's `owner_id` can assign / `@mention` it. Default for newly created agents.
+- `workspace`: any member can assign / `@mention` it.
+
+## Data model
+
+```
+agent
+├── id, workspace_id, name, description, avatar_url
+├── providers TEXT[], default_provider, default_daemon_id
+├── instructions TEXT, tools JSONB, triggers JSONB
+├── visibility, status, max_concurrent_tasks
+├── github_code_access
+├── owner_id, archived_at, archived_by
+├── created_at, updated_at
+
+agent_skill (M:N → skill)
+agent_task_queue (1:N → task)
+```
+
+## Acceptance criteria
+
+- Given an agent with `providers=["claude_code"]`, when a task is enqueued and the only online runtime is `codex`, then the task stays `queued`.
+- Given an agent with two online runtimes both for `claude_code`, the dispatcher picks the runtime with fewer active tasks.
+- Given an agent with `visibility=private`, when a non-owner tries to assign an issue to it, then the request is rejected.
+- Given an archived agent, when a user tries to assign it, then the assignment is rejected and the agent does not appear in the assignee picker.
+- Given an agent at `max_concurrent_tasks`, when a new task is enqueued, then the task remains `queued` until a slot frees.
+
+## Open questions
+
+- Should `default_daemon_id` become a hard pin (always run here, fail if offline) in addition to today's soft preference?
+- Should agents support per-trigger `enabled` flags via `triggers` JSONB explicitly (today the trigger is "configured = enabled")?
+- Should the `github_code_access` field be enforced server-side (today it is informational; the agent CLI honors it via its own auth)?
+- Should `private` visibility be the default forever, or should workspaces opt into "agents are public by default" via settings?

--- a/docs/spec/features/issues.md
+++ b/docs/spec/features/issues.md
@@ -1,0 +1,208 @@
+# Issues, Comments, Labels, Attachments
+
+## Problem
+
+Tracking work for a mixed human-and-agent team needs all the usual issue-tracker primitives (status, priority, assignee, comments, labels) — plus a polymorphic assignee so agents and members are interchangeable on the board, plus a structured `acceptance_criteria` so an agent has a machine-readable definition of "done."
+
+## Goals
+
+1. **Linear-grade board ergonomics** without inventing new vocabulary (statuses, priorities, labels, subscribers, reactions, threads).
+2. **Polymorphic everything** — assignee, creator, comment author, reaction actor, subscriber can all be a `member` or an `agent`.
+3. **Threaded comments** that an agent can post into without special-casing.
+4. **Structured acceptance criteria** that drive the verification loop in [tasks-and-verification.md](tasks-and-verification.md) when a verifier is configured.
+5. **Mentions that do work**, not just notify — `@AgentName` in a comment can dispatch a task; mention chain depth is bounded.
+
+## Non-Goals
+
+- Sprint / cycle planning.
+- Estimation, story points, velocity.
+- Custom fields per workspace.
+- Multi-step workflows beyond the fixed status set.
+
+## Personas & user stories
+
+- *As a tech lead*, I want a board where humans and agents share the same columns so I can see total throughput, not two separate views.
+- *As an agent author*, I want my agent to be able to post a comment, attach a file, and change status using the same APIs members use.
+- *As a reviewer*, I want a way to write acceptance criteria once, and have the system enforce them at the end.
+- *As a member*, I want `@AgentName` in a comment to actually queue work for that agent.
+- *As an admin*, I want bulk update / delete to clear out stale backlog quickly.
+
+## Requirements
+
+### Issue entity
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Statuses | `backlog | todo | in_progress | in_review | done | blocked | cancelled` | P0 | Shipped |
+| Priorities | `urgent | high | medium | low | none` | P0 | Shipped |
+| Polymorphic assignee | `assignee_type ∈ {member, agent}` + `assignee_id` (nullable for unassigned) | P0 | Shipped |
+| Polymorphic creator | `creator_type ∈ {member, agent, webhook}` + `creator_id` | P0 | Shipped |
+| Parent / sub-issues | `parent_issue_id` FK; `GET /issues/{id}/sub-issues` lists children | P0 | Shipped |
+| Board ordering | `position FLOAT`; drag-to-reorder | P0 | Shipped |
+| Due date | `due_date TIMESTAMPTZ` | P0 | Shipped |
+| Numbered display | `issue_number` per workspace (e.g. `MUL-123`) — see migration 020 | P0 | Shipped |
+| Acceptance criteria | `acceptance_criteria JSONB` (array of `{id, title, check, severity}`); `criteria_status ∈ {pending, approved}` | P0 | Shipped |
+| Context refs | `context_refs JSONB` — array of references the agent should consult | P0 | Shipped |
+| Dev links | `issue_dev_links` — links out to PRs, branches, deploys | P0 | Shipped |
+| Verifier agent | `verifier_agent_id` + `verification_phase` + `verification_round` + `max_verification_rounds` | P0 | Shipped |
+| Batch update | `POST /api/issues/batch-update` | P0 | Shipped |
+| Batch delete | `POST /api/issues/batch-delete` | P0 | Shipped |
+| Cross-workspace resolution | `GET /api/issues/{id}/resolve` returns the workspace slug for an issue id (used by CLI / deep links) | P0 | Shipped |
+
+### Comments
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Polymorphic author | `member | agent` | P0 | Shipped |
+| Comment types | `comment | status_change | progress_update | system` | P0 | Shipped |
+| Threading | `parent_id` FK with cascading delete (migration 018) | P0 | Shipped |
+| Update / delete | `PUT/DELETE /api/comments/{commentId}` | P0 | Shipped |
+| Reactions | `comment_reaction` — actor + emoji; unique per actor/comment/emoji | P0 | Shipped |
+| Attachments | Attached via `attachment` table — `attachment_to_comment` or `attachment_to_issue` | P0 | Shipped |
+| System comments | Special `author_type='system'` (migration 054) for events without a human/agent actor | P0 | Shipped |
+| Mentions | `[@Name](mention://agent/<id>)` or `mention://user/<id>` markdown link → parsed by `util.ParseMentions` | P0 | Shipped |
+
+### Labels
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Workspace-level CRUD | `/api/labels` | P0 | Shipped |
+| Many-to-many | `issue_to_label` join table | P0 | Shipped |
+| Per-issue management | `GET/PUT /api/issues/{id}/labels` | P0 | Shipped |
+
+### Reactions
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| On issues | `POST/DELETE /api/issues/{id}/reactions` | P0 | Shipped |
+| On comments | `POST/DELETE /api/comments/{commentId}/reactions` | P0 | Shipped |
+
+### Subscribers & timeline
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Auto-subscribe on create / assign / comment | `member` and `agent` creators auto-subscribed | P0 | Shipped |
+| Manual subscribe / unsubscribe | `POST /api/issues/{id}/subscribe`, `/unsubscribe` | P0 | Shipped |
+| List subscribers | `GET /api/issues/{id}/subscribers` | P0 | Shipped |
+| Unified timeline | `GET /api/issues/{id}/timeline` — comments + activity log merged | P0 | Shipped |
+
+### Attachments
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Pre-signed upload | `POST /api/upload-file` returns the URL | P0 | Shipped |
+| Attach to issue or comment | `attachment` row stored with FK | P0 | Shipped |
+| Download | `GET /api/attachments/{id}/download` — auth-gated, workspace-resolved by handler | P0 | Shipped |
+| List on issue | `GET /api/issues/{id}/attachments` | P0 | Shipped |
+| Delete | `DELETE /api/attachments/{id}` | P0 | Shipped |
+| Storage | S3 backend, optional CloudFront URL signing (see `auth.NewCloudFrontSignerFromEnv`) | P0 | Shipped |
+
+### Mention chain (loop prevention)
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Agent mention triggers a task | When `@AgentName` is in a new comment, the system enqueues a task for that agent with `trigger_comment_id` | P0 | Shipped |
+| Chain count | `issue.agent_mention_chain_count` increments per agent-to-agent mention | P0 | Shipped |
+| Chain generation | `agent_mention_chain_generation BIGINT` — logical clock; humans can reset it | P0 | Shipped |
+| Max chain depth | Hard cap enforced before enqueue (prevents agent ping-pong) | P0 | Shipped |
+| Human reset | Posting a human comment increments generation, clearing the chain | P0 | Shipped |
+
+## Data model
+
+```
+issue
+├── id, workspace_id, issue_number, title, description
+├── status, priority, position, due_date
+├── assignee_type, assignee_id (polymorphic)
+├── creator_type, creator_id (polymorphic; member|agent|webhook)
+├── parent_issue_id
+├── acceptance_criteria JSONB[], criteria_status
+├── verifier_agent_id, verification_phase, verification_round, max_verification_rounds
+├── last_verification_result JSONB
+├── context_refs JSONB[]
+├── agent_mention_chain_count, agent_mention_chain_generation
+├── created_at, updated_at
+
+comment (threaded)
+├── id, issue_id, workspace_id
+├── author_type (member|agent|system), author_id
+├── parent_id (self-FK, cascade delete)
+├── type (comment|status_change|progress_update|system)
+├── content
+
+issue_label / issue_to_label
+issue_dependency (blocks | blocked_by | related)
+issue_subscriber (recipient_type, recipient_id)
+issue_reaction / comment_reaction (actor, emoji)
+attachment (issue or comment, uploader, filename, url, content_type, size_bytes)
+issue_dev_link (type, url, label)
+```
+
+## API surface (summary)
+
+```
+GET    /api/issues
+POST   /api/issues
+POST   /api/issues/batch-update
+POST   /api/issues/batch-delete
+
+GET    /api/issues/{id}
+PUT    /api/issues/{id}
+DELETE /api/issues/{id}
+GET    /api/issues/{id}/sub-issues
+GET    /api/issues/{id}/timeline
+
+POST   /api/issues/{id}/comments
+GET    /api/issues/{id}/comments
+
+GET    /api/issues/{id}/subscribers
+POST   /api/issues/{id}/subscribe
+POST   /api/issues/{id}/unsubscribe
+
+GET    /api/issues/{id}/active-task
+POST   /api/issues/{id}/tasks/{taskId}/cancel
+GET    /api/issues/{id}/task-runs
+
+PUT    /api/issues/{id}/criteria
+POST   /api/issues/{id}/criteria/approve
+POST   /api/issues/{id}/criteria/reject
+
+GET    /api/issues/{id}/labels
+PUT    /api/issues/{id}/labels
+
+POST   /api/issues/{id}/reactions
+DELETE /api/issues/{id}/reactions
+
+GET    /api/issues/{id}/attachments
+
+PUT    /api/comments/{commentId}
+DELETE /api/comments/{commentId}
+POST   /api/comments/{commentId}/reactions
+DELETE /api/comments/{commentId}/reactions
+
+GET    /api/labels
+POST   /api/labels
+PUT    /api/labels/{id}
+DELETE /api/labels/{id}
+
+DELETE /api/attachments/{id}
+GET    /api/attachments/{id}/download
+
+GET    /api/issues/{id}/resolve   (cross-workspace)
+```
+
+## Acceptance criteria (spec-level)
+
+- Given an issue with no assignee, when a member assigns it to an agent, then a task is enqueued and the WS hub emits `issue.updated`.
+- Given a comment containing `[@A](mention://agent/<id>)`, when posted by a human, then a task is enqueued for agent A with `trigger_comment_id` set and `chain_generation` advanced.
+- Given a comment containing `[@B](mention://agent/<id>)`, when posted by agent A and chain depth is below the cap, then a task is enqueued for agent B.
+- Given a comment containing `[@B](mention://agent/<id>)`, when posted by agent A and chain depth equals the cap, then no task is enqueued and a system comment notes the cap was hit.
+- Given an issue with a `verifier_agent_id` set, when assigned, the system enters the verification loop (see [tasks-and-verification.md](tasks-and-verification.md)).
+- Given an attachment, when a non-member downloads via the signed URL, then the server returns 403 (workspace membership is checked at fetch time).
+
+## Open questions
+
+- Should `position` reorder be coarsened (LexoRank-style) — the FLOAT approach risks precision loss after many reorders?
+- Should issues link out to runs in the **board column UI** by default (saves a click)?
+- Should the **mention chain cap** be workspace-configurable?
+- Webhook-authored issues set `creator_type='webhook'`; the inbox routing assumes member/agent creators auto-subscribe. Confirm there is no notification gap for "this webhook-created issue has no subscribers" (today the assigned agent and team are still routed).

--- a/docs/spec/features/realtime-and-inbox.md
+++ b/docs/spec/features/realtime-and-inbox.md
@@ -1,0 +1,144 @@
+# Real-time, Inbox & Activity Log
+
+## Problem
+
+A board where agents are working in parallel is only useful if humans see status changes immediately. The system has to (1) broadcast every mutation in real-time, (2) route notifications to the right people via the right channel (in-app inbox, Telegram), and (3) keep an auditable activity history per issue.
+
+## Goals
+
+1. **Live UI** — every mutation that affects a workspace is broadcast on the WS hub. The frontend rehydrates from REST after each connect, then drives off WS thereafter.
+2. **Routed notifications** — an `inbox_item` is a per-recipient delivery with a severity (`action_required | attention | info`), an issue link, and read/archive state.
+3. **Multi-channel** — inbox + Telegram today; channel selection is a per-user setting (plus per-workspace group chat).
+4. **Per-issue activity log** merged with comments into a single timeline.
+5. **Bulk inbox hygiene** — mark-all-read, archive-completed, archive-all-read.
+
+## Non-Goals
+
+- A general-purpose notification routing engine (Hookdeck / Knock / Courier-like).
+- Email digests.
+- Mobile push (no native apps).
+- Slack integration (no handler yet; could be added behind the same notification listener pattern).
+
+## Personas & user stories
+
+- *As a user with the dashboard open*, I want to see comments appear without refreshing.
+- *As a recipient of a task failure*, I want an inbox item that links straight to the failed task.
+- *As a workspace admin*, I want the team Telegram group to receive a one-line notice when an `action_required` issue lands.
+- *As a tech lead reviewing an issue history*, I want comments and status changes interleaved chronologically.
+
+## Requirements
+
+### WebSocket hub
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Single `/ws` endpoint | One connection per browser; rooms keyed by `workspace_id` | P0 | Shipped |
+| Membership gate | Connect rejected if not a member of the requested workspace | P0 | Shipped |
+| Hub broadcast | `Hub.Broadcast(workspaceID, event)` invoked from handlers and `TaskService` | P0 | Shipped |
+| Auto-reconnect on client | `WSClient` reconnects with exponential backoff; resubscribes rooms | P0 | Shipped |
+| Inbound message routing | Reserved but not used today (clients are read-only) | P1 | Planned |
+| Cross-instance fanout | — | P2 | Future (Redis / NATS) |
+
+### Event types (broadcast on `workspace_id` room)
+
+| Event | Triggered by |
+|---|---|
+| `issue.created`, `issue.updated`, `issue.deleted` | Issue CRUD |
+| `issue.batch_updated`, `issue.batch_deleted` | Bulk endpoints |
+| `comment.created`, `comment.updated`, `comment.deleted` | Comment CRUD |
+| `reaction.added`, `reaction.removed` | Reaction add / remove |
+| `subscription.changed` | Subscribe / unsubscribe |
+| `task.queued`, `task.dispatched`, `task.started`, `task.progress`, `task.message`, `task.completed`, `task.failed`, `task.cancelled` | Task lifecycle |
+| `daemon.heartbeat`, `daemon.archived` | Daemon updates |
+| `runtime.online`, `runtime.offline`, `runtime.usage` | Runtime updates |
+| `inbox.created`, `inbox.read`, `inbox.archived` | Inbox events |
+| `verification.phase_changed`, `criteria.updated` | Verification loop |
+
+The frontend listens via `useWSEvent` and patches its zustand stores.
+
+### Internal event bus
+
+A separate in-process bus (`server/internal/events/`) lets server-side listeners react to mutations without coupling handlers to side effects.
+
+| Listener | Purpose |
+|---|---|
+| Subscriber listener | Auto-subscribes creator/assignee/commenter to an issue |
+| Inbox listener | Materializes `inbox_item` rows from events |
+| Telegram listener | Posts to per-user channels and workspace group chats |
+| Activity-log listener | Writes `activity_log` rows |
+| Mention listener | Parses mentions and enqueues tasks (with chain accounting) |
+
+### Inbox
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Per-recipient routing | `recipient_type ∈ {member, agent}` + `recipient_id` | P0 | Shipped |
+| Item types | `issue_assigned`, `status_changed`, `new_comment`, `mention`, `task_failed`, `verification_blocked`, `criteria_ready`, etc. | P0 | Shipped |
+| Severity | `action_required | attention | info` | P0 | Shipped |
+| Title + body + issue link | Standard payload | P0 | Shipped |
+| Read state | `read BOOLEAN` | P0 | Shipped |
+| Archive state | `archived BOOLEAN` | P0 | Shipped |
+| Details JSONB | Additional context per item type (since migration 019) | P0 | Shipped |
+| Unread count | `GET /api/inbox/unread-count` | P0 | Shipped |
+| Mark single read | `POST /api/inbox/{id}/read` | P0 | Shipped |
+| Mark all read | `POST /api/inbox/mark-all-read` | P0 | Shipped |
+| Archive single | `POST /api/inbox/{id}/archive` | P0 | Shipped |
+| Archive all | `POST /api/inbox/archive-all` | P0 | Shipped |
+| Archive all read | `POST /api/inbox/archive-all-read` | P0 | Shipped |
+| Archive completed | `POST /api/inbox/archive-completed` — items whose linked issue is `done | cancelled` | P0 | Shipped |
+
+### Activity log
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Per-issue, per-actor entries | `actor_type ∈ {member, agent, system}` | P0 | Shipped |
+| Action types | `created, status_changed, assigned, unassigned, priority_changed, labels_changed, criteria_approved, verification_passed/failed, …` | P0 | Shipped |
+| Details JSONB | Type-specific payload | P0 | Shipped |
+| Timeline endpoint | `GET /api/issues/{id}/timeline` merges comments + activity log | P0 | Shipped |
+
+### Telegram notifications
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Per-user channel | `user_notification_channel(channel_type='telegram', channel_id)` linked via bot DM (migration 053) | P0 | Shipped |
+| Per-workspace group chat | `workspace.settings.telegram_group` with chat id and enabled flag | P0 | Shipped |
+| Notification filters | Workspace setting picks which event types go to the group | P0 | Shipped |
+| Server requires `TELEGRAM_BOT_TOKEN` env | — | P0 | Shipped |
+| Slack / email channels | — | P2 | Future |
+
+## Data model
+
+```
+inbox_item
+├── id, workspace_id
+├── recipient_type, recipient_id, actor_type, actor_id
+├── type, severity, issue_id
+├── title, body, details JSONB
+├── read, archived, created_at
+
+activity_log
+├── id, workspace_id, issue_id
+├── actor_type, actor_id
+├── action, details JSONB
+├── created_at
+
+user_notification_channel
+├── id, user_id, channel_type, channel_id
+├── created_at
+```
+
+## Acceptance criteria
+
+- Given an open dashboard, when another user updates an issue, then the change appears in the UI within 1s without manual refresh.
+- Given a member assigned to an issue, when assignment occurs, then an `issue_assigned` inbox item is created with severity `attention`.
+- Given a task failure, then a `task_failed` inbox item with severity `action_required` is created and routed to subscribers.
+- Given a workspace with Telegram group enabled, when a configured event type fires, then a message is posted to the group with a link back to the issue.
+- Given a user marking all inbox as read, when they reconnect on another device, then unread-count returns 0 and the UI reflects it.
+
+## Open questions
+
+- Should we **batch inbox items** for high-frequency events (e.g. 50 task messages in 30s)?
+- Should the **activity log have a retention policy** (e.g. archive after N months)?
+- Should **agent recipients** receive inbox items at all? Today the schema allows it; the rendering doesn't surface them.
+- Should we add a **digest mode** — instead of one Telegram message per event, send a rollup every N minutes?
+- Should the **timeline endpoint paginate** instead of returning all events for large issues?

--- a/docs/spec/features/recurring-templates.md
+++ b/docs/spec/features/recurring-templates.md
@@ -1,0 +1,104 @@
+# Recurring Issue Templates
+
+## Problem
+
+Some work is recurring on a schedule (daily standup recap, weekly health-check, end-of-sprint cleanup) and should land on the agent queue without a human kicking it off. The product needs a primitive that creates a new issue on a cron schedule, with the same assignee, labels, and dispatch hints each time.
+
+## Goals
+
+1. **Cron-driven issue creation** with timezone support — recurring work fires at the user's local "9am every weekday."
+2. **Same template, many issues** — every fire creates a fresh issue (not a re-open of the same one) so each occurrence has its own thread.
+3. **Optional bounding** — `max_runs` lets a template stop after N occurrences without manual cleanup.
+4. **Per-template subscribers** — known interested members are auto-subscribed to every issue created from the template.
+5. **Reliable single-fire** — a tick that occurs while a server is multi-replica must not produce duplicates.
+
+## Non-Goals
+
+- Generic workflow scheduling beyond "create one issue."
+- Multiple actions per fire (each template creates one issue today).
+- Conditional triggers ("only fire if X is true").
+- Editing already-created issues from a template change.
+
+## Personas & user stories
+
+- *As a tech lead*, I want a "weekly metrics review" issue created every Monday at 9am, assigned to our analytics agent.
+- *As an admin*, I want to pause a recurring template without losing its config.
+- *As an admin*, I want a template that runs four times then stops (e.g. a campaign).
+- *As a stakeholder*, I want to be auto-subscribed to every issue from a template I care about.
+
+## Requirements
+
+### Template entity
+
+| Field | Type | Notes |
+|---|---|---|
+| `id`, `workspace_id` | UUID | |
+| `name` | TEXT | Human label, not the issue title |
+| `cron` | TEXT | 5-field cron expression |
+| `timezone` | TEXT | Default `UTC`; e.g. `America/New_York` |
+| `title`, `description`, `priority` | — | Used to create each issue |
+| `assignee_type`, `assignee_id` | polymorphic | Optional (member or agent) |
+| `due_date_offset_hours` | INT | Relative due date; nullable |
+| `dispatch_provider`, `dispatch_daemon_id`, `dispatch_daemon_label` | — | Optional dispatch hints (mirrors webhook action config) |
+| `max_runs` | INT NULL | If set, stop creating after this many fires (migration 056) |
+| `runs_count` | INT | Monotonic counter |
+| `status` | `active | paused` | |
+| `created_by`, `created_at`, `updated_at` | | |
+
+### Subscriber list
+
+`recurring_template_subscriber(template_id, user_id)` — when an issue is created, each listed user is auto-added to the new issue's subscriber list, so their inbox sees it (migration 059).
+
+### Scheduling
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| In-process scheduler | `cmd/server/recurring_scheduler.go` ticks every 60s | P0 | Shipped |
+| Optimistic claim | `ClaimRecurringTemplate` row update guards against duplicate fires across replicas | P0 | Shipped |
+| Skip if paused | `status != 'active'` | P0 | Shipped |
+| Skip if `max_runs` reached | `runs_count >= max_runs` (when set) | P0 | Shipped |
+| Honor timezone | Cron evaluated in the template's TZ | P0 | Shipped |
+| Audit per fire | `runs_count` increments; created issue id is correlated via creator metadata | P0 | Shipped |
+
+### CRUD endpoints
+
+```
+GET    /api/recurring-templates
+POST   /api/recurring-templates                  (admin)
+GET    /api/recurring-templates/{id}
+PATCH  /api/recurring-templates/{id}             (admin)
+DELETE /api/recurring-templates/{id}             (admin)
+```
+
+## Data model
+
+```
+recurring_issue_template
+├── id, workspace_id, name
+├── cron, timezone
+├── title, description, priority
+├── assignee_type, assignee_id
+├── due_date_offset_hours
+├── dispatch_provider, dispatch_daemon_id, dispatch_daemon_label
+├── status, max_runs, runs_count
+├── created_by, created_at, updated_at
+
+recurring_template_subscriber
+├── template_id, user_id
+```
+
+## Acceptance criteria
+
+- Given an `active` template with cron `0 9 * * MON-FRI` and tz `America/New_York`, when the clock reaches 9:00am NYC time on a weekday, then exactly one new issue is created — even if two server instances tick concurrently.
+- Given a template with `max_runs=4` and `runs_count=4`, when the next tick fires, then no issue is created and the template is implicitly retired (no row deletion).
+- Given a template with two subscribers, when an issue is created, then both users appear in the new issue's `issue_subscriber` list.
+- Given a template with `assignee_type='agent'` and `assignee_id=X`, when the issue is created, then a task is enqueued to agent X (same path as a manual assignment).
+- Given a paused template, when the cron time matches, then no issue is created.
+
+## Open questions
+
+- Should a template support **multiple cron schedules** (e.g. daily and on the last day of the month) without splitting into two templates?
+- Should we offer a **"create if no open issue exists"** mode so a forgotten recurring issue doesn't pile up?
+- Should `runs_count` be **reset by re-activating** a paused template, or carry over?
+- Should the scheduler emit a **`recurring.fired` event** for observability (Telegram digest of "today's recurring issues")?
+- Should a template support **draft mode** — create the issue but leave it `backlog` and unassigned, requiring human review before agent execution?

--- a/docs/spec/features/runtimes-and-daemons.md
+++ b/docs/spec/features/runtimes-and-daemons.md
@@ -1,0 +1,161 @@
+# Runtimes, Daemons, CLI
+
+## Problem
+
+Coding agents (Claude Code, Codex, opencode, cursor) need to run somewhere the user trusts with their source tree and credentials — usually their own laptop or a workstation. Multica must let a user install one binary, authenticate once, and have all their machines available as compute for agent work, without opening inbound ports or sharing credentials with the cloud.
+
+## Goals
+
+1. **Single binary, single command** — `brew install multica` then `multica login && multica daemon start`.
+2. **Pull-only** — daemons never accept inbound connections; they poll an authenticated endpoint.
+3. **Per-machine, multi-workspace** — one daemon serves any number of workspaces the user belongs to.
+4. **Auto-detect available CLIs** — the daemon registers one runtime per detected provider.
+5. **Visibility** — Settings → Daemons / Runtimes shows liveness, CLI version, recent activity, daily token usage.
+6. **Self-service updates and pings** — admin can poke a daemon to verify health or force an update without SSHing in.
+
+## Non-Goals
+
+- Hosted (cloud) runtimes today.
+- A web-based terminal for the daemon.
+- Sandboxing the agent CLI beyond what the CLI itself does.
+- Auto-installing missing agent CLIs.
+
+## Personas & user stories
+
+- *As an engineer*, I want to install Multica, log in, and have my Mac show up as compute in five minutes.
+- *As an admin*, I want to see which of my team's machines are online and what they're running.
+- *As an oncall engineer*, I want to "ping" a daemon and see whether the agent CLI is healthy.
+- *As an engineer*, I want to silence a daemon for a specific workspace without uninstalling it.
+- *As a user with multiple Multica servers (e.g. self-host + cloud)*, I want a profile-based daemon so each server has its own state.
+
+## Requirements
+
+### Daemon lifecycle
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| User-owned daemons | Each `daemon` row has `user_id` (since migration 060). Daemons are personal compute. | P0 | Shipped |
+| Workspace assignment | `daemon_workspace` join table; user toggles which of their workspaces the daemon serves | P0 | Shipped |
+| Daemon token | `mdt_` prefix; minted at first registration; stored on the daemon | P0 | Shipped |
+| Register / deregister | `POST /api/daemon/register`, `POST /api/daemon/deregister` | P0 | Shipped |
+| Heartbeat | `POST /api/daemon/heartbeat` every 15s by default | P0 | Shipped |
+| Status fields | `id`, `daemon_id`, `status`, `last_heartbeat_at`, `cli_version`, `device_info JSONB`, `archived_at` | P0 | Shipped |
+| Archive / restore | `POST /api/daemons/{daemonId}/archive`, `/restore` (migration 046) | P0 | Shipped |
+| Get / update | `GET /api/daemons/{daemonId}`, `PATCH /api/daemons/{daemonId}` | P0 | Shipped |
+| Env inspection | `GET /api/daemons/{daemonId}/env` — returns the env vars the server expects this daemon to run with | P0 | Shipped |
+| Force update across workspace | `POST /api/workspaces/{id}/update-all-daemons` | P0 | Shipped |
+
+### Runtimes
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Auto-detect CLIs | Daemon scans PATH for `claude`, `codex`, `opencode`, `cursor` at startup | P0 | Shipped |
+| Register runtime per CLI per workspace | One `agent_runtime` row keyed by `(workspace_id, daemon_id, provider)` | P0 | Shipped |
+| Status | `online | offline` driven by heartbeat freshness | P0 | Shipped |
+| Per-runtime daily usage | `runtime_usage` row per (runtime, date, model) with token counters | P0 | Shipped |
+| List runtimes | `GET /api/runtimes` | P0 | Shipped |
+| Get usage | `GET /api/runtimes/{runtimeId}/usage` | P0 | Shipped |
+| Get recent activity | `GET /api/runtimes/{runtimeId}/activity` | P0 | Shipped |
+| Ping (health check) | Server requests, daemon executes, reports result: `POST /api/runtimes/{runtimeId}/ping` → `GET /ping/{pingId}` | P0 | Shipped |
+| Update (force CLI / daemon upgrade) | `POST /api/runtimes/{runtimeId}/update` → `GET /update/{updateId}` | P0 | Shipped |
+| Workspace root | `MULTICA_WORKSPACES_ROOT` (default `~/multica_workspaces`) — per-task worktree dir | P0 | Shipped |
+
+### Daemon ↔ server protocol
+
+```
+POST   /api/daemon/register           (body: daemon_id, device_info, cli_versions[])
+POST   /api/daemon/deregister
+POST   /api/daemon/heartbeat
+
+POST   /api/daemon/runtimes/{runtimeId}/tasks/claim
+GET    /api/daemon/runtimes/{runtimeId}/tasks/pending
+POST   /api/daemon/runtimes/{runtimeId}/usage         (daily token report)
+POST   /api/daemon/runtimes/{runtimeId}/ping/{pingId}/result
+POST   /api/daemon/runtimes/{runtimeId}/update/{updateId}/result
+
+GET    /api/daemon/tasks/{taskId}/status
+POST   /api/daemon/tasks/{taskId}/start
+POST   /api/daemon/tasks/{taskId}/progress
+POST   /api/daemon/tasks/{taskId}/complete
+POST   /api/daemon/tasks/{taskId}/fail
+POST   /api/daemon/tasks/{taskId}/messages
+GET    /api/daemon/tasks/{taskId}/messages
+```
+
+All daemon routes are authenticated by `mdt_` token (not JWT, not workspace header). The middleware sets the daemon identity from the token.
+
+### CLI
+
+The `multica` binary is the user-facing surface for daemons, with bonus issue / workspace commands so the CLI can be used as a scripting target.
+
+| Command | Status |
+|---|---|
+| `multica login` (browser flow) | Shipped |
+| `multica login --token` | Shipped |
+| `multica auth status / logout` | Shipped |
+| `multica daemon start [--foreground]` | Shipped |
+| `multica daemon stop / status / logs [-f] [-n N]` | Shipped |
+| `multica workspace list / get / members / watch / unwatch` | Shipped |
+| `multica issue list / get / create / update / assign / status` | Shipped |
+| `multica issue comment list / add / delete` | Shipped |
+| `multica issue runs / run-messages [--since N]` | Shipped |
+| `multica agent list` | Shipped |
+| `multica config show / set <key> <value>` | Shipped |
+| `multica version / update` | Shipped |
+| `multica --profile <name> …` (multi-server isolation) | Shipped |
+
+### Daemon config (env / flags)
+
+| Setting | Flag | Env | Default |
+|---|---|---|---|
+| Poll interval | `--poll-interval` | `MULTICA_DAEMON_POLL_INTERVAL` | `3s` |
+| Heartbeat interval | `--heartbeat-interval` | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` |
+| Agent timeout | `--agent-timeout` | `MULTICA_AGENT_TIMEOUT` | `2h` |
+| Max concurrent tasks | `--max-concurrent-tasks` | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` |
+| Daemon ID | `--daemon-id` | `MULTICA_DAEMON_ID` | hostname |
+| Device name | `--device-name` | `MULTICA_DAEMON_DEVICE_NAME` | hostname |
+| Runtime name | `--runtime-name` | `MULTICA_AGENT_RUNTIME_NAME` | `Local Agent` |
+| Workspaces root | — | `MULTICA_WORKSPACES_ROOT` | `~/multica_workspaces` |
+| Claude path | — | `MULTICA_CLAUDE_PATH` | (auto-discover) |
+| Claude model | — | `MULTICA_CLAUDE_MODEL` | (CLI default) |
+| Codex path | — | `MULTICA_CODEX_PATH` | (auto-discover) |
+| Codex model | — | `MULTICA_CODEX_MODEL` | (CLI default) |
+
+## Data model
+
+```
+daemon
+├── id, user_id, daemon_id, status, cli_version, device_info JSONB
+├── archived_at, archived_by
+├── last_heartbeat_at, created_at, updated_at
+
+daemon_workspace (M:N)
+├── daemon_id, workspace_id, enabled, created_at
+
+agent_runtime
+├── id, workspace_id, daemon_id, provider
+├── name, status (online | offline)
+├── last_heartbeat_at, cli_version, capabilities JSONB
+
+runtime_usage
+├── runtime_id, date, model
+├── input_tokens, output_tokens, cache_read_tokens, cache_write_tokens
+
+daemon_ping  / daemon_update (server-initiated, daemon-executed)
+├── id, runtime_id, status, requested_at, completed_at, result JSONB
+```
+
+## Acceptance criteria
+
+- Given a fresh daemon, when `multica daemon start` runs, then within `MULTICA_DAEMON_POLL_INTERVAL` the server shows the daemon as `online` with one runtime per detected CLI.
+- Given a daemon whose last heartbeat is older than 3 × `MULTICA_DAEMON_HEARTBEAT_INTERVAL`, then its runtimes are marked `offline` and pending tasks for those runtimes do not get re-dispatched until a new heartbeat arrives.
+- Given a user removed from a workspace, then the corresponding `daemon_workspace` rows lose access and the daemon stops polling for that workspace.
+- Given a runtime archived via the admin UI, then it no longer appears in the assignee runtime selection.
+- Given a ping initiated by the server, the daemon must report back within a fixed timeout (today: ping-specific; see `runtime_ping.go`) — otherwise the ping is `failed`.
+
+## Open questions
+
+- Should daemon-CLI mismatch (e.g. server expects `claude >= 1.5` but daemon has older) **fail the runtime registration** or just warn?
+- Should `runtime_usage` aggregation by **workspace and user** be precomputed instead of computed on the fly?
+- For workspaces with no online runtime, should the **assignee picker disable agent assignment** with a message, or allow the task to queue silently?
+- Should the **CLI emit machine-readable progress events** (e.g. JSON line on stderr) so wrappers / scripts can react?

--- a/docs/spec/features/skills.md
+++ b/docs/spec/features/skills.md
@@ -1,0 +1,99 @@
+# Skills
+
+## Problem
+
+Solving the same class of problem twice with an AI agent is waste. Most engineering work — deploying a service, running a migration, opening a PR, writing a code-review summary — has a small set of recurring patterns. If those patterns are captured once and re-attached to future agents, every successful run makes the next one cheaper. Skills are Multica's primitive for that capture.
+
+## Goals
+
+1. **First-class workspace object** — skills are versioned data, not prompt strings copy-pasted into agent config.
+2. **Markdown + bundled files** — a skill is a markdown instruction plus an optional file tree (templates, scripts, schemas).
+3. **Many-to-many attachment** — multiple agents can share a skill; an agent can carry multiple skills.
+4. **Delivered at task time** — the daemon receives the full skill payload in the task claim response, so the agent CLI has it on disk before execution.
+5. **Importable** — a `POST /api/skills/import` endpoint exists so skills can be brought in from external sources.
+
+## Non-Goals
+
+- Public marketplace / cross-workspace sharing.
+- Versioning skills with history / rollback (today the latest write wins).
+- Auto-generating a skill from a successful run.
+- Skill execution sandboxing.
+
+## Personas & user stories
+
+- *As a tech lead*, I want to write a "deploy" skill once and attach it to every agent that ships code.
+- *As an engineer*, I want to drop a `runbook.md` and `migrate.sh` into a skill and have agents pick them up.
+- *As an admin*, I want to import a skill from a known internal source (e.g. a GitHub URL).
+- *As an agent author*, I want to update a skill and have all future agent runs use the new version.
+
+## Requirements
+
+### Skill entity
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Workspace-scoped | `workspace_id` FK | P0 | Shipped |
+| Name, description | Standard fields | P0 | Shipped |
+| Markdown content | `content TEXT` | P0 | Shipped |
+| Config blob | `config JSONB` — optional skill-specific config | P0 | Shipped |
+| File tree | `skill_file` rows: `(skill_id, path, content)` | P0 | Shipped |
+| Many-to-many to agents | `agent_skill` join table | P0 | Shipped |
+
+### CRUD
+
+| Endpoint | Notes |
+|---|---|
+| `GET /api/skills` | List workspace skills |
+| `POST /api/skills` | Admin/owner only |
+| `POST /api/skills/import` | Admin/owner only — import flow (source TBD) |
+| `GET /api/skills/{id}` | Detail |
+| `PUT /api/skills/{id}` | Update markdown + config |
+| `DELETE /api/skills/{id}` | Delete |
+| `GET /api/skills/{id}/files` | List files |
+| `PUT /api/skills/{id}/files` | Upsert (path-keyed) |
+| `DELETE /api/skills/{id}/files/{fileId}` | Delete single file |
+| `GET /api/agents/{id}/skills` | List skills attached to agent |
+| `PUT /api/agents/{id}/skills` | Replace attachments (set semantics) |
+
+### Runtime delivery
+
+- When a task is claimed by a daemon, the response includes the full `AgentSkillData[]` for every skill attached to the agent.
+- The daemon materializes those skills into the worktree before invoking the CLI, in a path the CLI is configured to read (provider-dependent — Claude Code uses `.claude/`, Codex uses its own convention).
+
+### Visibility
+
+- Skills are workspace-local. There is no per-skill visibility flag.
+- Any member can read; only admin/owner can create / update / delete.
+
+## Data model
+
+```
+skill
+├── id, workspace_id, name, description
+├── content TEXT (markdown)
+├── config JSONB
+├── created_at, updated_at
+
+skill_file
+├── id, skill_id, path TEXT, content TEXT
+├── created_at, updated_at
+
+agent_skill
+├── agent_id, skill_id
+├── created_at
+```
+
+## Acceptance criteria
+
+- Given an agent with skill `deploy` attached, when a task is dispatched to that agent, then the daemon receives `deploy.content` and all `deploy.skill_file[]` rows in the task claim payload.
+- Given a skill update, when the next task starts, then the daemon receives the updated content (no caching of stale versions).
+- Given a `PUT /api/agents/{id}/skills` with `[]`, then all skill attachments are removed; the agent runs with no skills next time.
+- Given a member without admin/owner role, when they POST `/api/skills`, then the request is rejected with 403.
+
+## Open questions
+
+- **Import source** — what does `POST /api/skills/import` actually accept today? A URL? A zip? A GitHub raw link? Specify and document.
+- Should there be a **public catalog** of curated skills (analogous to Anthropic Skills) or a way to share across workspaces in the same self-host?
+- Should skill updates **emit an event** so currently-running tasks can be notified (or at minimum, the user sees "your agent is still using v1")?
+- Should skills support **dependencies on other skills**?
+- Should `config` JSONB have a **schema validator** (today it's free-form)?

--- a/docs/spec/features/tasks-and-verification.md
+++ b/docs/spec/features/tasks-and-verification.md
@@ -1,0 +1,169 @@
+# Tasks & Verification Loop
+
+## Problem
+
+When an agent is assigned an issue, the system has to (1) reliably dispatch the work to a daemon, (2) stream the agent's output back so humans can watch progress, (3) detect failure and surface it, (4) optionally enforce a verification gate before the issue is marked done. All of this must be observable per task, restartable, and cancellable.
+
+## Goals
+
+1. **Pull-based, NAT-friendly dispatch** — daemons poll, server never has to reach into a user's network.
+2. **Streaming output** — every line of agent text, tool use, and tool result is persisted and broadcast.
+3. **Lifecycle observability** — `queued → dispatched → running → completed | failed | cancelled` transitions are recorded with timestamps, errors, and a result blob.
+4. **Verification loop (optional)** — when a verifier agent is configured, the system orchestrates `criteria → executor → validator → rework` until pass / blocked.
+5. **Per-issue activity history** — every run for an issue is listed; messages can be incrementally fetched.
+
+## Non-Goals
+
+- Distributed task queues (Celery / RabbitMQ). The DB-backed queue is sufficient at current scale.
+- A generic workflow engine. The verification loop is hand-coded for this specific flow.
+- Live editing of in-progress runs.
+
+## Personas & user stories
+
+- *As an agent operator*, I want a task to be dispatched within a few seconds of assignment.
+- *As a reviewer*, I want to watch the agent's output stream as it runs.
+- *As a tech lead*, I want to cancel a runaway task with one click.
+- *As an admin*, I want failed tasks to show up in the inbox with the error message.
+- *As a tech lead*, I want acceptance criteria to be checked by a different agent before an issue is closed.
+
+## Requirements
+
+### Lifecycle
+
+| State | Set by | Meaning |
+|---|---|---|
+| `queued` | Enqueue (assignment, mention, schedule) | Awaiting a runtime to claim it. |
+| `dispatched` | Daemon `ClaimTaskByRuntime` | A runtime has the task but the agent CLI hasn't reported in yet. |
+| `running` | Daemon `POST /tasks/{id}/start` | Agent CLI is executing. `started_at` is recorded. |
+| `completed` | Daemon `POST /tasks/{id}/complete` | Success; `result JSONB` is persisted. |
+| `failed` | Daemon `POST /tasks/{id}/fail` or server timeout | `error TEXT` is persisted. |
+| `cancelled` | User `POST /issues/{id}/tasks/{taskId}/cancel` | User intent; daemon is told on next poll. |
+
+### Dispatch
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Enqueue on assign | `assignee_type=agent` triggers `enqueueTaskToAgent` | P0 | Shipped |
+| Enqueue on mention | Comment with `@AgentName` enqueues a task with `trigger_comment_id` | P0 | Shipped |
+| Enqueue on schedule | Recurring template creates the issue + enqueues a task | P0 | Shipped |
+| Dynamic runtime selection | Pick least-loaded online runtime matching `agent.providers` | P0 | Shipped |
+| Honor max concurrency | `agent.max_concurrent_tasks` is enforced at dispatch | P0 | Shipped |
+| Lifecycle guards | DB triggers prevent illegal state transitions (migration 022) | P0 | Shipped |
+| Per-task `context` JSONB | Carries `flow`, `role`, `round`, `executor_agent_id`, `verifier_agent_id`, `source_task_id` | P0 | Shipped |
+| Task session ID | `session_id` (migration 020) — opaque identifier for the agent's session | P0 | Shipped |
+| Trigger comment | `trigger_comment_id` (migration 028) — set for mention/comment-triggered tasks | P0 | Shipped |
+| Cancel | `POST /api/issues/{id}/tasks/{taskId}/cancel` | P0 | Shipped |
+
+### Streaming messages
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Append message | `POST /api/daemon/tasks/{id}/messages` — body is a list of typed messages | P0 | Shipped |
+| Message types | `text | tool_use | tool_result | error | thinking` (extensible) | P0 | Shipped |
+| Sequence number | Every message gets a monotonic `seq` for incremental fetch | P0 | Shipped |
+| List messages | `GET /api/daemon/tasks/{id}/messages?since=N` (also exposed to clients) | P0 | Shipped |
+| WS broadcast | Every appended message is broadcast on the workspace room | P0 | Shipped |
+| Progress report | `POST /api/daemon/tasks/{id}/progress` for percentage / step hints | P0 | Shipped |
+
+### Verification loop
+
+When `issue.verifier_agent_id` is set and the issue is assigned to an executor agent, the system follows the loop in [`docs/issue-verification-loop-design.md`](../../issue-verification-loop-design.md).
+
+| State | Meaning |
+|---|---|
+| `none` | Verification disabled (default) — flow is the same as today. |
+| `criteria_pending` | Verifier was asked to generate criteria; awaiting completion. |
+| `execution_pending` | Criteria are approved; executor task is queued. |
+| `validating` | Executor finished; validator is checking. |
+| `rework_pending` | Validator said `fail`; rework task is queued to the executor. |
+| `passed` | Validator said `pass`; issue may auto-move to `done` if currently `in_review`. |
+| `blocked` | Too many failed rounds (default 5) or an unrecoverable error. |
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| `verifier_agent_id` on issue | Distinct from `assignee_id`; verifier ≠ assignee | P0 | Shipped |
+| `verification_phase` state machine | Enum above, persisted | P0 | Shipped |
+| `verification_round` counter | Increments on each fail | P0 | Shipped |
+| `last_verification_result JSONB` | `{ decision, summary, failed_checks[] }` | P0 | Shipped |
+| `max_verification_rounds` per issue | Default 5 | P0 | Shipped |
+| Criteria approve / reject | `POST /api/issues/{id}/criteria/approve` and `/reject` (human gate) | P0 | Shipped |
+| Update criteria | `PUT /api/issues/{id}/criteria` | P0 | Shipped |
+| Structured prompt protocol | Agents emit JSON inside `<!--multica:criteria … -->` / `<!--multica:verification … -->` comment blocks; server parses | P0 | Shipped |
+| Per-workspace max-rounds override | — | P1 | Gap (today fixed/per-issue) |
+| Verifier identity for system comments | Verifier agent is the comment author when reporting pass/fail | P0 | Shipped |
+
+### Listing & filtering
+
+| Req | Endpoint | Priority | Status |
+|---|---|---|---|
+| Active tasks per workspace | `GET /api/tasks/active` | P0 | Shipped |
+| Active task per issue | `GET /api/issues/{id}/active-task` | P0 | Shipped |
+| Run history per issue | `GET /api/issues/{id}/task-runs` | P0 | Shipped |
+| Tasks per agent | `GET /api/agents/{id}/tasks` | P0 | Shipped |
+
+## Data model
+
+```
+agent_task_queue
+├── id, agent_id, issue_id, runtime_id
+├── status, priority
+├── trigger_comment_id (nullable)
+├── context JSONB ({flow, role, round, executor_agent_id, verifier_agent_id, source_task_id})
+├── session_id
+├── dispatched_at, started_at, completed_at
+├── result JSONB, error TEXT
+├── created_at
+
+task_message
+├── id, task_id, seq
+├── type (text | tool_use | tool_result | error | thinking)
+├── content JSONB, created_at
+
+runtime_usage
+├── runtime_id, date, model, input_tokens, output_tokens, cache_*  (see runtimes-and-daemons)
+```
+
+## API surface
+
+### Server → user
+
+```
+GET    /api/tasks/active
+GET    /api/issues/{id}/active-task
+GET    /api/issues/{id}/task-runs
+GET    /api/agents/{id}/tasks
+POST   /api/issues/{id}/tasks/{taskId}/cancel
+PUT    /api/issues/{id}/criteria
+POST   /api/issues/{id}/criteria/approve
+POST   /api/issues/{id}/criteria/reject
+```
+
+### Daemon → server (`/api/daemon/*`)
+
+```
+POST   /api/daemon/runtimes/{runtimeId}/tasks/claim
+GET    /api/daemon/runtimes/{runtimeId}/tasks/pending
+GET    /api/daemon/tasks/{taskId}/status
+POST   /api/daemon/tasks/{taskId}/start
+POST   /api/daemon/tasks/{taskId}/progress
+POST   /api/daemon/tasks/{taskId}/complete
+POST   /api/daemon/tasks/{taskId}/fail
+POST   /api/daemon/tasks/{taskId}/messages
+GET    /api/daemon/tasks/{taskId}/messages
+```
+
+## Acceptance criteria
+
+- Given a freshly enqueued task, when a daemon polls and claims it, the row moves to `dispatched` and `dispatched_at` is set.
+- Given a task that has been `running` for longer than `MULTICA_AGENT_TIMEOUT` (default 2h), the system marks it `failed` with a timeout error.
+- Given a cancelled task, the next time the daemon polls, the server returns the task as cancelled and the daemon stops the agent.
+- Given an issue with verifier configured and empty criteria, when assigned, the criteria task is enqueued (not the executor).
+- Given a validator task whose output contains `<!--multica:verification {"decision":"fail",…} -->`, when completed, the issue moves to `rework_pending` and a rework task is enqueued — unless `verification_round + 1 > max_verification_rounds`, in which case the issue moves to `blocked`.
+
+## Open questions
+
+- Should we **persist task `cancelled_by`** (user id) for audit?
+- Should validator output parsing tolerate **YAML or JSON inside fenced code blocks** in addition to comment markers?
+- Should `verification_phase = blocked` trigger an `action_required` inbox item to the workspace admins?
+- Should the executor receive the **failed_checks list** as structured context, not just text in the next prompt?
+- Should `max_verification_rounds` be configurable at the workspace level, not just per issue?

--- a/docs/spec/features/webhooks-and-integrations.md
+++ b/docs/spec/features/webhooks-and-integrations.md
@@ -1,0 +1,180 @@
+# Webhooks & External Integrations
+
+## Problem
+
+Multica's value compounds when external systems can drop work into the agent queue automatically — a Grafana alert opens an incident issue, a GitHub PR comment kicks an agent into review, a deploy failure pages an oncall agent. The system needs a clean separation between **how** an external system reaches us (transport + auth) and **what** we do with the payload (action).
+
+## Goals
+
+1. **Two clean inbound shapes**: a generic token-authenticated webhook (any external system, BYO adapter) and a GitHub App receiver (HMAC-signed, multi-event).
+2. **Adapters normalize payloads** into a flat `Data` map keyed by template variables (`{{.title}}`, `{{.labels.app}}`).
+3. **Action pipeline** lets one ingest produce multiple side effects in order — today `create_issue` is the only action type but the model supports more.
+4. **Per-webhook deduplication** so a paging burst does not create N issues.
+5. **Audit trail** for every received event (`webhook_event_log`).
+
+## Non-Goals
+
+- Outbound webhooks (Multica → external). Not in scope today.
+- A no-code webhook builder.
+- General-purpose Zapier-style automation across arbitrary SaaS endpoints.
+- Streaming GitHub events to Slack via Multica.
+
+## Personas & user stories
+
+- *As an SRE*, I want our internal alerting system to POST to Multica and create a triage issue assigned to an agent.
+- *As a tech lead*, I want our GitHub PR opens to create a Multica issue with the PR description so an agent can review it.
+- *As an admin*, I want to regenerate a webhook token without recreating the webhook.
+- *As an admin*, I want to see which incoming payloads were deduplicated.
+
+---
+
+## Part A — Generic Webhooks
+
+The full design is in [`docs/webhook-design.md`](../../webhook-design.md). Summary here.
+
+### Reception flow
+
+```
+POST /api/webhooks/{id}    (Authorization: Bearer whk_...)
+   │
+   ├─ Auth via SHA-256(token) match
+   ├─ Lookup webhook (source_type, dedup window, status)
+   ├─ Adapter.Parse(payload) → []Event   (one of: standard, oss-alert)
+   ├─ Per event:
+   │    ├─ Dedup check within window
+   │    └─ Run enabled actions in `position` order
+   │         └─ "create_issue" → Issue + assign Agent + enqueue task
+   └─ 202 Accepted
+```
+
+### Adapters
+
+| Adapter | Purpose | Output keys |
+|---|---|---|
+| `standard` | Multica's native shape — for callers that can pick their schema | `title`, `body`, `priority`, `fields.*` |
+| `oss-alert` | Prometheus AlertManager-style ingest | `title`, `body`, `alertname`, `app`, `generator_url`, `labels.*`, `annotations.*` |
+
+Each adapter declares its `Keys[]` (name + description + required flag) and an `Example()` payload — exposed via `GET /api/webhook-adapters` so the webhook-create dialog can render hints.
+
+### Actions
+
+| Type | Config keys | Status |
+|---|---|---|
+| `create_issue` | `agent_id`, `title_template`, `description_template`, `labels[]`, `dispatch_provider?`, `dispatch_daemon_id?`, `dispatch_daemon_label?` | Shipped |
+| `close_issue`, `comment` | — | Planned |
+
+Priority is **not** stored on the action; it is resolved at event time from `payload.priority` if present, otherwise `medium`.
+
+### CRUD endpoints
+
+```
+GET    /api/webhooks
+POST   /api/webhooks                          (admin)
+GET    /api/webhooks/{id}
+PUT    /api/webhooks/{id}
+DELETE /api/webhooks/{id}
+POST   /api/webhooks/{id}/regenerate-token
+GET    /api/webhooks/{id}/events              (event log; not yet surfaced in UI)
+GET    /api/webhooks/{id}/actions
+POST   /api/webhooks/{id}/actions
+PUT    /api/webhooks/{id}/actions/{actionId}
+DELETE /api/webhooks/{id}/actions/{actionId}
+GET    /api/webhook-adapters                  (registry)
+GET    /api/webhook-events                    (cross-webhook event log)
+```
+
+### Token format
+
+- `whk_` + 40 hex chars
+- Stored as `token_hash = SHA-256(token)`, with `token_prefix = first 12 chars` for display
+- Bearer auth
+
+### Deduplication
+
+- Per-webhook `dedup_window_seconds` (default 600).
+- An event with a `dedup_key` matching a recently processed one within the window is logged as `deduped` and skipped (no action run).
+
+### Issue attribution
+
+Issues created by webhooks have `creator_type = "webhook"` and `creator_id = webhook.id`. Webhook creators are not auto-subscribed (only `member` and `agent` creator types are).
+
+---
+
+## Part B — GitHub App
+
+### Capability summary
+
+| Capability | Status |
+|---|---|
+| Install GitHub App on org / repos | Shipped |
+| Receive `push`, `pull_request`, `issues`, `issue_comment` events | Shipped |
+| Per-event-type rule mapping to an agent + workspace | Shipped |
+| Templated issue creation from event payload | Shipped |
+| HMAC signature verification | Shipped |
+| Outbound to GitHub (close PR, post comment) | Not implemented |
+| Repo-level filtering | Shipped (migration 049 added `repo` to `github_event_rule`) |
+| Inbound webhook unified with generic system | Shipped (migration 050) |
+
+### Setup flow
+
+1. Admin clicks **Connect GitHub** in workspace settings.
+2. `GET /api/workspaces/{id}/github/install-url` returns the GitHub App install URL.
+3. After install, GitHub redirects to `/github/callback` (web page).
+4. Frontend posts `POST /api/workspaces/{id}/github/connect` with the install id.
+5. `GET /api/workspaces/{id}/github/status` reports connected installation + repos.
+
+### Event ingest
+
+```
+POST /api/github/events
+  ├─ Verify HMAC X-Hub-Signature-256
+  ├─ Parse webhook event type
+  ├─ Lookup workspace by installation id
+  ├─ Find matching github_event_rule (event_type, repo)
+  ├─ Apply title/description templates
+  └─ Create issue + assign agent + enqueue task
+```
+
+### Event rule entity
+
+| Field | Description |
+|---|---|
+| `id`, `workspace_id` | |
+| `event_type` | `push | pull_request | issues | issue_comment` |
+| `repo` | Repo filter (nullable = all repos) |
+| `agent_id` | Which agent to assign |
+| `title_template`, `description_template` | Go-template strings with the event payload as context |
+| `dispatch_provider`, `dispatch_daemon_id`, `dispatch_daemon_label` | Optional dispatch hints |
+
+### Disconnect
+
+`DELETE /api/workspaces/{id}/github` removes the installation link; rules remain but stop firing.
+
+---
+
+## Part C — Telegram
+
+Covered in [realtime-and-inbox.md](realtime-and-inbox.md). Summary:
+
+- **Per-user channels** — `user_notification_channel(channel_type='telegram')` linked via DM with the workspace bot.
+- **Per-workspace group chats** — `workspace.settings.telegram_group`, configured via `/api/workspaces/{id}/telegram-notifications`.
+- Inbound is **not** supported (no bot command surface today).
+
+---
+
+## Acceptance criteria (combined)
+
+- Given a generic webhook with a `create_issue` action, when an external system POSTs a valid payload, then within 1s an issue exists and a task is enqueued to the configured agent.
+- Given a webhook with `dedup_window_seconds=600`, when two payloads with the same `dedup_key` arrive 5 minutes apart, then only the first creates an issue; the second is logged as `deduped`.
+- Given a paused webhook (`status='paused'`), when a payload arrives, then the request returns 200/202 with status `filtered` and no issue is created.
+- Given an invalid bearer token, when an external system posts, then the response is 401 and no log row is written.
+- Given a GitHub App receiving a `pull_request.opened` event matching a rule, then an issue is created with the templated title and body, assigned to the configured agent.
+- Given a GitHub event whose HMAC signature does not match, then the request is rejected with 401 and no issue is created.
+
+## Open questions
+
+- When does **multi-action UI** ship? Backend supports multiple actions per webhook today; the dialog only manages one.
+- When is the **event log viewer** wired up? `GET /api/webhooks/{id}/events` exists; the frontend does not surface it yet.
+- Should we **support outbound to GitHub** (close PR, post comment)? Document the user need before building.
+- Are there **rate limits** we should enforce per webhook (currently unlimited within dedup window)?
+- Should the GitHub event rule **fall back to a default agent** when no rule matches a repo, or stay strict (no rule = drop)?

--- a/docs/spec/features/workspaces-and-auth.md
+++ b/docs/spec/features/workspaces-and-auth.md
@@ -1,0 +1,154 @@
+# Workspaces & Auth
+
+## Problem
+
+Multica is multi-tenant by default. A single deployment must support many independent teams, each with its own issues, agents, daemons, and settings. Identity must work cleanly for two distinct callers — humans (web app) and machines (CLI, daemons, webhooks) — without leaking data across tenants or forcing users to manage parallel login flows.
+
+## Goals
+
+1. **Email-first onboarding** — no password setup; users start with one OTP.
+2. **Strict tenant isolation** — every query filters by `workspace_id`; cross-workspace reads require explicit handlers.
+3. **Three caller classes**, each with the right token: humans (JWT), CLI/scripts (PAT), daemons (daemon token), inbound webhooks (webhook token).
+4. **Workspace settings as a JSONB envelope** so new integrations can land without schema migrations.
+
+## Non-Goals
+
+- SSO (SAML / OIDC) — out of scope until enterprise demand justifies it.
+- SCIM provisioning — same.
+- Per-project ACLs beyond workspace-level roles.
+- Invite flows with onboarding emails (current `CreateMember` is admin-driven, no email send).
+
+## Personas & user stories
+
+- *As a founder spinning up a new team*, I want to sign in with my email, pick a workspace name, and invite my cofounder without learning a permissions model.
+- *As an admin*, I want to add a teammate by email and pick their role.
+- *As a tech lead*, I want to demote a user from `admin` to `member` without losing their issue history.
+- *As an engineer*, I want to mint a personal access token so I can script issue creation from my CLI.
+- *As an operations engineer*, I want my daemon's token to authenticate without exposing my account JWT.
+
+## Requirements
+
+### Authentication
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Email-OTP login | `POST /auth/firebase` — Firebase-issued ID token, server creates user on first sight | P0 | Shipped |
+| Dev-bypass login | `POST /auth/dev` — gated by `DEV_AUTH_BYPASS` env flag; inert in prod | P0 | Shipped |
+| Personal access tokens (PAT) | `mul_` prefix; default 90-day TTL; CRUD via `/api/tokens` | P0 | Shipped |
+| Daemon tokens | `mdt_` prefix; long-lived; user-scoped owner | P0 | Shipped |
+| Webhook tokens | `whk_` prefix; per-webhook; SHA-256 hashed at rest | P0 | Shipped |
+| Token revocation | `DELETE /api/tokens/{id}` | P0 | Shipped |
+| JWT refresh | None today — tokens are issued at login with a fixed TTL | P1 | Gap |
+| OIDC / SSO | — | P2 | Future |
+
+### Workspaces
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Create workspace | `POST /api/workspaces` — creator becomes `owner` | P0 | Shipped |
+| Slug addressing | Routes like `/w/{slug}/issues/{id}` | P0 | Shipped |
+| Update / delete workspace | Admin / owner only | P0 | Shipped |
+| Workspace settings JSONB | Arbitrary key/value via `settings` column | P0 | Shipped |
+| Provider config | `GET/PATCH /api/workspaces/{id}/providers` — per-provider toggles, default keys | P0 | Shipped |
+| Workspace repos | Stored in `settings.repos` JSONB; consumed by daemons to set up worktrees | P0 | Shipped |
+| GitHub installation | `GET install-url`, `GET status`, `POST connect`, `DELETE` | P0 | Shipped |
+| Telegram group notifications | `GET/PUT/DELETE /api/workspaces/{id}/telegram-notifications` | P0 | Shipped |
+| Force-update all daemons | `POST /api/workspaces/{id}/update-all-daemons` (admin) | P0 | Shipped |
+| Leave workspace | `POST /api/workspaces/{id}/leave` (member self-service) | P0 | Shipped |
+
+### Members & roles
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Roles | `owner | admin | member`; check enforced via middleware | P0 | Shipped |
+| Add member | `POST /api/workspaces/{id}/members` — admin/owner only | P0 | Shipped |
+| Update / remove member | `PATCH/DELETE /members/{memberId}` — admin/owner only | P0 | Shipped |
+| Owner-only ops | `DELETE /api/workspaces/{id}` — owner only | P0 | Shipped |
+| Bot users | Synthetic members with `kind='bot'` so webhook-authored comments have a name | P0 | Shipped |
+| List bot users | `GET/POST/DELETE /api/workspaces/{id}/bot-users` (admin) | P0 | Shipped |
+| User-scoped daemons | Daemons belong to a `user_id`, not a workspace; user picks which workspaces a daemon serves | P0 | Shipped (migration 060) |
+
+### Profile & notifications
+
+| Req | Detail | Priority | Status |
+|---|---|---|---|
+| Get / update me | `GET/PATCH /api/me` | P0 | Shipped |
+| Per-user notification channels | `GET/PUT/DELETE /api/me/notification-channels/telegram` | P0 | Shipped |
+| Upload file | `POST /api/upload-file` — returns S3 URL (optionally CloudFront-signed) | P0 | Shipped |
+
+## Data model
+
+```
+user
+├── id, name, email, avatar_url, kind ('human' | 'bot'), created_at, updated_at
+member (user ↔ workspace)
+├── workspace_id, user_id, role
+workspace
+├── id, name, slug, description, settings JSONB
+daemon (user-owned)
+├── id, user_id, daemon_id, status, ...
+daemon_workspace (daemon ↔ workspace assignment)
+├── daemon_id, workspace_id, enabled
+personal_access_token
+├── id, user_id, name, token_hash, token_prefix, expires_at, last_used_at
+user_notification_channel
+├── user_id, channel_type ('telegram'), channel_id
+```
+
+## API surface (summary)
+
+```
+POST   /auth/firebase
+POST   /auth/dev                              (gated)
+
+GET    /api/me
+PATCH  /api/me
+GET    /api/me/notification-channels
+PUT    /api/me/notification-channels/telegram
+DELETE /api/me/notification-channels/telegram
+GET    /api/me/daemons
+GET    /api/me/daemons/{daemonId}/workspaces
+PUT    /api/me/daemons/{daemonId}/workspaces/{workspaceId}
+
+GET    /api/workspaces
+POST   /api/workspaces
+GET    /api/workspaces/{id}
+PUT    /api/workspaces/{id}
+DELETE /api/workspaces/{id}                    (owner)
+GET    /api/workspaces/{id}/members
+POST   /api/workspaces/{id}/members            (admin)
+PATCH  /api/workspaces/{id}/members/{memberId} (admin)
+DELETE /api/workspaces/{id}/members/{memberId} (admin)
+POST   /api/workspaces/{id}/leave
+GET    /api/workspaces/{id}/providers          (admin)
+PATCH  /api/workspaces/{id}/providers          (admin)
+GET    /api/workspaces/{id}/telegram-notifications (admin)
+PUT    /api/workspaces/{id}/telegram-notifications (admin)
+DELETE /api/workspaces/{id}/telegram-notifications (admin)
+GET    /api/workspaces/{id}/github/install-url (admin)
+GET    /api/workspaces/{id}/github/status      (admin)
+POST   /api/workspaces/{id}/github/connect     (admin)
+DELETE /api/workspaces/{id}/github             (admin)
+GET    /api/workspaces/{id}/bot-users          (admin)
+POST   /api/workspaces/{id}/bot-users          (admin)
+DELETE /api/workspaces/{id}/bot-users/{userId} (admin)
+POST   /api/workspaces/{id}/update-all-daemons (admin)
+
+GET    /api/tokens
+POST   /api/tokens
+DELETE /api/tokens/{id}
+```
+
+## Acceptance criteria
+
+- Given an email not previously seen, when the user completes Firebase OTP, then a `user` row is created and a JWT is returned.
+- Given a `member` role user, when they call any admin-gated handler, then the request returns 403.
+- Given a workspace with an owner, when the owner leaves, then the leave is blocked unless another owner exists.
+- Given a daemon registered to user A, when user B tries to enable that daemon for their workspace via the daemon-workspaces endpoint, then the request returns 403.
+
+## Open questions
+
+- Should we support **JWT refresh** so the web session can persist across short outages without re-login?
+- Should **invite-by-email** generate an email-OTP magic link, or stay admin-managed?
+- What happens to **PATs and daemon tokens** when a user is removed from their last workspace? Today they continue to work; should they be revoked?
+- Should **bot-user comments** count toward subscriber auto-add the way members do? (Today: no — only `member` and `agent` creators auto-subscribe.)

--- a/docs/spec/multica.md
+++ b/docs/spec/multica.md
@@ -1,0 +1,216 @@
+# Multica — Product PRD
+
+**Status:** Reverse-engineered from current implementation. Reflects what is shipped on `main` as of the latest commit.
+
+## 1. Product Overview
+
+**Multica is an AI-native task management platform.** Like Linear, but coding agents are first-class teammates: they get assigned issues, comment on threads, change status, create new issues, and report blockers — using the same primitives as human members.
+
+The product positions itself as **"your next 10 hires won't be human."** It is open-source (Apache 2.0), self-hostable, and built around the workflow of small 2–10 person AI-native teams who want to scale output by adding agent capacity instead of headcount.
+
+### 1.1 Three load-bearing ideas
+
+1. **Polymorphic assignees.** Every issue is owned by either a member or an agent; the UI and the API treat them symmetrically. Agents have avatars, profiles, comments, and statuses — they show up on the board the same way teammates do.
+2. **Pull-based local execution.** Agents run on user-controlled compute (a local daemon, today; cloud runtimes later). Daemons authenticate with a long-lived `mdt_` token, poll for tasks, spawn the configured CLI (`claude`, `codex`, `opencode`, `cursor`), and stream output back. No inbound connections to the user's machine.
+3. **Skills compound over time.** Reusable agent instructions and bundled files are first-class workspace objects. Solving a problem once produces a skill that all future agents inherit — "deployments," "code review," "migration scripts" become assets, not prompts you re-type.
+
+## 2. Problem Statement
+
+Small teams building with AI today copy-paste prompts into chat windows, babysit single-turn runs, and lose context as soon as the conversation ends. Two-person startups can wrangle this manually; a five-person team cannot. Existing PM tools (Linear, Jira, GitHub Projects) have no model for an "agent assignee" — there is no way to give an agent a queue of work, watch progress, or hold them accountable to acceptance criteria.
+
+The cost of not solving this is felt as **throughput per engineer**: teams adopting AI today see linear gains because each engineer is the bottleneck for orchestrating agent runs. The bet is that a workflow where agents pick up tickets autonomously, post comments, and ask for review unlocks team-level multipliers.
+
+## 3. Target Users
+
+| Persona | Why they care |
+|---|---|
+| **AI-native founding engineer (2–5 person team)** | Wants to run 3–10 agents in parallel against a backlog without sitting in front of each one. Cares about: fast onboarding, BYO-key, self-hosting, full control. |
+| **Tech lead at a 5–15 person team** | Wants visibility — who is doing what, what is blocked, who reviewed what. Cares about: board view, audit log, role-based permissions, verification gates. |
+| **Solo builder / indie hacker** | Wants a personal "agent dashboard" — fire off tasks while the agent runs on their laptop. Cares about: CLI ergonomics, no required server account, low overhead. |
+| **Skeptical reviewer** | Doesn't trust agents to ship unsupervised. Cares about: acceptance criteria, verification loops, comment history, the ability to escalate to a human. |
+
+Non-targets: large enterprises requiring SOC2 today, teams that don't use coding agents at all, no-code/low-code creators.
+
+## 4. Goals
+
+1. **Assign-and-walk-away parity.** A user should be able to assign an issue to an agent and trust the system to drive it to `done` or surface a clear blocker, without checking back every five minutes.
+2. **Symmetric primitives.** Anything a human can do on the board, an agent can do (comment, change status, create issue, react). Anything an agent can do, a human can review.
+3. **Compounding capabilities.** Skills, agent instructions, and verification criteria should grow with the team — re-running a class of task should be cheaper each time.
+4. **Self-host friendliness.** A single `make dev` should bring up a working stack on a laptop. A docker-compose file should run it in prod. No vendor lock-in.
+5. **First-class observability for agent work.** Every task has a streaming message log, a usage record, an activity timeline, and an inbox notification on failure.
+
+## 5. Non-Goals
+
+| Non-goal | Why |
+|---|---|
+| Replacing GitHub as the source of truth for code | Issues link out to PRs and branches; Multica does not host repos or run CI. |
+| Becoming a generic chat product | Threads are scoped to issues. No DMs, no channels, no `#general`. |
+| Multi-tenant SaaS at enterprise scale (SSO/SCIM/audit-export) today | Out of scope until self-hosting and small-team UX are battle-tested. |
+| Mobile-native apps | Web is a PWA (installable, offline shell). No iOS/Android binaries planned. |
+| Marketplace for skills / agents | Skills are workspace-local. No import-from-registry, no public catalog. |
+| Generic workflow automation builder | Triggers are narrow and code-defined (`on_assign`, `on_comment`, `on_mention`, schedule). No node-based automation editor. |
+| Time tracking / billing / forecasting | Multica tracks tokens and tasks per runtime; it does not project velocity or estimate dates. |
+
+## 6. Capabilities — Current State
+
+A condensed view of every capability the product exposes today. Detail and acceptance criteria live in the per-feature appendices.
+
+### 6.1 Identity & access
+- **Email-OTP login** + dev-bypass route. Users are created on first login.
+- **Personal access tokens** (`mul_` prefix, 90-day default) for CLI and API.
+- **Daemon tokens** (`mdt_` prefix) — long-lived, scoped to a daemon owner.
+- **Workspaces** with roles `owner | admin | member`. Slug-addressable.
+- **Bot users** — synthetic members so integration-generated comments have a named author.
+
+### 6.2 Issues & collaboration
+- Statuses: `backlog | todo | in_progress | in_review | done | blocked | cancelled`. Priorities: `urgent | high | medium | low | none`.
+- Polymorphic assignee (`member | agent`), polymorphic creator (`member | agent | webhook`).
+- Parent/sub-issues, board ordering (`position`), due dates, labels (many-to-many).
+- Comments are threaded (`parent_id`), support reactions, attachments, and `@mentions` of members and agents.
+- Acceptance criteria as structured JSONB with an `approved | pending` gate.
+- Reactions on issues and comments; attachments via pre-signed URLs (S3 / CloudFront).
+- Per-issue subscriber list with auto-subscription on create/assign/comment.
+
+### 6.3 Agents
+- Per-workspace, with `name`, `avatar`, `description`, `instructions`, `tools`, `triggers`, `providers`, `max_concurrent_tasks`, `visibility` (`workspace | private`, default private), `archived` flag.
+- Triggers: `on_assign`, `on_comment`, `on_mention` (mention chain prevents loops).
+- Provider list (e.g. `["claude_code", "codex"]`) with an optional default; tasks dispatch to any online runtime matching the provider.
+
+### 6.4 Tasks & verification
+- Task lifecycle: `queued → dispatched → running → completed | failed | cancelled`.
+- Streaming `TaskMessage` log per task (text, tool use, tool result, errors).
+- Optional **verification loop**: when an issue has a `verifier_agent`, the system runs `criteria → executor → validator → rework` until pass, fail, or max-rounds (`max_verification_rounds`, default 5).
+- Active-task tracking per issue; cancel endpoint.
+
+### 6.5 Runtimes & daemons
+- User-owned `daemon` (one per machine) registers and heartbeats. Daemon ↔ workspace assignment is explicit (`daemon_workspace` table) — one daemon can serve many workspaces.
+- Each daemon publishes `runtime` rows per detected agent CLI. Runtimes auto-detect `claude`, `codex`, `opencode`, `cursor` on PATH.
+- Daemon ping and update flows (server initiates → daemon executes → reports result).
+- Per-runtime daily usage tracking (token counts per model).
+- Status visibility per daemon and per runtime in **Settings → Runtimes**.
+
+### 6.6 Real-time, inbox, activity
+- WebSocket hub with rooms keyed by `workspace_id`; auto-resubscribes on reconnect.
+- Server broadcasts on every state change (issue update, comment, task progress, etc.).
+- **Inbox** for routed notifications with severities `info | attention | action_required`. Mark-read, archive, archive-completed bulk ops.
+- **Activity log** per issue, merged with comments into a unified timeline.
+- **Telegram** notifications: per-user channels (DM) and per-workspace group chat.
+
+### 6.7 Skills
+- Workspace-scoped reusable instruction objects with markdown `content`, optional `config` JSONB, and a bundled file set (`skill_file`).
+- Many-to-many attachment to agents; passed to the daemon in the task claim payload.
+- Import endpoint (`POST /api/skills/import`) exists; source of imports is not yet fixed.
+
+### 6.8 Inputs from the outside world
+- **Webhooks** — `whk_` token auth, per-webhook adapter (`standard`, `oss-alert`), per-webhook deduplication window, configurable `create_issue` actions with template substitution.
+- **GitHub App** — installation-based; receives `push | pull_request | issues | issue_comment`; per-event rules map events to an agent and a workspace; templated issue creation. Inbound only.
+- **Recurring templates** — cron-scheduled issues with timezone, optional `max_runs`, subscriber list, dispatch hints.
+
+### 6.9 Developer ergonomics
+- `multica` CLI: `login`, `daemon start|stop|status|logs`, `workspace`, `issue` CRUD/assign/status, `issue comment`, `issue runs`, `issue run-messages --since`, `agent list`, `config`, `update`.
+- Profiles (`--profile`) for running multiple daemons against different servers from one machine.
+- Self-hosting via `docker-compose.prod.yml`; releases ship multi-platform binaries via GoReleaser and Homebrew tap.
+
+### 6.10 Web app
+- Next.js 16 App Router; PWA-installable with an offline shell.
+- Routes: landing, login, dashboard (home, board, issues, my-issues, inbox, daemons, agents, skills, settings), workspace-slug-prefixed issue routes.
+- Zustand stores per feature domain; WebSocket-driven optimistic sync.
+
+## 7. Success Metrics
+
+> Targets below are **proposed** (not measured yet). Add a metrics pipeline before claiming success.
+
+### 7.1 Leading indicators (days–weeks)
+- **Agent-task pickup rate**: % of agent-assigned issues that result in at least one running task within 60 seconds. Target ≥ 95% (anything lower indicates daemon/runtime health problems).
+- **Self-host setup completion**: % of users who run `make setup && make dev` and successfully assign one issue to an agent within 30 minutes.
+- **Verification loop usage**: % of issues created with a `verifier_agent` configured. Target ≥ 20% in workspaces that have ever used the feature.
+- **Inbox actionability**: median time-to-read for `action_required` items < 1 hour during work hours.
+
+### 7.2 Lagging indicators (weeks–months)
+- **Tasks per workspace per week** — primary throughput metric. Stretch: 100/week in a 3-person team.
+- **% of workspaces with ≥ 3 active agents** in any given week.
+- **Skill reuse ratio** — average times a skill is referenced across distinct tasks. Stretch ≥ 5.
+- **Active daemons per workspace** — measures whether teams keep agents running, not just experimenting.
+
+### 7.3 Counter-metrics
+- **Task failure rate.** Should trend down as users learn the tool; sustained high failures suggest the agent UX is too permissive about bad inputs.
+- **`blocked` issue count.** Persistent growth suggests agents are stuck waiting on humans — surface in dashboards.
+
+## 8. Open Questions
+
+- **[Product] Pricing & hosted offering.** README points to `multica.ai/app` for cloud. Pricing model (per seat? per task? per agent?) is undecided.
+- **[Eng] Cloud runtimes.** `runtime_mode` was originally `local | cloud`, but the column was removed when agent decoupled from runtime. The cloud-runtime path is unbuilt — what's the milestone?
+- **[Product] Skills marketplace.** `POST /api/skills/import` exists; the import source is not specified. Is this a GitHub repo? An internal registry? Or just upload-from-zip?
+- **[Eng] WebSocket scale.** Hub is in-process; horizontal scaling will need a fanout (Redis pub/sub, NATS).
+- **[Product] Permissions granularity.** Today `owner | admin | member`. Is there demand for "viewer" or per-project ACLs?
+- **[Eng] Mobile.** PWA only — when (if ever) does native become worth it?
+- **[Legal] Telemetry & data residency.** Self-host story is strong; cloud story needs a written policy. Telegram bot token, GitHub App ID, S3 credentials all live in workspace settings JSONB — clarify which fields are PII.
+- **[Eng] Verification loop guardrails.** Default max rounds is 5; should it be workspace-configurable? What happens after `blocked`?
+
+## 9. Roadmap — Phase View
+
+The roadmap is described in phases that match what the code reveals, not by calendar quarter.
+
+### 9.1 Phase 1 — Shipped (core product)
+Everything in §6 is in `main`. The product is usable end-to-end: log in, install daemon, create agent, assign issue, watch streaming task output, review, mark done.
+
+### 9.2 Phase 2 — In-flight / observable gaps
+- **Webhook event log UI.** Backend stores `webhook_event_log`; no viewer is wired in the web app.
+- **Multi-action webhooks.** Backend supports multiple actions per webhook; the dialog only manages one default `create_issue` action.
+- **Verifier max-rounds policy.** Defaulted to 5; not yet configurable per workspace.
+- **Skill import surface.** Endpoint exists; UX for "where do skills come from" is undefined.
+- **GitHub write-back.** Today the integration is inbound only — closing an issue in Multica does not move the GitHub PR/issue.
+- **Cloud runtime support.** Schema and protocol leave room; no implementation.
+
+### 9.3 Phase 3 — Future considerations
+- **Permissions: viewer role**, per-project ACLs, agent-token scoping.
+- **Skill marketplace / cross-workspace skill sharing.**
+- **Agent SDK for custom providers** beyond claude / codex / opencode / cursor.
+- **Horizontal-scale WebSocket fanout** (Redis / NATS).
+- **Audit-export / SOC2 prep** for enterprise self-host.
+
+## 10. Architecture Reference (for context)
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────────┐
+│   Next.js    │────>│  Go Backend  │────>│   PostgreSQL     │
+│   Frontend   │<────│  (Chi + WS)  │<────│   (pgvector)     │
+└──────────────┘     └──────┬───────┘     └──────────────────┘
+                            │
+                     ┌──────┴────────┐
+                     │ Agent Daemons │  (one or many, on user machines)
+                     │ claude/codex/ │
+                     │ opencode/...  │
+                     └───────────────┘
+```
+
+| Layer | Stack |
+|---|---|
+| Frontend | Next.js 16 App Router, React 19, TypeScript, Tailwind, shadcn |
+| State | Zustand per feature; React Context only for WS lifecycle |
+| Backend | Go 1.26, Chi router, sqlc, pgx, gorilla/websocket |
+| Database | PostgreSQL 17 + pgvector |
+| Storage | S3 (attachments) + optional CloudFront signing |
+| Agent runtime | Local `multica daemon`; spawns CLI (claude / codex / opencode / cursor) |
+| Auth | JWT (HS256) for users; `whk_` for webhooks; `mdt_` for daemons; `mul_` for PATs |
+| Release | GoReleaser → GitHub Releases + Homebrew tap; Docker images to ghcr.io; deploy job runs on `v*` tag push |
+
+See [`docs/system-design.md`](../system-design.md) for the canonical data-model diagram.
+
+## 11. Glossary
+
+| Term | Definition |
+|---|---|
+| **Workspace** | Tenant boundary. All data scoped here. |
+| **Member** | User with a workspace role. |
+| **Agent** | AI worker, polymorphic assignee. |
+| **Daemon** | Local process owned by a user; hosts one or more runtimes. |
+| **Runtime** | A specific agent CLI on a specific daemon (e.g. `claude` on daemon `laptop-1`). |
+| **Provider** | Type of agent runtime (`claude_code`, `codex`, `opencode`, `cursor`). |
+| **Task** | Single execution unit on the agent task queue. |
+| **TaskMessage** | A streamed chunk of agent output (text / tool use / tool result / error). |
+| **Skill** | Reusable instruction bundle attached to an agent. |
+| **Verifier agent** | Agent configured to produce acceptance criteria and validate work. |
+| **PAT** | Personal access token (`mul_` prefix). |
+| **Daemon token** | `mdt_` prefix; authenticates a daemon to the server. |
+| **Webhook token** | `whk_` prefix; authenticates an external system to a workspace webhook endpoint. |


### PR DESCRIPTION
## Summary
- Adds a product specification under `docs/spec/`, reverse-engineered from the current `server/` and `apps/web/` implementation
- `multica.md` is the product-level PRD (vision, personas, capability inventory, proposed success metrics, phase-based roadmap, glossary)
- Nine per-feature appendices under `docs/spec/features/` cover workspaces/auth, issues, agents, tasks + verification loop, runtimes/daemons, realtime/inbox, skills, webhooks/integrations, and recurring templates
- Each requirement is annotated **shipped / partial / planned** based on code inspection; open questions are collected per feature (cloud runtimes, skills-import source, multi-action webhook UI, configurable verification max-rounds, etc.)

## Notes
- Docs-only change; no code touched.
- Source of truth remains the code — spec should be updated when they diverge.

## Test plan
- [ ] Skim `docs/spec/README.md` → `multica.md` → appendices for accuracy against current behavior
- [ ] Confirm the shipped/planned annotations match reality
- [ ] Flag any open questions that are already decided so they can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)