### PR TITLE
fix(web): blur pin button after click so controls hide on pointer leave

### DIFF
--- a/apps/web/app/(dashboard)/_components/app-sidebar.test.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.test.tsx
@@ -653,6 +653,20 @@ describe("AppSidebar pinned issues", () => {
     expect(sectionContainers[0]).toBe("recents-pinned-section");
   });
 
+  it("blurs the pin button after clicking so controls hide when the pointer leaves", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    await screen.findByText("Other workspace issue");
+
+    const pinBtn = screen.getByRole("button", { name: /Pin Other workspace issue/i });
+    await user.click(pinBtn);
+
+    // After clicking, the button must not hold focus so the hover-only
+    // controls disappear when the pointer moves away.
+    expect(document.activeElement).not.toBe(pinBtn);
+  });
+
   it("unpins an issue from the Pinned section", async () => {
     const user = userEvent.setup();
     useRecentsPrefsStore.setState({ pinnedIssueIds: ["issue-2"] });

--- a/apps/web/app/(dashboard)/_components/app-sidebar.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.tsx
@@ -127,6 +127,7 @@ function RecentIssueRow({
           event.preventDefault();
           event.stopPropagation();
           onTogglePin();
+          event.currentTarget.blur();
         }}
       >
         {pinned ? <PinOff /> : <Pin />}


### PR DESCRIPTION
## Summary

Fixes #215

- After clicking a Recents pin/unpin button, the button retained focus. This triggered the `group-focus-within/menu-item:opacity-100` CSS rule, keeping the hover-only action cluster visible even after the pointer moved away.
- Fix: call `event.currentTarget.blur()` in the onClick handler immediately after the pin action. Focus is dropped right away, so the controls disappear as soon as the pointer leaves the row.
- Hover still reveals the controls. Keyboard focus still makes them visible and operable (the `group-focus-within` rule still applies when the user tabs to the button).

## Test plan

- [x] All 26 existing sidebar tests pass
- [x] New test: `blurs the pin button after clicking so controls hide when the pointer leaves` — asserts `document.activeElement !== pinBtn` after a click, confirming focus is released

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHL5Esx7tXnQpUFo3c3ccu)_