### PR TITLE
feat(agent): add model catalog defaults

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -39,6 +39,7 @@ import type {
   AgentTrigger,
   AgentTriggerType,
   AgentTask,
+  ProviderConfig,
   CreateAgentRequest,
   UpdateAgentRequest,
 } from "@/shared/types";
@@ -121,6 +122,25 @@ const SUPPORTED_PROVIDERS = [
   { key: "cursor", label: "Cursor" },
 ] as const;
 
+function providerLabel(provider: string): string {
+  return SUPPORTED_PROVIDERS.find((p) => p.key === provider)?.label ?? provider;
+}
+
+function normalizeProviderConfig(raw: Record<string, ProviderConfig> | undefined): Record<string, ProviderConfig> {
+  if (!raw) return {};
+  const out: Record<string, ProviderConfig> = {};
+  for (const [key, config] of Object.entries(raw)) {
+    out[key] = {
+      enabled: config.enabled ?? false,
+      api_key: config.api_key ?? "",
+      target_version: config.target_version ?? "",
+      default_model: config.default_model ?? "",
+      supported_models: config.supported_models ?? [],
+    };
+  }
+  return out;
+}
+
 function CreateAgentDialog({
   onClose,
   onCreate,
@@ -128,11 +148,29 @@ function CreateAgentDialog({
   onClose: () => void;
   onCreate: (data: CreateAgentRequest) => Promise<void>;
 }) {
+  const workspace = useWorkspaceStore((s) => s.workspace);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [selectedProviders, setSelectedProviders] = useState<string[]>([SUPPORTED_PROVIDERS[0].key]);
+  const [defaultProvider, setDefaultProvider] = useState<string | null>(SUPPORTED_PROVIDERS[0].key);
+  const [defaultModel, setDefaultModel] = useState<string | null>(null);
+  const [providerConfig, setProviderConfig] = useState<Record<string, ProviderConfig>>({});
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
   const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (!workspace) return;
+    api.getProviderConfig(workspace.id)
+      .then((config) => setProviderConfig(normalizeProviderConfig(config.providers)))
+      .catch(() => setProviderConfig({}));
+  }, [workspace]);
+
+  const defaultProviderModels = defaultProvider
+    ? providerConfig[defaultProvider]?.supported_models ?? []
+    : [];
+  const catalogDefaultModel = defaultProvider
+    ? providerConfig[defaultProvider]?.default_model ?? ""
+    : "";
 
   const handleSubmit = async () => {
     if (!name.trim() || selectedProviders.length === 0) return;
@@ -142,6 +180,8 @@ function CreateAgentDialog({
         name: name.trim(),
         description: description.trim(),
         providers: selectedProviders,
+        default_provider: defaultProvider,
+        default_model: defaultModel,
         visibility,
         triggers: [
           { id: generateId(), type: "on_assign", enabled: true, config: {} },
@@ -199,13 +239,17 @@ function CreateAgentDialog({
                   <button
                     key={p.key}
                     type="button"
-                    onClick={() =>
-                      setSelectedProviders((prev) =>
-                        selected
-                          ? prev.filter((k) => k !== p.key)
-                          : [...prev, p.key],
-                      )
-                    }
+                    onClick={() => {
+                      const next = selected
+                        ? selectedProviders.filter((k) => k !== p.key)
+                        : [...selectedProviders, p.key];
+                      if (next.length === 0) return;
+                      setSelectedProviders(next);
+                      if (defaultProvider && !next.includes(defaultProvider)) {
+                        setDefaultProvider(next[0] ?? null);
+                        setDefaultModel(null);
+                      }
+                    }}
                     className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
                       selected
                         ? "border-primary bg-primary/5"
@@ -221,6 +265,62 @@ function CreateAgentDialog({
               Select one or more providers. Tasks will be dispatched to any online environment.
             </p>
           </div>
+
+          <div>
+            <Label className="text-xs text-muted-foreground">Default Provider</Label>
+            <div className="mt-1.5 flex gap-2 flex-wrap">
+              {selectedProviders.map((provider) => (
+                <button
+                  key={provider}
+                  type="button"
+                  onClick={() => {
+                    setDefaultProvider(provider);
+                    setDefaultModel(null);
+                  }}
+                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                    defaultProvider === provider
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:bg-muted"
+                  }`}
+                >
+                  <span className="font-medium">{providerLabel(provider)}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {defaultProvider && defaultProviderModels.length > 0 && (
+            <div>
+              <Label className="text-xs text-muted-foreground">Default Model</Label>
+              <div className="mt-1.5 flex gap-2 flex-wrap">
+                <button
+                  type="button"
+                  onClick={() => setDefaultModel(null)}
+                  className={`rounded-lg border px-3 py-2 font-mono text-xs transition-colors ${
+                    defaultModel === null
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:bg-muted"
+                  }`}
+                >
+                  {catalogDefaultModel ? `Tested default (${catalogDefaultModel})` : "Provider default"}
+                </button>
+                {defaultProviderModels.map((model) => (
+                  <button
+                    key={model}
+                    type="button"
+                    onClick={() => setDefaultModel(model)}
+                    className={`rounded-lg border px-3 py-2 font-mono text-xs transition-colors ${
+                      defaultModel === model
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:bg-muted"
+                    }`}
+                  >
+                    {model}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           <div>
             <Label className="text-xs text-muted-foreground">Visibility</Label>
@@ -1283,8 +1383,10 @@ function SettingsTab({
   const [codeAccess, setCodeAccess] = useState(agent.github_code_access ?? "read");
   const [providers, setProviders] = useState<string[]>(agent.providers ?? []);
   const [defaultProvider, setDefaultProvider] = useState<string | null>(agent.default_provider ?? null);
+  const [defaultModel, setDefaultModel] = useState<string | null>(agent.default_model ?? null);
   const [defaultDaemonId, setDefaultDaemonId] = useState<string | null>(agent.default_daemon_id ?? null);
   const [maxConcurrentTasks, setMaxConcurrentTasks] = useState<string>(String(agent.max_concurrent_tasks ?? 6));
+  const [providerConfig, setProviderConfig] = useState<Record<string, ProviderConfig>>({});
   const [saving, setSaving] = useState(false);
   const { upload, uploading } = useFileUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1294,6 +1396,20 @@ function SettingsTab({
   useEffect(() => {
     if (workspace) fetchAllRuntimes();
   }, [workspace, fetchAllRuntimes]);
+
+  useEffect(() => {
+    if (!workspace) return;
+    api.getProviderConfig(workspace.id)
+      .then((config) => setProviderConfig(normalizeProviderConfig(config.providers)))
+      .catch(() => setProviderConfig({}));
+  }, [workspace]);
+
+  const defaultProviderModels = defaultProvider
+    ? providerConfig[defaultProvider]?.supported_models ?? []
+    : [];
+  const catalogDefaultModel = defaultProvider
+    ? providerConfig[defaultProvider]?.default_model ?? ""
+    : "";
 
   const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -1318,6 +1434,7 @@ function SettingsTab({
     codeAccess !== (agent.github_code_access ?? "read") ||
     JSON.stringify(providers) !== JSON.stringify(agent.providers ?? []) ||
     defaultProvider !== (agent.default_provider ?? null) ||
+    defaultModel !== (agent.default_model ?? null) ||
     defaultDaemonId !== (agent.default_daemon_id ?? null) ||
     parsedMaxConcurrentTasks !== (agent.max_concurrent_tasks ?? 6);
 
@@ -1332,7 +1449,7 @@ function SettingsTab({
     }
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), description, visibility, providers, github_code_access: codeAccess as Agent["github_code_access"], default_provider: defaultProvider, default_daemon_id: defaultDaemonId, max_concurrent_tasks: parsedMaxConcurrentTasks });
+      await onSave({ name: name.trim(), description, visibility, providers, github_code_access: codeAccess as Agent["github_code_access"], default_provider: defaultProvider, default_model: defaultModel, default_daemon_id: defaultDaemonId, max_concurrent_tasks: parsedMaxConcurrentTasks });
       toast.success("Settings saved");
     } catch {
       toast.error("Failed to save settings");
@@ -1476,6 +1593,7 @@ function SettingsTab({
                   if (next.length === 0) return;
                   if (defaultProvider && !next.includes(defaultProvider)) {
                     setDefaultProvider(null);
+                    setDefaultModel(null);
                   }
                   setProviders(next);
                 }}
@@ -1505,7 +1623,10 @@ function SettingsTab({
             <button
               key={provider}
               type="button"
-              onClick={() => setDefaultProvider(provider)}
+              onClick={() => {
+                setDefaultProvider(provider);
+                setDefaultModel(null);
+              }}
               className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
                 defaultProvider === provider
                   ? "border-primary bg-primary/5"
@@ -1518,7 +1639,10 @@ function SettingsTab({
           {defaultProvider && (
             <button
               type="button"
-              onClick={() => setDefaultProvider(null)}
+              onClick={() => {
+                setDefaultProvider(null);
+                setDefaultModel(null);
+              }}
               className="flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
             >
               Clear
@@ -1526,6 +1650,42 @@ function SettingsTab({
           )}
         </div>
       </div>
+
+      {defaultProvider && defaultProviderModels.length > 0 && (
+        <div>
+          <Label className="text-xs text-muted-foreground">Default Model</Label>
+          <p className="text-xs text-muted-foreground mt-0.5 mb-1.5">
+            Tasks use this model when dispatched through the default provider.
+          </p>
+          <div className="mt-1.5 flex gap-2 flex-wrap">
+            <button
+              type="button"
+              onClick={() => setDefaultModel(null)}
+              className={`rounded-lg border px-3 py-2 font-mono text-xs transition-colors ${
+                defaultModel === null
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:bg-muted"
+              }`}
+            >
+              {catalogDefaultModel ? `Tested default (${catalogDefaultModel})` : "Provider default"}
+            </button>
+            {defaultProviderModels.map((model) => (
+              <button
+                key={model}
+                type="button"
+                onClick={() => setDefaultModel(model)}
+                className={`rounded-lg border px-3 py-2 font-mono text-xs transition-colors ${
+                  defaultModel === model
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:bg-muted"
+                }`}
+              >
+                {model}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div>
         <Label className="text-xs text-muted-foreground">Default Environment</Label>
@@ -1666,6 +1826,11 @@ function AgentDetail({
             {agent.providers?.length > 0 && (
               <span className="flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
                 {agent.providers.join(", ")}
+              </span>
+            )}
+            {agent.default_model && (
+              <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-muted-foreground">
+                {agent.default_model}
               </span>
             )}
             {(!agent.default_provider || !agent.default_daemon_id) && (

--- a/apps/web/app/(dashboard)/settings/_components/providers-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/providers-tab.tsx
@@ -23,6 +23,8 @@ const emptyConfig = (): ProviderConfig => ({
   enabled: false,
   api_key: "",
   target_version: "",
+  default_model: "",
+  supported_models: [],
 });
 
 function normalizeProviders(raw: Record<string, ProviderConfig> | undefined): Record<string, ProviderConfig> {
@@ -33,6 +35,8 @@ function normalizeProviders(raw: Record<string, ProviderConfig> | undefined): Re
       enabled: v.enabled ?? false,
       api_key: v.api_key ?? "",
       target_version: v.target_version ?? "",
+      default_model: v.default_model ?? "",
+      supported_models: v.supported_models ?? [],
     };
   }
   return out;
@@ -192,6 +196,29 @@ export function ProvidersTab() {
                         {config.target_version || "Not managed"}
                       </p>
                     </div>
+
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">Default Model</Label>
+                      <p className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">
+                        {config.default_model || "Provider default"}
+                      </p>
+                    </div>
+
+                    {config.supported_models && config.supported_models.length > 0 && (
+                      <div className="space-y-1.5">
+                        <Label className="text-xs">Supported Models</Label>
+                        <div className="flex flex-wrap gap-1.5">
+                          {config.supported_models.map((model) => (
+                            <span
+                              key={model}
+                              className="rounded-md bg-muted px-2 py-1 font-mono text-xs text-muted-foreground"
+                            >
+                              {model}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
               </CardContent>

--- a/apps/web/features/issues/components/pickers/agent-dispatch-confirm.test.tsx
+++ b/apps/web/features/issues/components/pickers/agent-dispatch-confirm.test.tsx
@@ -11,6 +11,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     workspace_id: "ws-1",
     providers: ["claude"],
     default_provider: null,
+    default_model: null,
     name: "Claude Agent",
     description: "",
     instructions: "",

--- a/apps/web/features/issues/utils/dispatch.test.ts
+++ b/apps/web/features/issues/utils/dispatch.test.ts
@@ -8,6 +8,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     workspace_id: "ws-1",
     providers: ["claude"],
     default_provider: null,
+    default_model: null,
     name: "Agent",
     description: "",
     instructions: "",

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -85,6 +85,8 @@ export interface AgentTask {
   result: unknown;
   error: string | null;
   created_at: string;
+  requested_model?: string;
+  observed_model?: string;
   /** Comment that triggered this run; absent/null when triggered by the issue itself. */
   trigger_comment_id?: string | null;
 }
@@ -94,6 +96,7 @@ export interface Agent {
   workspace_id: string;
   providers: string[];
   default_provider: string | null;
+  default_model: string | null;
   name: string;
   description: string;
   instructions: string;
@@ -120,6 +123,7 @@ export interface CreateAgentRequest {
   avatar_url?: string;
   providers: string[];
   default_provider?: string | null;
+  default_model?: string | null;
   visibility?: AgentVisibility;
   tools?: AgentTool[];
   triggers?: AgentTrigger[];
@@ -135,6 +139,7 @@ export interface UpdateAgentRequest {
   avatar_url?: string;
   providers?: string[];
   default_provider?: string | null;
+  default_model?: string | null;
   visibility?: AgentVisibility;
   status?: AgentStatus;
   tools?: AgentTool[];

--- a/apps/web/shared/types/workspace.ts
+++ b/apps/web/shared/types/workspace.ts
@@ -23,6 +23,8 @@ export interface ProviderConfig {
   enabled: boolean;
   api_key: string;
   target_version?: string;
+  default_model?: string;
+  supported_models?: string[];
 }
 
 export interface WorkspaceProviderSettings {

--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -50,6 +50,7 @@ export const mockAgents: Agent[] = [
     workspace_id: "ws-1",
     providers: ["claude"],
     default_provider: null,
+    default_model: null,
     name: "Claude Agent",
     description: "",
     instructions: "",

--- a/e2e/providers.spec.ts
+++ b/e2e/providers.spec.ts
@@ -122,17 +122,26 @@ test.describe("Workspace Providers", () => {
     expect(updated.providers?.codex?.api_key).toContain("****");
     expect(updated.providers?.codex?.api_key).toContain("1234");
     expect(updated.providers?.codex?.target_version).toBeTruthy();
+    expect(updated.providers?.codex?.default_model).toBeTruthy();
+    expect(updated.providers?.codex?.supported_models ?? []).toContain(updated.providers?.codex?.default_model);
 
     // GET should return same redacted config
     const fetched = await api.getProviderConfig();
     expect(fetched.providers?.codex?.enabled).toBe(true);
     expect(fetched.providers?.codex?.target_version).toBe(updated.providers?.codex?.target_version);
+    expect(fetched.providers?.codex?.default_model).toBe(updated.providers?.codex?.default_model);
   });
 
-  test("provider config API: rejects configured target version", async () => {
+  test("provider config API: rejects repository-owned catalog fields", async () => {
     const res = await api.updateProviderConfig({
       providers: {
-        codex: { enabled: true, api_key: "sk-codex-test-key-1234", target_version: "0.1.0" },
+        codex: {
+          enabled: true,
+          api_key: "sk-codex-test-key-1234",
+          target_version: "0.1.0",
+          default_model: "gpt-5.2-codex",
+          supported_models: ["gpt-5.2-codex"],
+        },
       },
     });
     expect((res as Record<string, unknown>).error).toBeDefined();

--- a/server/internal/codeagent/versions.go
+++ b/server/internal/codeagent/versions.go
@@ -1,11 +1,43 @@
 package codeagent
 
+// ProviderCatalogEntry describes the repository-owned code-agent CLI and model
+// choices validated by make test-agent-compat.
+type ProviderCatalogEntry struct {
+	Version         string
+	DefaultModel    string
+	SupportedModels []string
+}
+
+// ProviderCatalog is the repository-owned catalog of code-agent CLI versions
+// and model choices. Keep Dockerfile.agent-compat in sync when bumping versions.
+var ProviderCatalog = map[string]ProviderCatalogEntry{
+	"claude": {
+		Version:         "2.1.109",
+		DefaultModel:    "sonnet",
+		SupportedModels: []string{"sonnet", "opus", "haiku"},
+	},
+	"codex": {
+		Version:         "0.118.0",
+		DefaultModel:    "gpt-5.2-codex",
+		SupportedModels: []string{"gpt-5.2-codex", "gpt-5.1-codex", "gpt-5"},
+	},
+	"cursor": {
+		Version:         "2026.05.16-0338208",
+		DefaultModel:    "gpt-5.5",
+		SupportedModels: []string{"gpt-5.5", "gpt-5.3-codex", "claude-4.6-sonnet"},
+	},
+	"opencode": {
+		DefaultModel:    "gpt-5.2-codex",
+		SupportedModels: []string{"gpt-5.2-codex", "gpt-5"},
+	},
+}
+
 // VerifiedProviderVersions are the code-agent CLI versions validated by
 // make test-agent-compat. Keep Dockerfile.agent-compat in sync when bumping.
 var VerifiedProviderVersions = map[string]string{
-	"claude": "2.1.109",
-	"codex":  "0.118.0",
-	"cursor": "2026.05.16-0338208",
+	"claude": ProviderCatalog["claude"].Version,
+	"codex":  ProviderCatalog["codex"].Version,
+	"cursor": ProviderCatalog["cursor"].Version,
 }
 
 // Version returns the repository-owned verified version for a provider.
@@ -18,4 +50,30 @@ func Version(provider string) (string, bool) {
 func MustVersion(provider string) string {
 	version, _ := Version(provider)
 	return version
+}
+
+// Catalog returns the repository-owned catalog entry for a provider.
+func Catalog(provider string) (ProviderCatalogEntry, bool) {
+	entry, ok := ProviderCatalog[provider]
+	return entry, ok
+}
+
+// MustCatalog returns the catalog entry or a zero-value entry for display paths.
+func MustCatalog(provider string) ProviderCatalogEntry {
+	entry, _ := Catalog(provider)
+	return entry
+}
+
+// SupportsModel reports whether model is in the provider's tested model list.
+func SupportsModel(provider, model string) bool {
+	entry, ok := Catalog(provider)
+	if !ok {
+		return false
+	}
+	for _, supported := range entry.SupportedModels {
+		if supported == model {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/codeagent/versions_test.go
+++ b/server/internal/codeagent/versions_test.go
@@ -1,0 +1,34 @@
+package codeagent
+
+import "testing"
+
+func TestCatalogIncludesModelsForVerifiedProviders(t *testing.T) {
+	t.Parallel()
+
+	for provider, version := range VerifiedProviderVersions {
+		entry, ok := Catalog(provider)
+		if !ok {
+			t.Fatalf("Catalog(%q) missing", provider)
+		}
+		if entry.Version != version {
+			t.Fatalf("Catalog(%q).Version = %q, want %q", provider, entry.Version, version)
+		}
+		if entry.DefaultModel == "" {
+			t.Fatalf("Catalog(%q).DefaultModel is empty", provider)
+		}
+		if len(entry.SupportedModels) == 0 {
+			t.Fatalf("Catalog(%q).SupportedModels is empty", provider)
+		}
+		if !SupportsModel(provider, entry.DefaultModel) {
+			t.Fatalf("Catalog(%q) default model %q is not supported", provider, entry.DefaultModel)
+		}
+	}
+}
+
+func TestSupportsModelRejectsUnknownModel(t *testing.T) {
+	t.Parallel()
+
+	if SupportsModel("codex", "not-a-tested-model") {
+		t.Fatal("unexpected support for unknown model")
+	}
+}

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -86,7 +86,7 @@ func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages
 	}, nil)
 }
 
-func (c *Client) CompleteTask(ctx context.Context, taskID, output, prURL, branchName, sessionID, workDir string) error {
+func (c *Client) CompleteTask(ctx context.Context, taskID, output, prURL, branchName, sessionID, workDir, requestedModel, observedModel string) error {
 	body := map[string]any{"output": output}
 	if prURL != "" {
 		body["pr_url"] = prURL
@@ -99,6 +99,12 @@ func (c *Client) CompleteTask(ctx context.Context, taskID, output, prURL, branch
 	}
 	if workDir != "" {
 		body["work_dir"] = workDir
+	}
+	if requestedModel != "" {
+		body["requested_model"] = requestedModel
+	}
+	if observedModel != "" {
+		body["observed_model"] = observedModel
 	}
 	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/tasks/%s/complete", taskID), body, nil)
 }
@@ -143,7 +149,7 @@ type PendingPing struct {
 // PendingUpdate represents a CLI update request from the server.
 type PendingUpdate struct {
 	ID            string `json:"id"`
-	Target        string `json:"target"`         // "multica", "claude", "codex", etc.
+	Target        string `json:"target"` // "multica", "claude", "codex", etc.
 	TargetVersion string `json:"target_version"`
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1086,7 +1086,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 		}
 	default:
 		taskLog.Info("task completed", "status", result.Status)
-		if err := d.client.CompleteTask(ctx, task.ID, result.Comment, result.PRURL, result.BranchName, result.SessionID, result.WorkDir); err != nil {
+		if err := d.client.CompleteTask(ctx, task.ID, result.Comment, result.PRURL, result.BranchName, result.SessionID, result.WorkDir, result.RequestedModel, result.ObservedModel); err != nil {
 			taskLog.Error("complete task failed, falling back to fail", "error", err)
 			if failErr := d.client.FailTask(ctx, task.ID, fmt.Sprintf("complete task failed: %s", err.Error())); failErr != nil {
 				taskLog.Error("fail task fallback also failed", "error", failErr)
@@ -1215,10 +1215,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	}
 
 	reused := task.PriorWorkDir != "" && env.WorkDir == task.PriorWorkDir
+	model := executionModel(task, entry)
 	taskLog.Info("starting agent",
 		"provider", provider,
 		"workdir", env.WorkDir,
-		"model", entry.Model,
+		"model", model,
 		"reused", reused,
 	)
 	if task.PriorSessionID != "" {
@@ -1229,7 +1230,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 
 	session, err := backend.Execute(ctx, prompt, agent.ExecOptions{
 		Cwd:             env.WorkDir,
-		Model:           entry.Model,
+		Model:           model,
 		Timeout:         d.cfg.AgentTimeout,
 		ResumeSessionID: task.PriorSessionID,
 	})
@@ -1382,10 +1383,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 			return TaskResult{}, fmt.Errorf("%s returned empty output", provider)
 		}
 		return TaskResult{
-			Status:    "completed",
-			Comment:   result.Output,
-			SessionID: result.SessionID,
-			WorkDir:   env.WorkDir,
+			Status:         "completed",
+			Comment:        result.Output,
+			SessionID:      result.SessionID,
+			WorkDir:        env.WorkDir,
+			RequestedModel: model,
 		}, nil
 	case "timeout":
 		return TaskResult{}, fmt.Errorf("%s timed out after %s", provider, d.cfg.AgentTimeout)
@@ -1396,6 +1398,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		}
 		return TaskResult{Status: "blocked", Comment: errMsg}, nil
 	}
+}
+
+func executionModel(task Task, entry AgentEntry) string {
+	if task.RequestedModel != "" {
+		return task.RequestedModel
+	}
+	return entry.Model
 }
 
 func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {

--- a/server/internal/daemon/model_test.go
+++ b/server/internal/daemon/model_test.go
@@ -1,0 +1,21 @@
+package daemon
+
+import "testing"
+
+func TestExecutionModelPrefersTaskRequestedModel(t *testing.T) {
+	t.Parallel()
+
+	got := executionModel(Task{RequestedModel: "gpt-5.2-codex"}, AgentEntry{Model: "gpt-5"})
+	if got != "gpt-5.2-codex" {
+		t.Fatalf("executionModel = %q, want task requested model", got)
+	}
+}
+
+func TestExecutionModelFallsBackToAgentEntryModel(t *testing.T) {
+	t.Parallel()
+
+	got := executionModel(Task{}, AgentEntry{Model: "gpt-5"})
+	if got != "gpt-5" {
+		t.Fatalf("executionModel = %q, want agent entry model", got)
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -34,9 +34,11 @@ type Task struct {
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // Claude session ID from a previous task on this issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
 	TriggerCommentID string         `json:"trigger_comment_id,omitempty"` // comment that triggered this task
-	GitHubToken      string `json:"github_token,omitempty"`
-	GitHubCodeAccess string `json:"github_code_access,omitempty"`
-	ProviderAPIKey   string `json:"provider_api_key,omitempty"` // workspace-level API key
+	GitHubToken      string         `json:"github_token,omitempty"`
+	GitHubCodeAccess string         `json:"github_code_access,omitempty"`
+	ProviderAPIKey   string         `json:"provider_api_key,omitempty"` // workspace-level API key
+	RequestedModel   string         `json:"requested_model,omitempty"`
+	ObservedModel    string         `json:"observed_model,omitempty"`
 }
 
 // AgentData holds agent details returned by the claim endpoint.
@@ -62,11 +64,13 @@ type SkillFileData struct {
 
 // TaskResult is the outcome of executing a task.
 type TaskResult struct {
-	Status     string `json:"status"`
-	Comment    string `json:"comment"`
-	PRURL      string `json:"pr_url,omitempty"`
-	BranchName string `json:"branch_name,omitempty"`
-	EnvType    string `json:"env_type,omitempty"`
-	SessionID  string `json:"session_id,omitempty"` // Claude session ID for future resumption
-	WorkDir    string `json:"work_dir,omitempty"`   // working directory used during execution
+	Status         string `json:"status"`
+	Comment        string `json:"comment"`
+	PRURL          string `json:"pr_url,omitempty"`
+	BranchName     string `json:"branch_name,omitempty"`
+	EnvType        string `json:"env_type,omitempty"`
+	SessionID      string `json:"session_id,omitempty"` // Claude session ID for future resumption
+	WorkDir        string `json:"work_dir,omitempty"`   // working directory used during execution
+	RequestedModel string `json:"requested_model,omitempty"`
+	ObservedModel  string `json:"observed_model,omitempty"`
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/nullne/multica/server/internal/codeagent"
 	gh "github.com/nullne/multica/server/internal/github"
 	"github.com/nullne/multica/server/internal/logger"
 	"github.com/nullne/multica/server/internal/service"
@@ -20,6 +21,7 @@ type AgentResponse struct {
 	WorkspaceID        string          `json:"workspace_id"`
 	Providers          []string        `json:"providers"`
 	DefaultProvider    *string         `json:"default_provider"`
+	DefaultModel       *string         `json:"default_model"`
 	Name               string          `json:"name"`
 	Description        string          `json:"description"`
 	Instructions       string          `json:"instructions"`
@@ -66,6 +68,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		WorkspaceID:        uuidToString(a.WorkspaceID),
 		Providers:          providers,
 		DefaultProvider:    textToPtr(a.DefaultProvider),
+		DefaultModel:       textToPtr(a.DefaultModel),
 		Name:               a.Name,
 		Description:        a.Description,
 		Instructions:       a.Instructions,
@@ -113,9 +116,11 @@ type AgentTaskResponse struct {
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
-	GitHubToken      string `json:"github_token,omitempty"`
-	GitHubCodeAccess string `json:"github_code_access,omitempty"`
-	ProviderAPIKey   string `json:"provider_api_key,omitempty"` // workspace-level API key for the provider
+	GitHubToken      string         `json:"github_token,omitempty"`
+	GitHubCodeAccess string         `json:"github_code_access,omitempty"`
+	ProviderAPIKey   string         `json:"provider_api_key,omitempty"` // workspace-level API key for the provider
+	RequestedModel   string         `json:"requested_model,omitempty"`
+	ObservedModel    string         `json:"observed_model,omitempty"`
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon
@@ -136,7 +141,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 	if t.Context != nil {
 		json.Unmarshal(t.Context, &contextData)
 	}
-	return AgentTaskResponse{
+	resp := AgentTaskResponse{
 		ID:               uuidToString(t.ID),
 		AgentID:          uuidToString(t.AgentID),
 		RuntimeID:        uuidToString(t.RuntimeID),
@@ -152,6 +157,13 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
 	}
+	if t.RequestedModel.Valid {
+		resp.RequestedModel = t.RequestedModel.String
+	}
+	if t.ObservedModel.Valid {
+		resp.ObservedModel = t.ObservedModel.String
+	}
+	return resp
 }
 
 func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
@@ -230,6 +242,7 @@ type CreateAgentRequest struct {
 	Providers          []string `json:"providers"`
 	Provider           string   `json:"provider"` // deprecated: single provider, use providers
 	DefaultProvider    *string  `json:"default_provider"`
+	DefaultModel       *string  `json:"default_model"`
 	Visibility         string   `json:"visibility"`
 	Tools              any      `json:"tools"`
 	Triggers           any      `json:"triggers"`
@@ -267,6 +280,10 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.DefaultProvider != nil && *req.DefaultProvider != "" && !containsString(providers, *req.DefaultProvider) {
 		writeError(w, http.StatusBadRequest, "default_provider must be one of providers")
+		return
+	}
+	defaultModel, ok := validateDefaultModel(w, req.DefaultProvider, req.DefaultModel)
+	if !ok {
 		return
 	}
 
@@ -309,6 +326,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Triggers:           triggers,
 		GithubCodeAccess:   req.GitHubCodeAccess,
 		DefaultProvider:    ptrToText(req.DefaultProvider),
+		DefaultModel:       defaultModel,
 		DefaultDaemonID:    parseOptionalUUID(req.DefaultDaemonID),
 		MaxConcurrentTasks: maxConcurrentTasks,
 	})
@@ -335,6 +353,7 @@ type UpdateAgentRequest struct {
 	AvatarURL          *string  `json:"avatar_url"`
 	Providers          []string `json:"providers"`
 	DefaultProvider    *string  `json:"default_provider"`
+	DefaultModel       *string  `json:"default_model"`
 	Visibility         *string  `json:"visibility"`
 	Status             *string  `json:"status"`
 	Tools              any      `json:"tools"`
@@ -390,6 +409,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	params := db.UpdateAgentParams{
 		ID:              parseUUID(id),
 		DefaultProvider: agent.DefaultProvider,
+		DefaultModel:    agent.DefaultModel,
 		DefaultDaemonID: agent.DefaultDaemonID,
 	}
 	if req.Name != nil {
@@ -408,11 +428,14 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		params.Providers = req.Providers
 	}
 	effectiveProviders := agent.Providers
+	effectiveDefaultProvider := agent.DefaultProvider
 	if len(req.Providers) > 0 {
 		effectiveProviders = req.Providers
 		if params.DefaultProvider.Valid && !containsString(effectiveProviders, params.DefaultProvider.String) {
 			params.DefaultProvider = pgtype.Text{Valid: false}
+			params.DefaultModel = pgtype.Text{Valid: false}
 		}
+		effectiveDefaultProvider = params.DefaultProvider
 	}
 	if req.Visibility != nil {
 		params.Visibility = pgtype.Text{String: *req.Visibility, Valid: true}
@@ -442,8 +465,22 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			params.DefaultProvider = pgtype.Text{String: *req.DefaultProvider, Valid: true}
+			effectiveDefaultProvider = params.DefaultProvider
 		} else {
 			params.DefaultProvider = pgtype.Text{Valid: false}
+			params.DefaultModel = pgtype.Text{Valid: false}
+			effectiveDefaultProvider = params.DefaultProvider
+		}
+	}
+	if _, ok := rawFields["default_model"]; ok {
+		validated, valid := validateDefaultModel(w, textToPtr(effectiveDefaultProvider), req.DefaultModel)
+		if !valid {
+			return
+		}
+		params.DefaultModel = validated
+	} else if params.DefaultModel.Valid {
+		if !effectiveDefaultProvider.Valid || !codeagent.SupportsModel(effectiveDefaultProvider.String, params.DefaultModel.String) {
+			params.DefaultModel = pgtype.Text{Valid: false}
 		}
 	}
 	if _, ok := rawFields["default_daemon_id"]; ok {
@@ -551,6 +588,21 @@ func containsString(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+func validateDefaultModel(w http.ResponseWriter, defaultProvider, defaultModel *string) (pgtype.Text, bool) {
+	if defaultModel == nil || *defaultModel == "" {
+		return pgtype.Text{Valid: false}, true
+	}
+	if defaultProvider == nil || *defaultProvider == "" {
+		writeError(w, http.StatusBadRequest, "default_model requires default_provider")
+		return pgtype.Text{}, false
+	}
+	if !codeagent.SupportsModel(*defaultProvider, *defaultModel) {
+		writeError(w, http.StatusBadRequest, "default_model must be supported by default_provider")
+		return pgtype.Text{}, false
+	}
+	return pgtype.Text{String: *defaultModel, Valid: true}, true
 }
 
 func (h *Handler) ListAgentTasks(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/nullne/multica/server/internal/codeagent"
 	db "github.com/nullne/multica/server/pkg/db/generated"
 )
 
@@ -162,6 +163,228 @@ func TestUpdateAgent_ProvidersChangeClearsStaleDefaultProvider(t *testing.T) {
 	}
 	if len(updated.Providers) != 1 || updated.Providers[0] != "claude" {
 		t.Fatalf("expected providers to be updated to [claude], got %#v", updated.Providers)
+	}
+}
+
+func TestCreateAgent_DefaultModelMustBelongToDefaultProvider(t *testing.T) {
+	catalog, _ := codeagent.Catalog("codex")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":             "default-model-agent",
+		"providers":        []string{"codex"},
+		"default_provider": "codex",
+		"default_model":    catalog.DefaultModel,
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp AgentResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID)
+	})
+
+	if resp.DefaultModel == nil || *resp.DefaultModel != catalog.DefaultModel {
+		t.Fatalf("expected default_model %q, got %#v", catalog.DefaultModel, resp.DefaultModel)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":             "invalid-default-model-agent",
+		"providers":        []string{"codex"},
+		"default_provider": "codex",
+		"default_model":    "not-a-tested-model",
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateAgent invalid model: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAgent_ProvidersChangeClearsStaleDefaultModel(t *testing.T) {
+	catalog, _ := codeagent.Catalog("codex")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":             "default-model-reset-agent",
+		"providers":        []string{"claude", "codex"},
+		"default_provider": "codex",
+		"default_model":    catalog.DefaultModel,
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created AgentResponse
+	json.NewDecoder(w.Body).Decode(&created)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, created.ID)
+	})
+
+	w = httptest.NewRecorder()
+	req = newRequest("PATCH", "/api/agents/"+created.ID, map[string]any{
+		"providers": []string{"claude"},
+	})
+	req = withURLParam(req, "id", created.ID)
+	testHandler.UpdateAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateAgent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated AgentResponse
+	json.NewDecoder(w.Body).Decode(&updated)
+	if updated.DefaultModel != nil {
+		t.Fatalf("expected default_model to be cleared, got %#v", updated.DefaultModel)
+	}
+}
+
+func TestCreateIssue_FreezesAgentDefaultModelOnTask(t *testing.T) {
+	catalog, _ := codeagent.Catalog("codex")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":             "task-model-agent",
+		"providers":        []string{"codex"},
+		"default_provider": "codex",
+		"default_model":    catalog.DefaultModel,
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var agentResp AgentResponse
+	json.NewDecoder(w.Body).Decode(&agentResp)
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "Task freezes model",
+		"status":        "in_progress",
+		"assignee_type": "agent",
+		"assignee_id":   agentResp.ID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var issueResp IssueResponse
+	json.NewDecoder(w.Body).Decode(&issueResp)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentResp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueResp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentResp.ID)
+	})
+
+	var requestedModel string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT requested_model FROM agent_task_queue WHERE agent_id = $1 AND issue_id = $2`,
+		agentResp.ID, issueResp.ID,
+	).Scan(&requestedModel); err != nil {
+		t.Fatalf("query task requested_model: %v", err)
+	}
+	if requestedModel != catalog.DefaultModel {
+		t.Fatalf("requested_model = %q, want %q", requestedModel, catalog.DefaultModel)
+	}
+}
+
+func TestCreateIssue_FreezesCatalogDefaultModelWhenAgentModelUnset(t *testing.T) {
+	catalog, _ := codeagent.Catalog("codex")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":             "task-catalog-model-agent",
+		"providers":        []string{"codex"},
+		"default_provider": "codex",
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var agentResp AgentResponse
+	json.NewDecoder(w.Body).Decode(&agentResp)
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "Task freezes catalog default model",
+		"status":        "in_progress",
+		"assignee_type": "agent",
+		"assignee_id":   agentResp.ID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var issueResp IssueResponse
+	json.NewDecoder(w.Body).Decode(&issueResp)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentResp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueResp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentResp.ID)
+	})
+
+	var requestedModel string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT requested_model FROM agent_task_queue WHERE agent_id = $1 AND issue_id = $2`,
+		agentResp.ID, issueResp.ID,
+	).Scan(&requestedModel); err != nil {
+		t.Fatalf("query task requested_model: %v", err)
+	}
+	if requestedModel != catalog.DefaultModel {
+		t.Fatalf("requested_model = %q, want catalog default %q", requestedModel, catalog.DefaultModel)
+	}
+}
+
+func TestCompleteTask_PersistsRequestedAndObservedModels(t *testing.T) {
+	ctx := context.Background()
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent_runtime WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID,
+	).Scan(&runtimeID); err != nil {
+		t.Fatalf("get runtime: %v", err)
+	}
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, description, visibility, owner_id, tools, triggers, providers, default_provider)
+		VALUES ($1, 'complete-model-agent', '', 'workspace', $2, '[]'::jsonb, '[]'::jsonb, ARRAY['claude'], 'claude')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'complete task model', 'in_progress', 'medium', 'member', $2, 98989, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, requested_model)
+		VALUES ($1, $2, $3, 'running', 0, 'sonnet')
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	task, err := testHandler.TaskService.CompleteTask(ctx, parseUUID(taskID), []byte(`{"output":"done"}`), "session-1", "/tmp/work", "sonnet", "claude-sonnet-4-20250514")
+	if err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+	if !task.RequestedModel.Valid || task.RequestedModel.String != "sonnet" {
+		t.Fatalf("requested_model = %#v, want sonnet", task.RequestedModel)
+	}
+	if !task.ObservedModel.Valid || task.ObservedModel.String != "claude-sonnet-4-20250514" {
+		t.Fatalf("observed_model = %#v, want claude-sonnet-4-20250514", task.ObservedModel)
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -556,11 +556,13 @@ func (h *Handler) ReportTaskProgress(w http.ResponseWriter, r *http.Request) {
 
 // CompleteTask marks a running task as completed.
 type TaskCompleteRequest struct {
-	PRURL      string `json:"pr_url"`
-	BranchName string `json:"branch_name"`
-	Output     string `json:"output"`
-	SessionID  string `json:"session_id"` // Claude session ID for future resumption
-	WorkDir    string `json:"work_dir"`   // working directory used during execution
+	PRURL          string `json:"pr_url"`
+	BranchName     string `json:"branch_name"`
+	Output         string `json:"output"`
+	SessionID      string `json:"session_id"` // Claude session ID for future resumption
+	WorkDir        string `json:"work_dir"`   // working directory used during execution
+	RequestedModel string `json:"requested_model"`
+	ObservedModel  string `json:"observed_model"`
 }
 
 func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
@@ -573,7 +575,7 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, _ := json.Marshal(req)
-	task, err := h.TaskService.CompleteTask(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir)
+	task, err := h.TaskService.CompleteTask(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir, req.RequestedModel, req.ObservedModel)
 	if err != nil {
 		slog.Warn("complete task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusBadRequest, err.Error())

--- a/server/internal/handler/workspace_providers.go
+++ b/server/internal/handler/workspace_providers.go
@@ -18,9 +18,11 @@ import (
 
 // ProviderConfig holds the configuration for a single code agent provider.
 type ProviderConfig struct {
-	Enabled       bool   `json:"enabled"`
-	APIKey        string `json:"api_key,omitempty"`
-	TargetVersion string `json:"target_version,omitempty"`
+	Enabled         bool     `json:"enabled"`
+	APIKey          string   `json:"api_key,omitempty"`
+	TargetVersion   string   `json:"target_version,omitempty"`
+	DefaultModel    string   `json:"default_model,omitempty"`
+	SupportedModels []string `json:"supported_models,omitempty"`
 }
 
 // WorkspaceProviderSettings is the providers section of workspace.settings.
@@ -109,7 +111,10 @@ func redactProviderSettings(ps WorkspaceProviderSettings) WorkspaceProviderSetti
 			cfg = ps.Providers[provider]
 		}
 		cfg.APIKey = redactAPIKey(cfg.APIKey)
-		cfg.TargetVersion = codeagent.MustVersion(provider)
+		catalog := codeagent.MustCatalog(provider)
+		cfg.TargetVersion = catalog.Version
+		cfg.DefaultModel = catalog.DefaultModel
+		cfg.SupportedModels = catalog.SupportedModels
 		out.Providers[provider] = cfg
 	}
 	return out
@@ -122,6 +127,9 @@ func rejectConfiguredTargetVersions(ps WorkspaceProviderSettings) error {
 	for provider, cfg := range ps.Providers {
 		if cfg.TargetVersion != "" {
 			return fmt.Errorf("provider %s target_version is repository-owned", provider)
+		}
+		if cfg.DefaultModel != "" || len(cfg.SupportedModels) > 0 {
+			return fmt.Errorf("provider %s model catalog is repository-owned", provider)
 		}
 	}
 	return nil

--- a/server/internal/handler/workspace_providers_test.go
+++ b/server/internal/handler/workspace_providers_test.go
@@ -27,6 +27,13 @@ func TestRedactProviderSettingsReturnsRepoVersions(t *testing.T) {
 	if codex.TargetVersion != want {
 		t.Fatalf("expected codex target_version %q, got %q", want, codex.TargetVersion)
 	}
+	catalog, _ := codeagent.Catalog("codex")
+	if codex.DefaultModel != catalog.DefaultModel {
+		t.Fatalf("expected codex default_model %q, got %q", catalog.DefaultModel, codex.DefaultModel)
+	}
+	if len(codex.SupportedModels) == 0 {
+		t.Fatal("expected codex supported_models")
+	}
 
 	claude := out.Providers["claude"]
 	want, _ = codeagent.Version("claude")
@@ -45,6 +52,23 @@ func TestRejectConfiguredTargetVersions(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected target_version to be rejected")
+	}
+}
+
+func TestRejectConfiguredProviderCatalogFields(t *testing.T) {
+	t.Parallel()
+
+	err := rejectConfiguredTargetVersions(WorkspaceProviderSettings{
+		Providers: map[string]ProviderConfig{
+			"codex": {
+				Enabled:         true,
+				DefaultModel:    "gpt-5.2-codex",
+				SupportedModels: []string{"gpt-5.2-codex"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected model catalog fields to be rejected")
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/nullne/multica/server/internal/codeagent"
 	"github.com/nullne/multica/server/internal/events"
 	"github.com/nullne/multica/server/internal/mention"
 	"github.com/nullne/multica/server/internal/realtime"
@@ -216,6 +217,17 @@ func (s *TaskService) enqueueTaskToAgent(ctx context.Context, issue db.Issue, ag
 	}
 
 	runtimeID := runtime.ID
+	requestedModel := pgtype.Text{}
+	if agent.DefaultProvider.Valid && agent.DefaultProvider.String == runtime.Provider {
+		switch {
+		case agent.DefaultModel.Valid && codeagent.SupportsModel(runtime.Provider, agent.DefaultModel.String):
+			requestedModel = agent.DefaultModel
+		case !agent.DefaultModel.Valid:
+			if catalog, ok := codeagent.Catalog(runtime.Provider); ok && catalog.DefaultModel != "" {
+				requestedModel = pgtype.Text{String: catalog.DefaultModel, Valid: true}
+			}
+		}
+	}
 
 	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
 		AgentID:          agentID,
@@ -224,6 +236,7 @@ func (s *TaskService) enqueueTaskToAgent(ctx context.Context, issue db.Issue, ag
 		Priority:         priorityToInt(issue.Priority),
 		TriggerCommentID: triggerCommentID,
 		Context:          contextData,
+		RequestedModel:   requestedModel,
 	})
 	if err != nil {
 		slog.Error("mention task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID), "error", err)
@@ -323,12 +336,14 @@ func (s *TaskService) StartTask(ctx context.Context, taskID pgtype.UUID) (*db.Ag
 
 // CompleteTask marks a task as completed.
 // Issue status is NOT changed here — the agent manages it via the CLI.
-func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, result []byte, sessionID, workDir string) (*db.AgentTaskQueue, error) {
+func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, result []byte, sessionID, workDir, requestedModel, observedModel string) (*db.AgentTaskQueue, error) {
 	task, err := s.Queries.CompleteAgentTask(ctx, db.CompleteAgentTaskParams{
-		ID:        taskID,
-		Result:    result,
-		SessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},
-		WorkDir:   pgtype.Text{String: workDir, Valid: workDir != ""},
+		ID:             taskID,
+		Result:         result,
+		SessionID:      pgtype.Text{String: sessionID, Valid: sessionID != ""},
+		WorkDir:        pgtype.Text{String: workDir, Valid: workDir != ""},
+		RequestedModel: pgtype.Text{String: requestedModel, Valid: requestedModel != ""},
+		ObservedModel:  pgtype.Text{String: observedModel, Valid: observedModel != ""},
 	})
 	if err != nil {
 		// Log the current task state to help debug why the update matched no rows.

--- a/server/migrations/062_agent_task_models.down.sql
+++ b/server/migrations/062_agent_task_models.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE agent_task_queue DROP COLUMN observed_model;
+ALTER TABLE agent_task_queue DROP COLUMN requested_model;
+
+ALTER TABLE agent DROP COLUMN default_model;

--- a/server/migrations/062_agent_task_models.up.sql
+++ b/server/migrations/062_agent_task_models.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE agent ADD COLUMN default_model TEXT;
+
+ALTER TABLE agent_task_queue ADD COLUMN requested_model TEXT;
+ALTER TABLE agent_task_queue ADD COLUMN observed_model TEXT;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model
 `
 
 type ArchiveAgentParams struct {
@@ -46,6 +46,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }
@@ -54,7 +55,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -77,6 +78,8 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
@@ -123,7 +126,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model
 `
 
 // Claims the next queued task for an agent, enforcing per-issue serialization and
@@ -150,22 +153,28 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (Agen
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
 
 const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
-SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
+SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4,
+    requested_model = COALESCE($5, requested_model),
+    observed_model = $6
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model
 `
 
 type CompleteAgentTaskParams struct {
-	ID        pgtype.UUID `json:"id"`
-	Result    []byte      `json:"result"`
-	SessionID pgtype.Text `json:"session_id"`
-	WorkDir   pgtype.Text `json:"work_dir"`
+	ID             pgtype.UUID `json:"id"`
+	Result         []byte      `json:"result"`
+	SessionID      pgtype.Text `json:"session_id"`
+	WorkDir        pgtype.Text `json:"work_dir"`
+	RequestedModel pgtype.Text `json:"requested_model"`
+	ObservedModel  pgtype.Text `json:"observed_model"`
 }
 
 func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskParams) (AgentTaskQueue, error) {
@@ -174,6 +183,8 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		arg.Result,
 		arg.SessionID,
 		arg.WorkDir,
+		arg.RequestedModel,
+		arg.ObservedModel,
 	)
 	var i AgentTaskQueue
 	err := row.Scan(
@@ -193,6 +204,8 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
@@ -212,9 +225,9 @@ func (q *Queries) CountRunningTasks(ctx context.Context, agentID pgtype.UUID) (i
 const createAgent = `-- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, providers, visibility, owner_id,
-    tools, triggers, instructions, github_code_access, default_provider, default_daemon_id, max_concurrent_tasks
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+	tools, triggers, instructions, github_code_access, default_provider, default_model, default_daemon_id, max_concurrent_tasks
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model
 `
 
 type CreateAgentParams struct {
@@ -230,6 +243,7 @@ type CreateAgentParams struct {
 	Instructions       string      `json:"instructions"`
 	GithubCodeAccess   string      `json:"github_code_access"`
 	DefaultProvider    pgtype.Text `json:"default_provider"`
+	DefaultModel       pgtype.Text `json:"default_model"`
 	DefaultDaemonID    pgtype.UUID `json:"default_daemon_id"`
 	MaxConcurrentTasks int32       `json:"max_concurrent_tasks"`
 }
@@ -248,6 +262,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.Instructions,
 		arg.GithubCodeAccess,
 		arg.DefaultProvider,
+		arg.DefaultModel,
 		arg.DefaultDaemonID,
 		arg.MaxConcurrentTasks,
 	)
@@ -273,14 +288,15 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }
 
 const createAgentTask = `-- name: CreateAgentTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context)
-VALUES ($1, $2, $3, 'queued', $4, $5, $6)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context, requested_model)
+VALUES ($1, $2, $3, 'queued', $4, $5, $6, $7)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model
 `
 
 type CreateAgentTaskParams struct {
@@ -290,6 +306,7 @@ type CreateAgentTaskParams struct {
 	Priority         int32       `json:"priority"`
 	TriggerCommentID pgtype.UUID `json:"trigger_comment_id"`
 	Context          []byte      `json:"context"`
+	RequestedModel   pgtype.Text `json:"requested_model"`
 }
 
 func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams) (AgentTaskQueue, error) {
@@ -300,6 +317,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		arg.Priority,
 		arg.TriggerCommentID,
 		arg.Context,
+		arg.RequestedModel,
 	)
 	var i AgentTaskQueue
 	err := row.Scan(
@@ -319,6 +337,8 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
@@ -327,7 +347,7 @@ const failAgentTask = `-- name: FailAgentTask :one
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = $2
 WHERE id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model
 `
 
 type FailAgentTaskParams struct {
@@ -355,6 +375,8 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
@@ -402,7 +424,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model FROM agent
 WHERE id = $1
 `
 
@@ -430,12 +452,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model FROM agent
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -468,12 +491,13 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -497,6 +521,8 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
@@ -576,7 +602,7 @@ func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPen
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('dispatched', 'running')
 ORDER BY created_at DESC
 `
@@ -607,6 +633,8 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedModel,
+			&i.ObservedModel,
 		); err != nil {
 			return nil, err
 		}
@@ -619,7 +647,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listActiveTasksByWorkspace = `-- name: ListActiveTasksByWorkspace :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.requested_model, atq.observed_model FROM agent_task_queue atq
 JOIN issue i ON atq.issue_id = i.id
 WHERE i.workspace_id = $1 AND atq.status IN ('queued', 'dispatched', 'running')
 ORDER BY atq.created_at DESC
@@ -651,6 +679,8 @@ func (q *Queries) ListActiveTasksByWorkspace(ctx context.Context, workspaceID pg
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedModel,
+			&i.ObservedModel,
 		); err != nil {
 			return nil, err
 		}
@@ -663,7 +693,7 @@ func (q *Queries) ListActiveTasksByWorkspace(ctx context.Context, workspaceID pg
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -694,6 +724,8 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedModel,
+			&i.ObservedModel,
 		); err != nil {
 			return nil, err
 		}
@@ -706,7 +738,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
 ORDER BY created_at ASC
 `
@@ -741,6 +773,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.DefaultDaemonID,
 			&i.MaxConcurrentTasks,
 			&i.DefaultProvider,
+			&i.DefaultModel,
 		); err != nil {
 			return nil, err
 		}
@@ -753,7 +786,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -788,6 +821,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.DefaultDaemonID,
 			&i.MaxConcurrentTasks,
 			&i.DefaultProvider,
+			&i.DefaultModel,
 		); err != nil {
 			return nil, err
 		}
@@ -800,7 +834,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -831,6 +865,8 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedModel,
+			&i.ObservedModel,
 		); err != nil {
 			return nil, err
 		}
@@ -843,7 +879,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -874,6 +910,8 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedModel,
+			&i.ObservedModel,
 		); err != nil {
 			return nil, err
 		}
@@ -888,7 +926,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -915,6 +953,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }
@@ -923,7 +962,7 @@ const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running', started_at = now()
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_model, observed_model
 `
 
 func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -946,6 +985,8 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedModel,
+		&i.ObservedModel,
 	)
 	return i, err
 }
@@ -963,11 +1004,12 @@ UPDATE agent SET
     instructions = COALESCE($10, instructions),
     github_code_access = COALESCE($11, github_code_access),
     default_provider = $12,
-    default_daemon_id = $13,
-    max_concurrent_tasks = COALESCE($14, max_concurrent_tasks),
+	default_model = $13,
+    default_daemon_id = $14,
+    max_concurrent_tasks = COALESCE($15, max_concurrent_tasks),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model
 `
 
 type UpdateAgentParams struct {
@@ -983,6 +1025,7 @@ type UpdateAgentParams struct {
 	Instructions       pgtype.Text `json:"instructions"`
 	GithubCodeAccess   pgtype.Text `json:"github_code_access"`
 	DefaultProvider    pgtype.Text `json:"default_provider"`
+	DefaultModel       pgtype.Text `json:"default_model"`
 	DefaultDaemonID    pgtype.UUID `json:"default_daemon_id"`
 	MaxConcurrentTasks pgtype.Int4 `json:"max_concurrent_tasks"`
 }
@@ -1001,6 +1044,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Instructions,
 		arg.GithubCodeAccess,
 		arg.DefaultProvider,
+		arg.DefaultModel,
 		arg.DefaultDaemonID,
 		arg.MaxConcurrentTasks,
 	)
@@ -1026,6 +1070,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }
@@ -1033,7 +1078,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, default_model
 `
 
 type UpdateAgentStatusParams struct {
@@ -1065,6 +1110,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.DefaultModel,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -40,6 +40,7 @@ type Agent struct {
 	DefaultDaemonID    pgtype.UUID        `json:"default_daemon_id"`
 	MaxConcurrentTasks int32              `json:"max_concurrent_tasks"`
 	DefaultProvider    pgtype.Text        `json:"default_provider"`
+	DefaultModel       pgtype.Text        `json:"default_model"`
 }
 
 type AgentRuntime struct {
@@ -82,6 +83,8 @@ type AgentTaskQueue struct {
 	SessionID        pgtype.Text        `json:"session_id"`
 	WorkDir          pgtype.Text        `json:"work_dir"`
 	TriggerCommentID pgtype.UUID        `json:"trigger_comment_id"`
+	RequestedModel   pgtype.Text        `json:"requested_model"`
+	ObservedModel    pgtype.Text        `json:"observed_model"`
 }
 
 type Attachment struct {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -19,8 +19,8 @@ WHERE id = $1 AND workspace_id = $2;
 -- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, providers, visibility, owner_id,
-    tools, triggers, instructions, github_code_access, default_provider, default_daemon_id, max_concurrent_tasks
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, sqlc.narg(default_provider), sqlc.narg(default_daemon_id), @max_concurrent_tasks)
+	tools, triggers, instructions, github_code_access, default_provider, default_model, default_daemon_id, max_concurrent_tasks
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, sqlc.narg(default_provider), sqlc.narg(default_model), sqlc.narg(default_daemon_id), @max_concurrent_tasks)
 RETURNING *;
 
 -- name: UpdateAgent :one
@@ -36,6 +36,7 @@ UPDATE agent SET
     instructions = COALESCE(sqlc.narg('instructions'), instructions),
     github_code_access = COALESCE(sqlc.narg('github_code_access'), github_code_access),
     default_provider = sqlc.narg('default_provider'),
+	default_model = sqlc.narg('default_model'),
     default_daemon_id = sqlc.narg('default_daemon_id'),
     max_concurrent_tasks = COALESCE(sqlc.narg('max_concurrent_tasks'), max_concurrent_tasks),
     updated_at = now()
@@ -58,8 +59,8 @@ WHERE agent_id = $1
 ORDER BY created_at DESC;
 
 -- name: CreateAgentTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context)
-VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id), sqlc.narg(context))
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context, requested_model)
+VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id), sqlc.narg(context), sqlc.narg(requested_model))
 RETURNING *;
 
 -- name: CancelAgentTasksByIssue :exec
@@ -110,7 +111,9 @@ RETURNING *;
 
 -- name: CompleteAgentTask :one
 UPDATE agent_task_queue
-SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
+SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4,
+    requested_model = COALESCE(sqlc.narg('requested_model'), requested_model),
+    observed_model = sqlc.narg('observed_model')
 WHERE id = $1 AND status = 'running'
 RETURNING *;
 


### PR DESCRIPTION
## Summary
- Add a repository-owned code agent catalog with tested CLI versions, default models, and supported model lists.
- Let agents store a default model, freeze the selected/catalog default model onto queued tasks, and persist requested/observed model data on completion.
- Surface provider model metadata and agent model selection in the web UI.

## Test plan
- `make check`
- `make test-ts`
- `make test-go`
- `make test`
- `make test-agent-compat`


Made with [Cursor](https://cursor.com)