### PR TITLE
fix(agent): harden code agent compatibility tests

### DIFF
--- a/Dockerfile.agent-compat
+++ b/Dockerfile.agent-compat
@@ -1,6 +1,8 @@
-FROM golang:1.26-alpine
+FROM golang:1.26
 
-RUN apk add --no-cache nodejs npm curl git bash su-exec shadow
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm curl git bash ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user (Claude CLI refuses --permission-mode bypassPermissions as root).
 RUN useradd -m -s /bin/bash testuser
@@ -11,6 +13,8 @@ ARG CODEX_VERSION=0.118.0
 
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 RUN npm install -g @openai/codex@${CODEX_VERSION}
+RUN curl https://cursor.com/install -fsS | bash \
+    && ln -sf /root/.local/bin/agent /usr/local/bin/agent
 
 # OpenCode: binary from GitHub releases (skip if unavailable).
 ARG OPENCODE_VERSION=0.3.7

--- a/Dockerfile.agent-compat
+++ b/Dockerfile.agent-compat
@@ -10,10 +10,17 @@ RUN useradd -m -s /bin/bash testuser
 # Pinned CLI versions — bump these when upgrading agent CLIs.
 ARG CLAUDE_VERSION=2.1.109
 ARG CODEX_VERSION=0.118.0
+ARG CURSOR_VERSION=2026.05.16-0338208
 
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 RUN npm install -g @openai/codex@${CODEX_VERSION}
-RUN curl https://cursor.com/install -fsS | bash \
+RUN os="$(uname -s | tr '[:upper:]' '[:lower:]')" \
+    && arch="$(uname -m)" \
+    && case "$arch" in x86_64|amd64) arch=x64 ;; arm64|aarch64) arch=arm64 ;; *) exit 1 ;; esac \
+    && mkdir -p "/root/.local/share/cursor-agent/versions/${CURSOR_VERSION}" /root/.local/bin \
+    && curl -fSL "https://downloads.cursor.com/lab/${CURSOR_VERSION}/${os}/${arch}/agent-cli-package.tar.gz" \
+        | tar --strip-components=1 -xzf - -C "/root/.local/share/cursor-agent/versions/${CURSOR_VERSION}" \
+    && ln -sf "/root/.local/share/cursor-agent/versions/${CURSOR_VERSION}/cursor-agent" /root/.local/bin/agent \
     && ln -sf /root/.local/bin/agent /usr/local/bin/agent
 
 # OpenCode: binary from GitHub releases (skip if unavailable).

