### PR TITLE
Add per-action event history to webhook actions

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/webhooks-tab.test.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/webhooks-tab.test.tsx
@@ -65,6 +65,7 @@ const mockListBotUsers = vi.fn();
 const mockListWebhookAdapters = vi.fn();
 const mockListWorkspaceWebhookEvents = vi.fn();
 const mockListWebhookEvents = vi.fn();
+const mockListWebhookActionEvents = vi.fn();
 const mockCreateWebhook = vi.fn();
 const mockUpdateWebhook = vi.fn();
 const mockCreateWebhookAction = vi.fn();
@@ -78,6 +79,7 @@ vi.mock("@/shared/api", () => ({
     listWebhookAdapters: (...args: any[]) => mockListWebhookAdapters(...args),
     listWorkspaceWebhookEvents: (...args: any[]) => mockListWorkspaceWebhookEvents(...args),
     listWebhookEvents: (...args: any[]) => mockListWebhookEvents(...args),
+    listWebhookActionEvents: (...args: any[]) => mockListWebhookActionEvents(...args),
     createWebhook: (...args: any[]) => mockCreateWebhook(...args),
     updateWebhook: (...args: any[]) => mockUpdateWebhook(...args),
     createWebhookAction: (...args: any[]) => mockCreateWebhookAction(...args),
@@ -118,6 +120,7 @@ function makeEvent(overrides: Partial<WebhookEvent> = {}): WebhookEvent {
   return {
     id: "evt-1",
     webhook_id: "wh-1",
+    action_id: null,
     dedup_key: "",
     payload: { title: "Test alert" },
     status: "processed",
@@ -166,6 +169,7 @@ describe("WebhooksTab — event history", () => {
     mockListWebhookAdapters.mockResolvedValue([]);
     mockListWorkspaceWebhookEvents.mockResolvedValue([]);
     mockListWebhookEvents.mockResolvedValue([]);
+    mockListWebhookActionEvents.mockResolvedValue([]);
   });
 
   it("does not load workspace events on mount — Event History is collapsed by default", async () => {
@@ -288,6 +292,109 @@ describe("WebhooksTab — event history", () => {
   });
 });
 
+describe("WebhooksTab — per-action event history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListWebhooks.mockResolvedValue([]);
+    mockListDaemons.mockResolvedValue([]);
+    mockListBotUsers.mockResolvedValue([]);
+    mockListWebhookAdapters.mockResolvedValue([]);
+    mockListWorkspaceWebhookEvents.mockResolvedValue([]);
+    mockListWebhookEvents.mockResolvedValue([]);
+    mockListWebhookActionEvents.mockResolvedValue([]);
+  });
+
+  async function expandWebhookCard() {
+    const nameEl = await screen.findByText("My Webhook");
+    const cardContainer = nameEl.closest("div.flex.items-center.gap-3");
+    const expandBtn = cardContainer?.querySelector("button");
+    if (!expandBtn) throw new Error("Could not find expand button");
+    fireEvent.click(expandBtn);
+  }
+
+  it("shows per-action recent events toggle when webhook card is expanded", async () => {
+    const wh = makeWebhookWithActions();
+    wh.actions = [
+      {
+        id: "action-1",
+        webhook_id: "wh-1",
+        action_type: "create_issue",
+        config: { agent_id: "agent-1", title_template: "", description_template: "", labels: [] },
+        enabled: true,
+        position: 0,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    mockListWebhooks.mockResolvedValue([wh]);
+
+    render(<WebhooksTab />);
+    await expandWebhookCard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Recent events")).toBeInTheDocument();
+    });
+  });
+
+  it("loads and displays action events when per-action panel is expanded", async () => {
+    const wh = makeWebhookWithActions();
+    wh.actions = [
+      {
+        id: "action-1",
+        webhook_id: "wh-1",
+        action_type: "create_issue",
+        config: { agent_id: "agent-1", title_template: "", description_template: "", labels: [] },
+        enabled: true,
+        position: 0,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    const actionEvent = makeEvent({ id: "evt-action-1", action_id: "action-1", status: "processed", payload: { title: "Action alert" } });
+    mockListWebhooks.mockResolvedValue([wh]);
+    mockListWebhookActionEvents.mockResolvedValue([actionEvent]);
+
+    render(<WebhooksTab />);
+    await expandWebhookCard();
+
+    const recentEventsBtn = await screen.findByText("Recent events");
+    fireEvent.click(recentEventsBtn);
+
+    await waitFor(() => {
+      expect(mockListWebhookActionEvents).toHaveBeenCalledWith("wh-1", "action-1");
+      expect(screen.getByText("Action alert")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'No events for this action yet' when action has no events", async () => {
+    const wh = makeWebhookWithActions();
+    wh.actions = [
+      {
+        id: "action-1",
+        webhook_id: "wh-1",
+        action_type: "create_issue",
+        config: { agent_id: "agent-1", title_template: "", description_template: "", labels: [] },
+        enabled: true,
+        position: 0,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    mockListWebhooks.mockResolvedValue([wh]);
+    mockListWebhookActionEvents.mockResolvedValue([]);
+
+    render(<WebhooksTab />);
+    await expandWebhookCard();
+
+    const recentEventsBtn = await screen.findByText("Recent events");
+    fireEvent.click(recentEventsBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("No events for this action yet")).toBeInTheDocument();
+    });
+  });
+});
+
 describe("WebhooksTab — subscriber config display", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -297,6 +404,7 @@ describe("WebhooksTab — subscriber config display", () => {
     mockListWebhookAdapters.mockResolvedValue([]);
     mockListWorkspaceWebhookEvents.mockResolvedValue([]);
     mockListWebhookEvents.mockResolvedValue([]);
+    mockListWebhookActionEvents.mockResolvedValue([]);
   });
 
   it("shows subscriber names in action summary when subscriber_ids are configured", async () => {
@@ -351,6 +459,7 @@ describe("WebhooksTab — confirmed agent dispatch", () => {
     ]);
     mockListWorkspaceWebhookEvents.mockResolvedValue([]);
     mockListWebhookEvents.mockResolvedValue([]);
+    mockListWebhookActionEvents.mockResolvedValue([]);
   });
 
   it("create dialog requires confirming an agent before saving", async () => {

--- a/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
@@ -576,7 +576,7 @@ function WebhookCard({
               <div className="italic text-muted-foreground/70">No actions configured</div>
             )}
             <WebhookEventsPanel
-              events={events}
+              events={events?.filter((e) => !e.action_id) ?? null}
               loading={eventsLoading}
               expanded={eventsExpanded}
               onToggle={() => setEventsExpanded((v) => !v)}
@@ -1684,7 +1684,8 @@ function ActionEventsPanel({
 }
 
 // ----------------------------------------------------------------------------
-// Per-webhook events panel (shown inside expanded card)
+// Per-webhook unrouted events panel (dedup / filter / pause / parse errors)
+// Shows only events that did not reach any action (action_id is null).
 // ----------------------------------------------------------------------------
 
 function WebhookEventsPanel({
@@ -1709,7 +1710,7 @@ function WebhookEventsPanel({
       >
         {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
         <History className="h-3 w-3" />
-        Recent Events
+        Unrouted events
       </button>
       {expanded && (
         <>
@@ -1717,7 +1718,7 @@ function WebhookEventsPanel({
             <div className="text-muted-foreground/70 italic">Loading events…</div>
           )}
           {!loading && events !== null && displayEvents.length === 0 && (
-            <div className="italic text-muted-foreground/70">No events recorded yet</div>
+            <div className="italic text-muted-foreground/70">No unrouted events</div>
           )}
           {!loading && displayEvents.map((evt) => (
             <WebhookEventRow key={evt.id} event={evt} />

--- a/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
@@ -566,6 +566,7 @@ function WebhookCard({
                 key={a.id}
                 action={a}
                 index={idx}
+                webhookId={webhook.id}
                 agentName={agentName}
                 memberName={memberName}
                 envName={envName}
@@ -590,16 +591,31 @@ function WebhookCard({
 function ActionSummary({
   action,
   index,
+  webhookId,
   agentName,
   memberName,
   envName,
 }: {
   action: WebhookAction;
   index: number;
+  webhookId: string;
   agentName: (id: string) => string;
   memberName: (id: string) => string;
   envName: (id: string) => string;
 }) {
+  const [eventsExpanded, setEventsExpanded] = useState(false);
+  const [events, setEvents] = useState<WebhookEvent[] | null>(null);
+  const [eventsLoading, setEventsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!eventsExpanded || events !== null) return;
+    setEventsLoading(true);
+    api.listWebhookActionEvents(webhookId, action.id)
+      .then(setEvents)
+      .catch(() => setEvents([]))
+      .finally(() => setEventsLoading(false));
+  }, [eventsExpanded, events, webhookId, action.id]);
+
   return (
     <div className="border-t pt-2 mt-1">
       <span className="text-[10px] font-semibold uppercase tracking-wide">
@@ -647,6 +663,12 @@ function ActionSummary({
           </div>
         );
       })()}
+      <ActionEventsPanel
+        events={events}
+        loading={eventsLoading}
+        expanded={eventsExpanded}
+        onToggle={() => setEventsExpanded((v) => !v)}
+      />
     </div>
   );
 }
@@ -1604,6 +1626,61 @@ function payloadSummary(payload: unknown): string {
   const title = p.title ?? p.alertname ?? (p.labels && typeof p.labels === "object" ? (p.labels as Record<string, unknown>).alertname : undefined);
   if (title) return String(title).slice(0, 80);
   return "";
+}
+
+// ----------------------------------------------------------------------------
+// Per-action events panel (shown inside each ActionSummary)
+// ----------------------------------------------------------------------------
+
+function ActionEventsPanel({
+  events,
+  loading,
+  expanded,
+  onToggle,
+}: {
+  events: WebhookEvent[] | null;
+  loading: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const displayEvents = events?.slice(0, 10) ?? [];
+
+  return (
+    <div className="mt-2 space-y-1">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex items-center gap-1 text-[10px] font-medium text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        <History className="h-3 w-3" />
+        Recent events
+        {events !== null && events.length > 0 && (
+          <span className="ml-1 text-[9px] rounded bg-muted px-1">{events.length}</span>
+        )}
+      </button>
+      {expanded && (
+        <>
+          {loading && (
+            <div className="text-[10px] text-muted-foreground/70 italic pl-4">Loading…</div>
+          )}
+          {!loading && events !== null && displayEvents.length === 0 && (
+            <div className="text-[10px] italic text-muted-foreground/70 pl-4">No events for this action yet</div>
+          )}
+          {!loading && displayEvents.map((evt) => (
+            <div key={evt.id} className="pl-4">
+              <WebhookEventRow event={evt} />
+            </div>
+          ))}
+          {!loading && events !== null && events.length > 10 && (
+            <div className="text-[10px] text-muted-foreground/70 italic pl-4">
+              Showing 10 of {events.length} events
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
 // ----------------------------------------------------------------------------

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -870,6 +870,10 @@ export class ApiClient {
     return this.fetch(`/api/webhooks/${id}/events`);
   }
 
+  async listWebhookActionEvents(webhookId: string, actionId: string): Promise<WebhookEvent[]> {
+    return this.fetch(`/api/webhooks/${webhookId}/actions/${actionId}/events`);
+  }
+
   async listWorkspaceWebhookEvents(): Promise<WebhookEvent[]> {
     return this.fetch("/api/webhook-events");
   }

--- a/apps/web/shared/types/webhook.ts
+++ b/apps/web/shared/types/webhook.ts
@@ -113,6 +113,7 @@ export type WebhookEventStatus = "processed" | "filtered" | "deduped" | "error";
 export interface WebhookEvent {
   id: string;
   webhook_id: string;
+  action_id: string | null;
   dedup_key: string;
   payload: unknown;
   status: WebhookEventStatus;

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -314,6 +314,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 					r.Get("/events", h.ListWebhookEvents)
 					r.Get("/actions", h.ListWebhookActions)
 					r.Post("/actions", h.CreateWebhookAction)
+					r.Get("/actions/{actionId}/events", h.ListWebhookActionEvents)
 					r.Put("/actions/{actionId}", h.UpdateWebhookAction)
 					r.Delete("/actions/{actionId}", h.DeleteWebhookAction)
 				})

--- a/server/internal/handler/webhook.go
+++ b/server/internal/handler/webhook.go
@@ -54,6 +54,7 @@ type WebhookActionResponse struct {
 type WebhookEventResponse struct {
 	ID           string  `json:"id"`
 	WebhookID    string  `json:"webhook_id"`
+	ActionID     *string `json:"action_id"`
 	DedupKey     string  `json:"dedup_key"`
 	Payload      any     `json:"payload"`
 	Status       string  `json:"status"`
@@ -108,6 +109,7 @@ func webhookEventToResponse(e db.WebhookEventLog) WebhookEventResponse {
 	return WebhookEventResponse{
 		ID:           uuidToString(e.ID),
 		WebhookID:    uuidToString(e.WebhookID),
+		ActionID:     uuidToPtr(e.ActionID),
 		DedupKey:     e.DedupKey,
 		Payload:      payload,
 		Status:       e.Status,
@@ -478,6 +480,36 @@ func (h *Handler) ListWorkspaceWebhookEvents(w http.ResponseWriter, r *http.Requ
 		WorkspaceID: parseUUID(workspaceID),
 		Limit:       limit,
 		Offset:      offset,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list events")
+		return
+	}
+
+	resp := make([]WebhookEventResponse, len(events))
+	for i, e := range events {
+		resp[i] = webhookEventToResponse(e)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) ListWebhookActionEvents(w http.ResponseWriter, r *http.Request) {
+	webhookID := chi.URLParam(r, "id")
+	actionID := chi.URLParam(r, "actionId")
+	workspaceID := resolveWorkspaceID(r)
+
+	existing, err := h.Queries.GetWebhook(r.Context(), parseUUID(webhookID))
+	if err != nil || uuidToString(existing.WorkspaceID) != workspaceID {
+		writeError(w, http.StatusNotFound, "webhook not found")
+		return
+	}
+
+	limit := int32(50)
+	offset := int32(0)
+	events, err := h.Queries.ListWebhookActionEvents(r.Context(), db.ListWebhookActionEventsParams{
+		ActionID: parseUUID(actionID),
+		Limit:    limit,
+		Offset:   offset,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list events")
@@ -900,20 +932,21 @@ func (h *Handler) IngestWebhook(w http.ResponseWriter, r *http.Request) {
 //
 // Returns (events parsed, issues/comments created).
 func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, body []byte, headers http.Header) (int, int) {
+	noAction := pgtype.UUID{}
 	if webhook.Status != "active" {
-		h.logWebhookEvent(ctx, webhook, "", body, "filtered", pgtype.UUID{}, "webhook is paused")
+		h.logWebhookEvent(ctx, webhook, noAction, "", body, "filtered", pgtype.UUID{}, "webhook is paused")
 		return 0, 0
 	}
 
 	adapter, err := wh.GetAdapter(webhook.SourceType)
 	if err != nil {
-		h.logWebhookEvent(ctx, webhook, "", body, "error", pgtype.UUID{}, err.Error())
+		h.logWebhookEvent(ctx, webhook, noAction, "", body, "error", pgtype.UUID{}, err.Error())
 		return 0, 0
 	}
 
 	events, err := adapter.Parse(json.RawMessage(body), headers)
 	if err != nil {
-		h.logWebhookEvent(ctx, webhook, "", body, "error", pgtype.UUID{}, "parse failed: "+err.Error())
+		h.logWebhookEvent(ctx, webhook, noAction, "", body, "error", pgtype.UUID{}, "parse failed: "+err.Error())
 		return 0, 0
 	}
 	if len(events) == 0 {
@@ -923,7 +956,7 @@ func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, bod
 
 	actions, err := h.Queries.ListEnabledWebhookActions(ctx, webhook.ID)
 	if err != nil {
-		h.logWebhookEvent(ctx, webhook, "", body, "error", pgtype.UUID{}, "list actions: "+err.Error())
+		h.logWebhookEvent(ctx, webhook, noAction, "", body, "error", pgtype.UUID{}, "list actions: "+err.Error())
 		return len(events), 0
 	}
 
@@ -939,14 +972,14 @@ func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, bod
 				WindowSeconds: float64(webhook.DedupWindowSeconds),
 			})
 			if dedupErr == nil {
-				h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "deduped", pgtype.UUID{}, "")
+				h.logWebhookEvent(ctx, webhook, noAction, evt.DedupKey, body, "deduped", pgtype.UUID{}, "")
 				continue
 			}
 		}
 
 		preexistingLink, hasPreexistingLink, linkErr := h.findIssueLinkForEvent(ctx, webhook.WorkspaceID, evt)
 		if linkErr != nil {
-			h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "error", pgtype.UUID{}, "lookup issue_link: "+linkErr.Error())
+			h.logWebhookEvent(ctx, webhook, noAction, evt.DedupKey, body, "error", pgtype.UUID{}, "lookup issue_link: "+linkErr.Error())
 			continue
 		}
 
@@ -954,7 +987,7 @@ func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, bod
 		for _, action := range actions {
 			ranOK, issueID, runErr := h.runWebhookAction(ctx, webhook, action, evt, preexistingLink, hasPreexistingLink)
 			if runErr != nil {
-				h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "error", pgtype.UUID{}, fmt.Sprintf("%s: %s", action.ActionType, runErr.Error()))
+				h.logWebhookEvent(ctx, webhook, action.ID, evt.DedupKey, body, "error", pgtype.UUID{}, fmt.Sprintf("%s: %s", action.ActionType, runErr.Error()))
 				continue
 			}
 			if !ranOK {
@@ -962,10 +995,10 @@ func (h *Handler) ingestWithWebhook(ctx context.Context, webhook db.Webhook, bod
 			}
 			processed = true
 			created++
-			h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "processed", issueID, "")
+			h.logWebhookEvent(ctx, webhook, action.ID, evt.DedupKey, body, "processed", issueID, "")
 		}
 		if !processed {
-			h.logWebhookEvent(ctx, webhook, evt.DedupKey, body, "filtered", pgtype.UUID{}, "no matching action")
+			h.logWebhookEvent(ctx, webhook, noAction, evt.DedupKey, body, "filtered", pgtype.UUID{}, "no matching action")
 		}
 	}
 
@@ -1343,13 +1376,14 @@ func renderTemplate(tmpl string, data map[string]string) string {
 	return result
 }
 
-func (h *Handler) logWebhookEvent(ctx context.Context, webhook db.Webhook, dedupKey string, payload []byte, status string, issueID pgtype.UUID, errMsg string) {
+func (h *Handler) logWebhookEvent(ctx context.Context, webhook db.Webhook, actionID pgtype.UUID, dedupKey string, payload []byte, status string, issueID pgtype.UUID, errMsg string) {
 	var errorMessage pgtype.Text
 	if errMsg != "" {
 		errorMessage = pgtype.Text{String: errMsg, Valid: true}
 	}
 	_, err := h.Queries.CreateWebhookEventLog(ctx, db.CreateWebhookEventLogParams{
 		WebhookID:    webhook.ID,
+		ActionID:     actionID,
 		DedupKey:     dedupKey,
 		Payload:      payload,
 		Status:       status,

--- a/server/migrations/062_webhook_event_action_id.down.sql
+++ b/server/migrations/062_webhook_event_action_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_webhook_event_log_action;
+ALTER TABLE webhook_event_log DROP COLUMN IF EXISTS action_id;

--- a/server/migrations/062_webhook_event_action_id.up.sql
+++ b/server/migrations/062_webhook_event_action_id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE webhook_event_log ADD COLUMN action_id UUID REFERENCES webhook_action(id) ON DELETE SET NULL;
+CREATE INDEX idx_webhook_event_log_action ON webhook_event_log(action_id, created_at DESC);

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -409,6 +409,7 @@ type WebhookAction struct {
 type WebhookEventLog struct {
 	ID           pgtype.UUID        `json:"id"`
 	WebhookID    pgtype.UUID        `json:"webhook_id"`
+	ActionID     pgtype.UUID        `json:"action_id"`
 	DedupKey     string             `json:"dedup_key"`
 	Payload      []byte             `json:"payload"`
 	Status       string             `json:"status"`

--- a/server/pkg/db/generated/webhook.sql.go
+++ b/server/pkg/db/generated/webhook.sql.go
@@ -135,13 +135,14 @@ func (q *Queries) CreateWebhookAction(ctx context.Context, arg CreateWebhookActi
 }
 
 const createWebhookEventLog = `-- name: CreateWebhookEventLog :one
-INSERT INTO webhook_event_log (webhook_id, dedup_key, payload, status, issue_id, error_message)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, webhook_id, dedup_key, payload, status, issue_id, error_message, created_at
+INSERT INTO webhook_event_log (webhook_id, action_id, dedup_key, payload, status, issue_id, error_message)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, webhook_id, action_id, dedup_key, payload, status, issue_id, error_message, created_at
 `
 
 type CreateWebhookEventLogParams struct {
 	WebhookID    pgtype.UUID `json:"webhook_id"`
+	ActionID     pgtype.UUID `json:"action_id"`
 	DedupKey     string      `json:"dedup_key"`
 	Payload      []byte      `json:"payload"`
 	Status       string      `json:"status"`
@@ -152,6 +153,7 @@ type CreateWebhookEventLogParams struct {
 func (q *Queries) CreateWebhookEventLog(ctx context.Context, arg CreateWebhookEventLogParams) (WebhookEventLog, error) {
 	row := q.db.QueryRow(ctx, createWebhookEventLog,
 		arg.WebhookID,
+		arg.ActionID,
 		arg.DedupKey,
 		arg.Payload,
 		arg.Status,
@@ -162,6 +164,7 @@ func (q *Queries) CreateWebhookEventLog(ctx context.Context, arg CreateWebhookEv
 	err := row.Scan(
 		&i.ID,
 		&i.WebhookID,
+		&i.ActionID,
 		&i.DedupKey,
 		&i.Payload,
 		&i.Status,
@@ -381,7 +384,7 @@ func (q *Queries) ListWebhookActions(ctx context.Context, webhookID pgtype.UUID)
 }
 
 const listWebhookEvents = `-- name: ListWebhookEvents :many
-SELECT id, webhook_id, dedup_key, payload, status, issue_id, error_message, created_at FROM webhook_event_log
+SELECT id, webhook_id, action_id, dedup_key, payload, status, issue_id, error_message, created_at FROM webhook_event_log
 WHERE webhook_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -405,6 +408,50 @@ func (q *Queries) ListWebhookEvents(ctx context.Context, arg ListWebhookEventsPa
 		if err := rows.Scan(
 			&i.ID,
 			&i.WebhookID,
+			&i.ActionID,
+			&i.DedupKey,
+			&i.Payload,
+			&i.Status,
+			&i.IssueID,
+			&i.ErrorMessage,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWebhookActionEvents = `-- name: ListWebhookActionEvents :many
+SELECT id, webhook_id, action_id, dedup_key, payload, status, issue_id, error_message, created_at FROM webhook_event_log
+WHERE action_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListWebhookActionEventsParams struct {
+	ActionID pgtype.UUID `json:"action_id"`
+	Limit    int32       `json:"limit"`
+	Offset   int32       `json:"offset"`
+}
+
+func (q *Queries) ListWebhookActionEvents(ctx context.Context, arg ListWebhookActionEventsParams) ([]WebhookEventLog, error) {
+	rows, err := q.db.Query(ctx, listWebhookActionEvents, arg.ActionID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []WebhookEventLog{}
+	for rows.Next() {
+		var i WebhookEventLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.WebhookID,
+			&i.ActionID,
 			&i.DedupKey,
 			&i.Payload,
 			&i.Status,
@@ -461,7 +508,7 @@ func (q *Queries) ListWebhooksByWorkspace(ctx context.Context, workspaceID pgtyp
 }
 
 const listWorkspaceWebhookEvents = `-- name: ListWorkspaceWebhookEvents :many
-SELECT wel.id, wel.webhook_id, wel.dedup_key, wel.payload, wel.status, wel.issue_id, wel.error_message, wel.created_at
+SELECT wel.id, wel.webhook_id, wel.action_id, wel.dedup_key, wel.payload, wel.status, wel.issue_id, wel.error_message, wel.created_at
 FROM webhook_event_log wel
 JOIN webhook w ON w.id = wel.webhook_id
 WHERE w.workspace_id = $1
@@ -487,6 +534,7 @@ func (q *Queries) ListWorkspaceWebhookEvents(ctx context.Context, arg ListWorksp
 		if err := rows.Scan(
 			&i.ID,
 			&i.WebhookID,
+			&i.ActionID,
 			&i.DedupKey,
 			&i.Payload,
 			&i.Status,

--- a/server/pkg/db/queries/webhook.sql
+++ b/server/pkg/db/queries/webhook.sql
@@ -70,8 +70,8 @@ RETURNING *;
 DELETE FROM webhook_action WHERE id = $1;
 
 -- name: CreateWebhookEventLog :one
-INSERT INTO webhook_event_log (webhook_id, dedup_key, payload, status, issue_id, error_message)
-VALUES ($1, $2, $3, $4, sqlc.narg(issue_id), sqlc.narg(error_message))
+INSERT INTO webhook_event_log (webhook_id, action_id, dedup_key, payload, status, issue_id, error_message)
+VALUES ($1, sqlc.narg(action_id), $2, $3, $4, sqlc.narg(issue_id), sqlc.narg(error_message))
 RETURNING *;
 
 -- name: ListWebhookEvents :many
@@ -79,6 +79,7 @@ SELECT * FROM webhook_event_log
 WHERE webhook_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
+
 
 -- name: CountWebhookEvents :one
 SELECT count(*) FROM webhook_event_log WHERE webhook_id = $1;
@@ -90,9 +91,15 @@ WHERE webhook_id = $1 AND dedup_key = $2 AND status = 'processed'
 LIMIT 1;
 
 -- name: ListWorkspaceWebhookEvents :many
-SELECT wel.id, wel.webhook_id, wel.dedup_key, wel.payload, wel.status, wel.issue_id, wel.error_message, wel.created_at
+SELECT wel.id, wel.webhook_id, wel.action_id, wel.dedup_key, wel.payload, wel.status, wel.issue_id, wel.error_message, wel.created_at
 FROM webhook_event_log wel
 JOIN webhook w ON w.id = wel.webhook_id
 WHERE w.workspace_id = $1
 ORDER BY wel.created_at DESC
+LIMIT $2 OFFSET $3;
+
+-- name: ListWebhookActionEvents :many
+SELECT * FROM webhook_event_log
+WHERE action_id = $1
+ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;


### PR DESCRIPTION
## Summary

Adds the ability to view recent webhook events filtered by individual webhook actions. Users can now expand a webhook card, then toggle a "Recent events" panel within each action to see events specific to that action.

## Key Changes

- **Database schema**: Added `action_id` column to `webhook_event_log` table with a foreign key to `webhook_action` and an index for efficient querying
- **Backend API**: 
  - New `ListWebhookActionEvents` handler to fetch events for a specific action
  - Updated `CreateWebhookEventLog` to accept and store `action_id` when logging webhook events
  - Modified webhook ingestion logic to pass the action ID when logging successful or failed action executions
- **Frontend**:
  - New `ActionEventsPanel` component that displays recent events for an action with expand/collapse toggle
  - Updated `ActionSummary` to load and display per-action events on demand
  - Added `listWebhookActionEvents` API client method
  - Updated `WebhookEvent` type to include optional `action_id` field
- **Tests**: Added comprehensive test suite for per-action event history functionality with mocks for the new API endpoint

## Implementation Details

- Events are loaded lazily when the per-action panel is first expanded
- Displays up to 10 most recent events with a count badge; shows "No events for this action yet" when empty
- Action ID is only set when an action successfully processes or fails; other event types (deduped, filtered) have null action_id
- Database index on `(action_id, created_at DESC)` enables efficient queries for recent action events

https://claude.ai/code/session_01LbxooTVKx5fuPxiuW5W6Se