--- a/apps/web/app/(dashboard)/settings/_components/providers-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/providers-tab.tsx
@@ -44,7 +44,6 @@ export function ProvidersTab() {
   const user = useWorkspaceStore.getState;
 
   const [providers, setProviders] = useState<Record<string, ProviderConfig>>({});
-  const [multicaVersion, setMulticaVersion] = useState("");
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
   const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
@@ -54,7 +53,6 @@ export function ProvidersTab() {
     try {
       const config = await api.getProviderConfig(workspace.id);
       setProviders(normalizeProviders(config.providers));
-      setMulticaVersion(config.multica_target_version ?? "");
     } catch {
       toast.error("Failed to load provider configuration");
     } finally {
@@ -89,17 +87,20 @@ export function ProvidersTab() {
     if (!workspace) return;
     setSaving(true);
     try {
+      const providersForSave = Object.fromEntries(
+        Object.entries(providers).map(([key, config]) => [
+          key,
+          {
+            enabled: config.enabled,
+            api_key: config.api_key,
+          },
+        ]),
+      );
       const data: WorkspaceProviderSettings = {
-        providers,
+        providers: providersForSave,
       };
-      if (multicaVersion.trim()) {
-        data.multica_target_version = multicaVersion.trim();
-      }
       const result = await api.updateProviderConfig(workspace.id, data);
       setProviders(normalizeProviders(result.providers));
-      if (result.multica_target_version) {
-        setMulticaVersion(result.multica_target_version);
-      }
       toast.success("Provider configuration saved");
     } catch {
       toast.error("Failed to save provider configuration");
@@ -186,13 +187,10 @@ export function ProvidersTab() {
                     </div>
 
                     <div className="space-y-1.5">
-                      <Label className="text-xs">Target Version</Label>
-                      <Input
-                        value="latest"
-                        readOnly
-                        disabled
-                        className="text-xs"
-                      />
+                      <Label className="text-xs">Tested Version</Label>
+                      <p className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">
+                        {config.target_version || "Not managed"}
+                      </p>
                     </div>
                   </div>
                 )}
@@ -201,24 +199,6 @@ export function ProvidersTab() {
           );
         })}
       </div>
-
-      <Card>
-        <CardContent className="pt-4 space-y-3">
-          <p className="text-sm font-medium">Multica CLI</p>
-          <div className="space-y-1.5">
-            <Label className="text-xs">Target Version</Label>
-            <Input
-              placeholder="latest"
-              value={multicaVersion}
-              onChange={(e) => setMulticaVersion(e.target.value)}
-              className="text-xs"
-            />
-            <p className="text-xs text-muted-foreground">
-              Target multica CLI version for environment updates.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
 
       <Button onClick={handleSave} disabled={saving}>
         <Save className="h-4 w-4 mr-1" />

--- a/apps/web/features/runtimes/components/runtime-list.tsx
+++ b/apps/web/features/runtimes/components/runtime-list.tsx
@@ -238,9 +238,6 @@ export function RuntimeList({
     try {
       const config: WorkspaceProviderSettings = await api.getProviderConfig(workspace.id);
       const targets: { target: string; version: string }[] = [];
-      if (config.multica_target_version) {
-        targets.push({ target: "multica", version: config.multica_target_version });
-      }
       if (config.providers) {
         for (const [provider, pc] of Object.entries(config.providers)) {
           if (pc.enabled && pc.target_version) {
@@ -249,7 +246,7 @@ export function RuntimeList({
         }
       }
       if (targets.length === 0) {
-        toast.error("No target versions configured. Set versions in Settings > Providers.");
+        toast.error("No managed provider versions available for enabled providers.");
         return;
       }
       const result = await api.updateAllDaemons(workspace.id, targets);

--- a/apps/web/shared/types/workspace.ts
+++ b/apps/web/shared/types/workspace.ts
@@ -22,12 +22,11 @@ export interface Workspace {
 export interface ProviderConfig {
   enabled: boolean;
   api_key: string;
-  target_version: string;
+  target_version?: string;
 }
 
 export interface WorkspaceProviderSettings {
   providers?: Record<string, ProviderConfig>;
-  multica_target_version?: string;
 }
 
 export interface Member {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -143,12 +143,12 @@ export class TestApiClient {
     return this.workspaceId;
   }
 
-  async getProviderConfig(): Promise<{ providers?: Record<string, { enabled: boolean; api_key: string; target_version: string }>; multica_target_version?: string }> {
+  async getProviderConfig(): Promise<{ providers?: Record<string, { enabled: boolean; api_key: string; target_version?: string }> }> {
     const res = await this.authedFetch(`/api/workspaces/${this.workspaceId}/providers`);
     return res.json();
   }
 
-  async updateProviderConfig(data: { providers?: Record<string, { enabled: boolean; api_key: string; target_version: string }>; multica_target_version?: string }) {
+  async updateProviderConfig(data: { providers?: Record<string, { enabled: boolean; api_key: string; target_version?: string }> }) {
     const res = await this.authedFetch(`/api/workspaces/${this.workspaceId}/providers`, {
       method: "PATCH",
       body: JSON.stringify(data),

--- a/e2e/providers.spec.ts
+++ b/e2e/providers.spec.ts
@@ -49,9 +49,9 @@ test.describe("Workspace Providers", () => {
     const claudeCard = page.locator("[data-slot='card']").filter({ hasText: "Claude Code" }).first();
     await claudeCard.locator("[data-slot='switch']").click();
 
-    // API Key and Target Version fields should appear
+    // API Key and read-only tested version should appear.
     await expect(page.locator("label:has-text('API Key')").first()).toBeVisible();
-    await expect(page.locator("label:has-text('Target Version')").first()).toBeVisible();
+    await expect(page.locator("text=Tested Version").first()).toBeVisible();
 
     // Fill in an API key
     const apiKeyInput = page.locator("input[placeholder='sk-...']").first();
@@ -74,7 +74,7 @@ test.describe("Workspace Providers", () => {
     // Pre-configure a provider via API
     await api.updateProviderConfig({
       providers: {
-        claude: { enabled: true, api_key: "sk-test-disable-me", target_version: "" },
+        claude: { enabled: true, api_key: "sk-test-disable-me" },
       },
     });
 
@@ -109,33 +109,39 @@ test.describe("Workspace Providers", () => {
     expect(config).toBeDefined();
   });
 
-  test("provider config API: update and get roundtrip", async () => {
+  test("provider config API: update and get roundtrip returns repo version", async () => {
     // Set provider config
     const updated = await api.updateProviderConfig({
       providers: {
-        codex: { enabled: true, api_key: "sk-codex-test-key-1234", target_version: "0.1.0" },
+        codex: { enabled: true, api_key: "sk-codex-test-key-1234" },
       },
-      multica_target_version: "0.2.0",
     });
 
     // Response should have redacted API key
     expect(updated.providers?.codex?.enabled).toBe(true);
     expect(updated.providers?.codex?.api_key).toContain("****");
     expect(updated.providers?.codex?.api_key).toContain("1234");
-    expect(updated.providers?.codex?.target_version).toBe("0.1.0");
-    expect(updated.multica_target_version).toBe("0.2.0");
+    expect(updated.providers?.codex?.target_version).toBeTruthy();
 
     // GET should return same redacted config
     const fetched = await api.getProviderConfig();
     expect(fetched.providers?.codex?.enabled).toBe(true);
-    expect(fetched.providers?.codex?.target_version).toBe("0.1.0");
-    expect(fetched.multica_target_version).toBe("0.2.0");
+    expect(fetched.providers?.codex?.target_version).toBe(updated.providers?.codex?.target_version);
+  });
+
+  test("provider config API: rejects configured target version", async () => {
+    const res = await api.updateProviderConfig({
+      providers: {
+        codex: { enabled: true, api_key: "sk-codex-test-key-1234", target_version: "0.1.0" },
+      },
+    });
+    expect((res as Record<string, unknown>).error).toBeDefined();
   });
 
   test("provider config API: rejects unsupported provider", async () => {
     const res = await api.updateProviderConfig({
       providers: {
-        "unsupported-provider": { enabled: true, api_key: "", target_version: "" },
+        "unsupported-provider": { enabled: true, api_key: "" },
       },
     });
     // The response should indicate an error (400 status), but since updateProviderConfig
@@ -147,7 +153,7 @@ test.describe("Workspace Providers", () => {
     // Set initial key
     await api.updateProviderConfig({
       providers: {
-        claude: { enabled: true, api_key: "sk-ant-real-key-abcd", target_version: "" },
+        claude: { enabled: true, api_key: "sk-ant-real-key-abcd" },
       },
     });
 
@@ -160,13 +166,13 @@ test.describe("Workspace Providers", () => {
     // Send back with the redacted key — server should preserve the original
     await api.updateProviderConfig({
       providers: {
-        claude: { enabled: true, api_key: redactedKey, target_version: "1.0.0" },
+        claude: { enabled: true, api_key: redactedKey },
       },
     });
 
     // Verify the key is still the same (not overwritten with the redacted value)
     const after = await api.getProviderConfig();
     expect(after.providers?.claude?.api_key).toContain("abcd");
-    expect(after.providers?.claude?.target_version).toBe("1.0.0");
+    expect(after.providers?.claude?.target_version).toBe(config.providers?.claude?.target_version);
   });
 });

--- a/server/internal/codeagent/versions.go
+++ b/server/internal/codeagent/versions.go
@@ -1,0 +1,21 @@
+package codeagent
+
+// VerifiedProviderVersions are the code-agent CLI versions validated by
+// make test-agent-compat. Keep Dockerfile.agent-compat in sync when bumping.
+var VerifiedProviderVersions = map[string]string{
+	"claude": "2.1.109",
+	"codex":  "0.118.0",
+	"cursor": "2026.05.16-0338208",
+}
+
+// Version returns the repository-owned verified version for a provider.
+func Version(provider string) (string, bool) {
+	version, ok := VerifiedProviderVersions[provider]
+	return version, ok
+}
+
+// MustVersion returns the verified version or an empty string for display paths.
+func MustVersion(provider string) string {
+	version, _ := Version(provider)
+	return version
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1173,7 +1173,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		case "claude":
 			agentEnv["ANTHROPIC_API_KEY"] = apiKey
 		case "codex":
-			agentEnv["OPENAI_API_KEY"] = apiKey
+			agentEnv["CODEX_API_KEY"] = apiKey
 		case "opencode":
 			agentEnv["OPENAI_API_KEY"] = apiKey
 		case "cursor":
@@ -1187,7 +1187,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
 		if provider == "codex" || provider == "opencode" {
-			if key := agentEnv["OPENAI_API_KEY"]; key != "" {
+			key := agentEnv["OPENAI_API_KEY"]
+			if provider == "codex" {
+				key = agentEnv["CODEX_API_KEY"]
+			}
+			if key != "" {
 				execenv.WriteCodexAuth(env.CodexHome, key, d.logger)
 			}
 		}

--- a/server/internal/daemon/install.go
+++ b/server/internal/daemon/install.go
@@ -7,48 +7,44 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/nullne/multica/server/internal/codeagent"
 )
 
 // installCommand returns the shell command to install a code agent CLI.
-// If targetVersion is empty, the latest version is installed.
-func installCommand(provider, targetVersion string) (string, []string) {
+// Versions are repository-owned; targetVersion is resolved before this is called.
+func installCommand(provider, targetVersion string) (string, []string, error) {
+	if targetVersion == "" {
+		return "", nil, fmt.Errorf("no verified version configured for provider %q", provider)
+	}
+
 	switch provider {
 	case "claude":
-		pkg := "@anthropic-ai/claude-code"
-		if targetVersion != "" {
-			pkg += "@" + targetVersion
-		}
-		return "npm", []string{"install", "-g", pkg}
+		return "npm", []string{"install", "-g", "@anthropic-ai/claude-code@" + targetVersion}, nil
 	case "codex":
-		pkg := "@openai/codex"
-		if targetVersion != "" {
-			pkg += "@" + targetVersion
-		}
-		return "npm", []string{"install", "-g", pkg}
+		return "npm", []string{"install", "-g", "@openai/codex@" + targetVersion}, nil
 	case "opencode":
-		// opencode is typically installed via go install or binary download.
-		// Attempt npm first as a common method.
-		pkg := "opencode"
-		if targetVersion != "" {
-			pkg += "@" + targetVersion
-		}
-		return "npm", []string{"install", "-g", pkg}
+		return "npm", []string{"install", "-g", "opencode@" + targetVersion}, nil
 	case "cursor":
-		return "bash", []string{"-c", "curl https://cursor.com/install -fsS | bash"}
+		return "bash", []string{"-c", cursorInstallScript(targetVersion)}, nil
 	default:
-		return "", nil
+		return "", nil, fmt.Errorf("auto-install not supported for provider %q", provider)
 	}
 }
 
 // InstallProvider installs a code agent CLI for the given provider.
 // Returns the output and any error.
 func InstallProvider(ctx context.Context, provider, targetVersion string, logger *slog.Logger) (string, error) {
-	bin, args := installCommand(provider, targetVersion)
-	if bin == "" {
-		return "", fmt.Errorf("auto-install not supported for provider %q", provider)
+	resolvedVersion, err := resolveInstallVersion(provider, targetVersion)
+	if err != nil {
+		return "", err
+	}
+	bin, args, err := installCommand(provider, resolvedVersion)
+	if err != nil {
+		return "", err
 	}
 
-	logger.Info("auto-installing code agent CLI", "provider", provider, "version", targetVersion, "command", fmt.Sprintf("%s %s", bin, strings.Join(args, " ")))
+	logger.Info("auto-installing code agent CLI", "provider", provider, "version", resolvedVersion, "command", fmt.Sprintf("%s %s", bin, strings.Join(args, " ")))
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
@@ -69,4 +65,43 @@ func InstallProvider(ctx context.Context, provider, targetVersion string, logger
 // This is the same as installing with a specific version.
 func UpdateProvider(ctx context.Context, provider, targetVersion string, logger *slog.Logger) (string, error) {
 	return InstallProvider(ctx, provider, targetVersion, logger)
+}
+
+func resolveInstallVersion(provider, requested string) (string, error) {
+	version, ok := codeagent.Version(provider)
+	if !ok {
+		return "", fmt.Errorf("no verified version configured for provider %q", provider)
+	}
+	if requested != "" && requested != version {
+		return "", fmt.Errorf("provider %q version is repository-owned: requested %q, verified %q", provider, requested, version)
+	}
+	return version, nil
+}
+
+func cursorInstallScript(version string) string {
+	return fmt.Sprintf(`
+set -euo pipefail
+version=%q
+case "$(uname -s)" in
+  Linux*) os=linux ;;
+  Darwin*) os=darwin ;;
+  *) echo "unsupported operating system: $(uname -s)" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) arch=x64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+base="$HOME/.local/share/cursor-agent/versions"
+tmp="$base/.tmp-$version-$$"
+final="$base/$version"
+mkdir -p "$tmp" "$HOME/.local/bin"
+trap 'rm -rf "$tmp"' EXIT
+curl -fSL "https://downloads.cursor.com/lab/$version/$os/$arch/agent-cli-package.tar.gz" \
+  | tar --strip-components=1 -xzf - -C "$tmp"
+rm -rf "$final"
+mv "$tmp" "$final"
+ln -sf "$final/cursor-agent" "$HOME/.local/bin/agent"
+ln -sf "$final/cursor-agent" "$HOME/.local/bin/cursor-agent"
+`, version)
 }

--- a/server/internal/daemon/install_test.go
+++ b/server/internal/daemon/install_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nullne/multica/server/internal/codeagent"
+)
+
+func TestInstallCommandUsesVerifiedVersion(t *testing.T) {
+	t.Parallel()
+
+	claudeVersion, _ := codeagent.Version("claude")
+	bin, args, err := installCommand("claude", claudeVersion)
+	if err != nil {
+		t.Fatalf("installCommand: %v", err)
+	}
+	if bin != "npm" {
+		t.Fatalf("expected npm, got %q", bin)
+	}
+	if got := strings.Join(args, " "); !strings.Contains(got, "@anthropic-ai/claude-code@"+claudeVersion) {
+		t.Fatalf("expected claude install to pin %q, got %q", claudeVersion, got)
+	}
+}
+
+func TestResolveInstallVersionUsesRepoDefault(t *testing.T) {
+	t.Parallel()
+
+	version, err := resolveInstallVersion("codex", "")
+	if err != nil {
+		t.Fatalf("resolveInstallVersion: %v", err)
+	}
+	want, _ := codeagent.Version("codex")
+	if version != want {
+		t.Fatalf("expected %q, got %q", want, version)
+	}
+}
+
+func TestResolveInstallVersionRejectsOverride(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveInstallVersion("codex", "9.9.9")
+	if err == nil {
+		t.Fatal("expected error for non-repo version")
+	}
+}
+
+func TestCursorInstallCommandPinsVerifiedVersion(t *testing.T) {
+	t.Parallel()
+
+	version, _ := codeagent.Version("cursor")
+	bin, args, err := installCommand("cursor", version)
+	if err != nil {
+		t.Fatalf("installCommand: %v", err)
+	}
+	if bin != "bash" {
+		t.Fatalf("expected bash, got %q", bin)
+	}
+	if got := strings.Join(args, " "); !strings.Contains(got, `version="`+version+`"`) {
+		t.Fatalf("expected cursor install script to pin %q, got %q", version, got)
+	}
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -121,43 +121,31 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 
 	mergedProviderConfig := make(map[string]map[string]any)
 	mergeProviderConfig := func(ps WorkspaceProviderSettings) {
-		if ps.Providers == nil {
-			return
-		}
-		for k, v := range ps.Providers {
+		for k, v := range daemonProviderConfig(ps) {
 			cur := mergedProviderConfig[k]
 			if cur == nil {
-				cur = map[string]any{
-					"enabled":        v.Enabled,
-					"api_key":        v.APIKey,
-					"target_version": v.TargetVersion,
-				}
-				mergedProviderConfig[k] = cur
+				mergedProviderConfig[k] = v
 				continue
 			}
 			// Provider is "enabled across daemon" if any workspace enables it.
-			if v.Enabled {
+			if enabled, _ := v["enabled"].(bool); enabled {
 				cur["enabled"] = true
 			}
-			if cur["api_key"] == "" && v.APIKey != "" {
-				cur["api_key"] = v.APIKey
+			if cur["api_key"] == "" && v["api_key"] != "" {
+				cur["api_key"] = v["api_key"]
 			}
-			if cur["target_version"] == "" && v.TargetVersion != "" {
-				cur["target_version"] = v.TargetVersion
+			if cur["target_version"] == "" && v["target_version"] != "" {
+				cur["target_version"] = v["target_version"]
 			}
 		}
 	}
 
 	workspaceRegs := make([]WorkspaceRegistration, 0, len(memberWorkspaces))
-	var multicaTargetVersion string
 
 	for _, ws := range memberWorkspaces {
 		wsID := ws.ID
 		_, enabled := enabledByWorkspace[uuidToString(wsID)]
 		ps := parseProviderSettings(ws.Settings)
-		if multicaTargetVersion == "" && ps.MulticaTargetVersion != "" {
-			multicaTargetVersion = ps.MulticaTargetVersion
-		}
 		mergeProviderConfig(ps)
 
 		runtimeResp, err := h.projectDaemonRuntimes(r.Context(), daemon, req, ps, wsID)
@@ -174,16 +162,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			repos = []RepoData{}
 		}
 
-		wsProviderConfig := make(map[string]map[string]any)
-		if ps.Providers != nil {
-			for k, v := range ps.Providers {
-				wsProviderConfig[k] = map[string]any{
-					"enabled":        v.Enabled,
-					"api_key":        v.APIKey,
-					"target_version": v.TargetVersion,
-				}
-			}
-		}
+		wsProviderConfig := daemonProviderConfig(ps)
 
 		workspaceRegs = append(workspaceRegs, WorkspaceRegistration{
 			WorkspaceID:    uuidToString(wsID),
@@ -209,10 +188,9 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 	)
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"daemon":                 daemonToResponse(daemon),
-		"workspaces":             workspaceRegs,
-		"provider_config":        mergedProviderConfig,
-		"multica_target_version": multicaTargetVersion,
+		"daemon":          daemonToResponse(daemon),
+		"workspaces":      workspaceRegs,
+		"provider_config": mergedProviderConfig,
 	})
 }
 
@@ -400,25 +378,20 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			ps := parseProviderSettings(ws.Settings)
-			for k, v := range ps.Providers {
+			for k, v := range daemonProviderConfig(ps) {
 				cur := merged[k]
 				if cur == nil {
-					cur = map[string]any{
-						"enabled":        v.Enabled,
-						"api_key":        v.APIKey,
-						"target_version": v.TargetVersion,
-					}
-					merged[k] = cur
+					merged[k] = v
 					continue
 				}
-				if v.Enabled {
+				if enabled, _ := v["enabled"].(bool); enabled {
 					cur["enabled"] = true
 				}
-				if cur["api_key"] == "" && v.APIKey != "" {
-					cur["api_key"] = v.APIKey
+				if cur["api_key"] == "" && v["api_key"] != "" {
+					cur["api_key"] = v["api_key"]
 				}
-				if cur["target_version"] == "" && v.TargetVersion != "" {
-					cur["target_version"] = v.TargetVersion
+				if cur["target_version"] == "" && v["target_version"] != "" {
+					cur["target_version"] = v["target_version"]
 				}
 			}
 		}

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nullne/multica/server/internal/auth"
+	"github.com/nullne/multica/server/internal/codeagent"
 	"github.com/nullne/multica/server/internal/events"
 	"github.com/nullne/multica/server/internal/realtime"
 	whpkg "github.com/nullne/multica/server/internal/webhook"
@@ -2707,7 +2708,8 @@ func TestRuntimeVisibilityRespectsAssignmentAndMembership(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	req = wsMemberRequest("POST", "/api/runtimes/"+runtimeID+"/update", map[string]any{"target_version": "1.2.3"})
+	codexVersion, _ := codeagent.Version("codex")
+	req = wsMemberRequest("POST", "/api/runtimes/"+runtimeID+"/update", map[string]any{"target_version": codexVersion})
 	req = withURLParam(req, "runtimeId", runtimeID)
 	testHandler.InitiateUpdate(w, req)
 	if w.Code != http.StatusOK {

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/nullne/multica/server/internal/codeagent"
 	db "github.com/nullne/multica/server/pkg/db/generated"
 )
 
@@ -209,6 +210,10 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.TargetVersion == "" {
 		writeError(w, http.StatusBadRequest, "target_version is required")
+		return
+	}
+	if verified, ok := codeagent.Version(rt.Provider); ok && req.TargetVersion != verified {
+		writeError(w, http.StatusBadRequest, "target_version is repository-owned")
 		return
 	}
 

--- a/server/internal/handler/workspace_providers.go
+++ b/server/internal/handler/workspace_providers.go
@@ -2,10 +2,12 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/nullne/multica/server/internal/codeagent"
 	"github.com/nullne/multica/server/internal/logger"
 	"github.com/nullne/multica/server/pkg/protocol"
 )
@@ -31,7 +33,7 @@ type WorkspaceProviderSettings struct {
 var SupportedProviders = []string{"claude", "codex", "opencode", "cursor"}
 
 // defaultProviderSettings returns the JSON bytes for the default workspace
-// settings with cursor enabled out of the box.
+// provider settings. Target versions are repository-owned and are not stored.
 func defaultProviderSettings() []byte {
 	b, _ := json.Marshal(WorkspaceProviderSettings{
 		Providers: map[string]ProviderConfig{
@@ -92,29 +94,46 @@ func mergeProviderSettingsIntoWorkspace(raw []byte, ps WorkspaceProviderSettings
 		}
 		full["providers"] = b
 	}
-	if ps.MulticaTargetVersion != "" {
-		b, err := json.Marshal(ps.MulticaTargetVersion)
-		if err != nil {
-			return nil, err
-		}
-		full["multica_target_version"] = b
-	}
+	delete(full, "multica_target_version")
 	return json.Marshal(full)
 }
 
 // redactProviderSettings returns a copy with API keys masked for safe API responses.
 func redactProviderSettings(ps WorkspaceProviderSettings) WorkspaceProviderSettings {
 	out := WorkspaceProviderSettings{
-		MulticaTargetVersion: ps.MulticaTargetVersion,
+		Providers: make(map[string]ProviderConfig, len(SupportedProviders)),
 	}
-	if ps.Providers != nil {
-		out.Providers = make(map[string]ProviderConfig, len(ps.Providers))
-		for k, v := range ps.Providers {
-			out.Providers[k] = ProviderConfig{
-				Enabled:       v.Enabled,
-				APIKey:        redactAPIKey(v.APIKey),
-				TargetVersion: v.TargetVersion,
-			}
+	for _, provider := range SupportedProviders {
+		cfg := ProviderConfig{}
+		if ps.Providers != nil {
+			cfg = ps.Providers[provider]
+		}
+		cfg.APIKey = redactAPIKey(cfg.APIKey)
+		cfg.TargetVersion = codeagent.MustVersion(provider)
+		out.Providers[provider] = cfg
+	}
+	return out
+}
+
+func rejectConfiguredTargetVersions(ps WorkspaceProviderSettings) error {
+	if ps.MulticaTargetVersion != "" {
+		return fmt.Errorf("multica_target_version is repository-owned")
+	}
+	for provider, cfg := range ps.Providers {
+		if cfg.TargetVersion != "" {
+			return fmt.Errorf("provider %s target_version is repository-owned", provider)
+		}
+	}
+	return nil
+}
+
+func daemonProviderConfig(ps WorkspaceProviderSettings) map[string]map[string]any {
+	out := make(map[string]map[string]any)
+	for provider, cfg := range ps.Providers {
+		out[provider] = map[string]any{
+			"enabled":        cfg.Enabled,
+			"api_key":        cfg.APIKey,
+			"target_version": codeagent.MustVersion(provider),
 		}
 	}
 	return out
@@ -157,6 +176,10 @@ func (h *Handler) UpdateWorkspaceProviders(w http.ResponseWriter, r *http.Reques
 				return
 			}
 		}
+	}
+	if err := rejectConfiguredTargetVersions(req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(id))
@@ -251,6 +274,10 @@ func (h *Handler) UpdateAllDaemons(w http.ResponseWriter, r *http.Request) {
 	for _, d := range daemons {
 		daemonUUID := uuidToString(d.ID)
 		for _, target := range req.Targets {
+			if verified, ok := codeagent.Version(target.Target); ok && target.Version != verified {
+				writeError(w, http.StatusBadRequest, "target_version is repository-owned")
+				return
+			}
 			if _, err := h.UpdateStore.CreateForDaemon(daemonUUID, target.Target, target.Version); err != nil {
 				slog.Debug("skip update", "daemon_id", daemonUUID, "target", target.Target, "error", err)
 				continue

--- a/server/internal/handler/workspace_providers_test.go
+++ b/server/internal/handler/workspace_providers_test.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nullne/multica/server/internal/codeagent"
+)
+
+func TestRedactProviderSettingsReturnsRepoVersions(t *testing.T) {
+	t.Parallel()
+
+	out := redactProviderSettings(WorkspaceProviderSettings{
+		Providers: map[string]ProviderConfig{
+			"codex": {Enabled: true, APIKey: "sk-test-1234"},
+		},
+	})
+
+	codex := out.Providers["codex"]
+	if !codex.Enabled {
+		t.Fatal("expected codex enabled")
+	}
+	if !strings.Contains(codex.APIKey, "1234") {
+		t.Fatalf("expected redacted API key to retain suffix, got %q", codex.APIKey)
+	}
+	want, _ := codeagent.Version("codex")
+	if codex.TargetVersion != want {
+		t.Fatalf("expected codex target_version %q, got %q", want, codex.TargetVersion)
+	}
+
+	claude := out.Providers["claude"]
+	want, _ = codeagent.Version("claude")
+	if claude.TargetVersion != want {
+		t.Fatalf("expected claude target_version %q, got %q", want, claude.TargetVersion)
+	}
+}
+
+func TestRejectConfiguredTargetVersions(t *testing.T) {
+	t.Parallel()
+
+	err := rejectConfiguredTargetVersions(WorkspaceProviderSettings{
+		Providers: map[string]ProviderConfig{
+			"codex": {Enabled: true, TargetVersion: "0.1.0"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected target_version to be rejected")
+	}
+}
+
+func TestMergeProviderSettingsRemovesMulticaTargetVersion(t *testing.T) {
+	t.Parallel()
+
+	merged, err := mergeProviderSettingsIntoWorkspace(
+		[]byte(`{"multica_target_version":"0.1.0","other":true}`),
+		WorkspaceProviderSettings{Providers: map[string]ProviderConfig{}},
+	)
+	if err != nil {
+		t.Fatalf("mergeProviderSettingsIntoWorkspace: %v", err)
+	}
+	if strings.Contains(string(merged), "multica_target_version") {
+		t.Fatalf("expected multica_target_version to be removed, got %s", merged)
+	}
+}

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -287,7 +287,7 @@ type claudeLogEntry struct {
 }
 
 type claudeMessageContent struct {
-	Role    string             `json:"role"`
+	Role    string               `json:"role"`
 	Content []claudeContentBlock `json:"content"`
 }
 
@@ -319,7 +319,23 @@ func trySend(ch chan<- Message, msg Message) {
 }
 
 func buildEnv(extra map[string]string) []string {
-	env := os.Environ()
+	return buildEnvOmitting(extra)
+}
+
+func buildEnvOmitting(extra map[string]string, omittedKeys ...string) []string {
+	omit := make(map[string]bool, len(omittedKeys))
+	for _, key := range omittedKeys {
+		omit[key] = true
+	}
+
+	env := make([]string, 0, len(os.Environ())+len(extra))
+	for _, item := range os.Environ() {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && omit[key] {
+			continue
+		}
+		env = append(env, item)
+	}
 	for k, v := range extra {
 		env = append(env, k+"="+v)
 	}

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -218,6 +218,28 @@ func TestBuildEnvNilExtras(t *testing.T) {
 	}
 }
 
+func TestBuildEnvOmittingSkipsSystemEnv(t *testing.T) {
+	t.Setenv("OMIT_ME", "system")
+
+	env := buildEnvOmitting(map[string]string{"KEEP_ME": "extra"}, "OMIT_ME")
+	for _, item := range env {
+		if item == "OMIT_ME=system" {
+			t.Fatal("expected OMIT_ME to be omitted")
+		}
+	}
+	if !containsEnv(env, "KEEP_ME=extra") {
+		t.Fatal("expected KEEP_ME extra env var")
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, item := range env {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
 
 func mustMarshal(t *testing.T, v any) json.RawMessage {
 	t.Helper()

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -36,7 +36,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
-	cmd.Env = buildEnv(b.cfg.Env)
+	cmd.Env = buildEnvOmitting(b.cfg.Env, "OPENAI_API_KEY")
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -143,19 +143,19 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 		// 2. Start thread
 		threadResult, err := c.request(runCtx, "thread/start", map[string]any{
-			"model":                    nilIfEmpty(opts.Model),
-			"modelProvider":            nil,
-			"profile":                  nil,
-			"cwd":                      opts.Cwd,
-			"approvalPolicy":           nil,
-			"sandbox":                  "workspace-write",
-			"config":                   nil,
-			"baseInstructions":         nil,
-			"developerInstructions":    nilIfEmpty(opts.SystemPrompt),
-			"compactPrompt":            nil,
-			"includeApplyPatchTool":    nil,
-			"experimentalRawEvents":    false,
-			"persistExtendedHistory":   true,
+			"model":                  nilIfEmpty(opts.Model),
+			"modelProvider":          nil,
+			"profile":                nil,
+			"cwd":                    opts.Cwd,
+			"approvalPolicy":         nil,
+			"sandbox":                "workspace-write",
+			"config":                 nil,
+			"baseInstructions":       nil,
+			"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
+			"compactPrompt":          nil,
+			"includeApplyPatchTool":  nil,
+			"experimentalRawEvents":  true,
+			"persistExtendedHistory": true,
 		})
 		if err != nil {
 			finalStatus = "failed"
@@ -191,7 +191,17 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		// Wait for turn completion or context cancellation
 		select {
 		case aborted := <-turnDone:
-			if aborted {
+			c.mu.Lock()
+			turnStatus := c.lastTurnStatus
+			turnError := c.lastError
+			c.mu.Unlock()
+			if turnStatus == "failed" {
+				finalStatus = "failed"
+				finalError = turnError
+				if finalError == "" {
+					finalError = "codex turn failed"
+				}
+			} else if aborted {
 				finalStatus = "aborted"
 				finalError = "turn was aborted"
 			}
@@ -235,19 +245,22 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 // ── codexClient: JSON-RPC 2.0 transport ──
 
 type codexClient struct {
-	cfg       Config
-	stdin     interface{ Write([]byte) (int, error) }
-	mu        sync.Mutex
-	nextID    int
-	pending   map[int]*pendingRPC
-	threadID  string
-	turnID    string
-	onMessage func(Message)
+	cfg        Config
+	stdin      interface{ Write([]byte) (int, error) }
+	mu         sync.Mutex
+	nextID     int
+	pending    map[int]*pendingRPC
+	threadID   string
+	turnID     string
+	onMessage  func(Message)
 	onTurnDone func(aborted bool)
 
 	notificationProtocol string // "unknown", "legacy", "raw"
 	turnStarted          bool
 	completedTurnIDs     map[string]bool
+	emittedText          bool
+	lastTurnStatus       string
+	lastError            string
 	// pendingCommands maps itemId → command string captured from
 	// item/commandExecution/requestApproval, which is the only place
 	// Codex includes the raw command text in the raw v2 protocol.
@@ -454,7 +467,8 @@ func (c *codexClient) handleNotification(raw map[string]json.RawMessage) {
 	if c.notificationProtocol != "legacy" {
 		if c.notificationProtocol == "unknown" &&
 			(method == "turn/started" || method == "turn/completed" ||
-				method == "thread/started" || strings.HasPrefix(method, "item/")) {
+				method == "thread/started" || method == "error" ||
+				strings.HasPrefix(method, "item/") || method == "rawResponseItem/completed") {
 			c.notificationProtocol = "raw"
 		}
 
@@ -475,9 +489,7 @@ func (c *codexClient) handleEvent(msg map[string]any) {
 		}
 	case "agent_message":
 		text, _ := msg["message"].(string)
-		if text != "" && c.onMessage != nil {
-			c.onMessage(Message{Type: MessageText, Content: text})
-		}
+		c.emitText(text)
 	case "exec_command_begin":
 		callID, _ := msg["call_id"].(string)
 		command, _ := msg["command"].(string)
@@ -531,6 +543,16 @@ func (c *codexClient) handleEvent(msg map[string]any) {
 
 func (c *codexClient) handleRawNotification(method string, params map[string]any) {
 	switch method {
+	case "error":
+		if msg := extractNestedString(params, "error", "message"); msg != "" {
+			c.mu.Lock()
+			c.lastError = msg
+			c.mu.Unlock()
+			if c.onMessage != nil {
+				c.onMessage(Message{Type: MessageError, Content: msg})
+			}
+		}
+
 	case "turn/started":
 		c.turnStarted = true
 		if turnID := extractNestedString(params, "turn", "id"); turnID != "" {
@@ -545,6 +567,14 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 		status := extractNestedString(params, "turn", "status")
 		aborted := status == "cancelled" || status == "canceled" ||
 			status == "aborted" || status == "interrupted"
+		errorMessage := extractNestedString(params, "turn", "error", "message")
+
+		c.mu.Lock()
+		c.lastTurnStatus = status
+		if errorMessage != "" {
+			c.lastError = errorMessage
+		}
+		c.mu.Unlock()
 
 		if c.completedTurnIDs == nil {
 			c.completedTurnIDs = map[string]bool{}
@@ -567,6 +597,10 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 				c.onTurnDone(false)
 			}
 		}
+
+	case "item/agentMessage/delta":
+		delta, _ := params["delta"].(string)
+		c.emitText(delta)
 
 	default:
 		if strings.HasPrefix(method, "item/") {
@@ -635,8 +669,8 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 
 	case method == "item/completed" && itemType == "agentMessage":
 		text, _ := item["text"].(string)
-		if text != "" && c.onMessage != nil {
-			c.onMessage(Message{Type: MessageText, Content: text})
+		if !c.emittedText {
+			c.emitText(text)
 		}
 		phase, _ := item["phase"].(string)
 		if phase == "final_answer" && c.turnStarted {
@@ -645,6 +679,14 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 			}
 		}
 	}
+}
+
+func (c *codexClient) emitText(text string) {
+	if text == "" || c.onMessage == nil {
+		return
+	}
+	c.emittedText = true
+	c.onMessage(Message{Type: MessageText, Content: text})
 }
 
 // ── Helpers ──

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -350,6 +350,33 @@ func TestCodexRawTurnCompletedAborted(t *testing.T) {
 	}
 }
 
+func TestCodexRawTurnCompletedFailedCapturesError(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	var done bool
+	c.onTurnDone = func(aborted bool) {
+		done = true
+		if aborted {
+			t.Fatal("expected aborted=false for failed status")
+		}
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-3","status":"failed","error":{"message":"bad auth"}}}}`)
+
+	if !done {
+		t.Fatal("expected onTurnDone for failed status")
+	}
+	if c.lastTurnStatus != "failed" {
+		t.Fatalf("expected lastTurnStatus failed, got %q", c.lastTurnStatus)
+	}
+	if c.lastError != "bad auth" {
+		t.Fatalf("expected lastError bad auth, got %q", c.lastError)
+	}
+}
+
 func TestCodexRawItemCommandExecution(t *testing.T) {
 	t.Parallel()
 
@@ -432,6 +459,47 @@ func TestCodexRawItemAgentMessageFinalAnswer(t *testing.T) {
 	}
 	if !turnDone {
 		t.Fatal("expected onTurnDone for final_answer")
+	}
+}
+
+func TestCodexRawAgentMessageDelta(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	var gotText string
+	c.onMessage = func(msg Message) {
+		if msg.Type == MessageText {
+			gotText += msg.Content
+		}
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"msg-1","delta":"4"}}`)
+
+	if gotText != "4" {
+		t.Fatalf("expected text delta '4', got %q", gotText)
+	}
+}
+
+func TestCodexRawAgentMessageFinalDoesNotDuplicateDelta(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	var gotText string
+	c.onMessage = func(msg Message) {
+		if msg.Type == MessageText {
+			gotText += msg.Content
+		}
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"msg-1","delta":"4"}}`)
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"agentMessage","id":"msg-1","text":"4","phase":"final_answer"}}}`)
+
+	if gotText != "4" {
+		t.Fatalf("expected text to be emitted once, got %q", gotText)
 	}
 }
 

--- a/server/pkg/agent/compat_test.go
+++ b/server/pkg/agent/compat_test.go
@@ -4,9 +4,12 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -14,7 +17,7 @@ import (
 // agentKeyEnv maps agent type to the environment variable holding the API key.
 var agentKeyEnv = map[string]string{
 	"claude":   "ANTHROPIC_API_KEY",
-	"codex":    "OPENAI_API_KEY",
+	"codex":    "CODEX_API_KEY or OPENAI_API_KEY",
 	"opencode": "OPENAI_API_KEY",
 	"cursor":   "CURSOR_API_KEY",
 }
@@ -44,7 +47,7 @@ func requireAgent(t *testing.T, agentType string) Config {
 	t.Helper()
 
 	envName := agentKeyEnv[agentType]
-	key := os.Getenv(envName)
+	key := providerAPIKey(agentType)
 	if key == "" {
 		t.Skipf("skipping %s: %s not set", agentType, envName)
 	}
@@ -80,8 +83,8 @@ func buildAgentEnv(agentType string) map[string]string {
 			env["ANTHROPIC_API_KEY"] = key
 		}
 	case "codex":
-		if key := os.Getenv("OPENAI_API_KEY"); key != "" {
-			env["OPENAI_API_KEY"] = key
+		if key := providerAPIKey(agentType); key != "" {
+			env["CODEX_API_KEY"] = key
 		}
 	case "opencode":
 		if key := os.Getenv("OPENAI_API_KEY"); key != "" {
@@ -94,6 +97,18 @@ func buildAgentEnv(agentType string) map[string]string {
 	}
 
 	return env
+}
+
+func providerAPIKey(agentType string) string {
+	switch agentType {
+	case "codex":
+		if key := os.Getenv("CODEX_API_KEY"); key != "" {
+			return key
+		}
+		return os.Getenv("OPENAI_API_KEY")
+	default:
+		return os.Getenv(agentKeyEnv[agentType])
+	}
 }
 
 // drainSession reads all messages and the final result from a session.
@@ -136,6 +151,7 @@ func runCompatTest(t *testing.T, agentType string) {
 
 	cfg := requireAgent(t, agentType)
 	cfg.Env = buildAgentEnv(agentType)
+	configureAgentAuth(t, agentType, cfg.Env)
 
 	backend, err := New(agentType, cfg)
 	if err != nil {
@@ -169,7 +185,10 @@ func runCompatTest(t *testing.T, agentType string) {
 		t.Errorf("Result.DurationMs = %d, expected > 0", result.DurationMs)
 	}
 	if result.Output == "" {
-		t.Logf("WARNING: Result.Output is empty (agent completed but produced no captured text)")
+		t.Fatal("Result.Output is empty; agent completed but produced no captured text")
+	}
+	if !strings.Contains(result.Output, "4") {
+		t.Fatalf("Result.Output = %q, expected it to contain %q", result.Output, "4")
 	}
 
 	// --- Validate Messages ---
@@ -185,6 +204,24 @@ func runCompatTest(t *testing.T, agentType string) {
 
 	t.Logf("%s: %d messages, result.Status=%s, output=%q",
 		agentType, len(msgs), result.Status, truncate(result.Output, 100))
+}
+
+func configureAgentAuth(t *testing.T, agentType string, env map[string]string) {
+	t.Helper()
+	if agentType != "codex" {
+		return
+	}
+	key := env["CODEX_API_KEY"]
+	if key == "" {
+		return
+	}
+	codexHome := t.TempDir()
+	authPath := filepath.Join(codexHome, "auth.json")
+	content := fmt.Sprintf(`{"auth_mode":"apikey","OPENAI_API_KEY":%q}`, key)
+	if err := os.WriteFile(authPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write codex auth: %v", err)
+	}
+	env["CODEX_HOME"] = codexHome
 }
 
 func truncate(s string, n int) string {


### PR DESCRIPTION
## Summary
- Require agent compatibility tests to capture non-empty output for the live prompt.
- Align Codex auth/env handling with daemon execution and parse current app-server message/error events.
- Install Cursor Agent CLI in the compatibility test image so Cursor runs in `make test-agent-compat`.
- Move verified code-agent versions into repository-owned defaults and expose them read-only in provider settings.
- Use repo-owned versions for daemon provider installs/updates and reject workspace-configured provider target versions.

## Test plan
- `go test ./pkg/agent ./internal/daemon`
- `go test ./internal/codeagent ./internal/daemon ./internal/handler`
- `pnpm --filter @multica/web typecheck`
- `make test-agent-compat`
- `make test`

Note: OpenCode compatibility remains skipped because the pinned release URL still does not install an `opencode` binary.