### PR TITLE
feat: embed agent run traces inside their reply comments

### DIFF
--- a/apps/web/features/issues/components/agent-live-card.test.ts
+++ b/apps/web/features/issues/components/agent-live-card.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import type { AgentTask } from "@/shared/types/agent";
-import { groupTaskRunsByTrigger, isActiveTask } from "./agent-live-card";
+import {
+  groupTaskRunsByTrigger,
+  isActiveTask,
+  partitionTaskRunsByResultComment,
+} from "./agent-live-card";
 
 function makeTask(overrides: Partial<AgentTask>): AgentTask {
   return {
@@ -66,5 +70,50 @@ describe("isActiveTask", () => {
     expect(isActiveTask(makeTask({ status: "completed" }))).toBe(false);
     expect(isActiveTask(makeTask({ status: "failed" }))).toBe(false);
     expect(isActiveTask(makeTask({ status: "cancelled" }))).toBe(false);
+  });
+});
+
+describe("partitionTaskRunsByResultComment", () => {
+  it("sends tasks without a result_comment_id to the standalone bucket", () => {
+    const tasks = [
+      makeTask({ id: "running", status: "running", result_comment_id: null }),
+      makeTask({ id: "no-reply", status: "completed", result_comment_id: undefined }),
+      makeTask({ id: "failed", status: "failed", result_comment_id: null }),
+    ];
+    const { embedded, standalone } = partitionTaskRunsByResultComment(tasks);
+    expect(embedded.size).toBe(0);
+    expect(standalone.map((t) => t.id)).toEqual(["running", "no-reply", "failed"]);
+  });
+
+  it("embeds tasks with a result_comment_id under that comment id", () => {
+    const tasks = [
+      makeTask({ id: "t1", status: "completed", result_comment_id: "reply-a" }),
+      makeTask({ id: "t2", status: "completed", result_comment_id: "reply-b" }),
+    ];
+    const { embedded, standalone } = partitionTaskRunsByResultComment(tasks);
+    expect(standalone).toHaveLength(0);
+    expect(embedded.get("reply-a")?.map((t) => t.id)).toEqual(["t1"]);
+    expect(embedded.get("reply-b")?.map((t) => t.id)).toEqual(["t2"]);
+  });
+
+  it("groups multiple runs that share one reply chronologically", () => {
+    const tasks = [
+      makeTask({ id: "third", created_at: "2026-05-03T00:00:00Z", result_comment_id: "reply-x" }),
+      makeTask({ id: "first", created_at: "2026-05-01T00:00:00Z", result_comment_id: "reply-x" }),
+      makeTask({ id: "second", created_at: "2026-05-02T00:00:00Z", result_comment_id: "reply-x" }),
+    ];
+    const { embedded } = partitionTaskRunsByResultComment(tasks);
+    expect(embedded.get("reply-x")?.map((t) => t.id)).toEqual(["first", "second", "third"]);
+  });
+
+  it("mixes the two buckets cleanly when some runs have a reply and others don't", () => {
+    const tasks = [
+      makeTask({ id: "active", status: "running", result_comment_id: null }),
+      makeTask({ id: "done", status: "completed", result_comment_id: "reply-y" }),
+      makeTask({ id: "orphan", status: "failed", result_comment_id: null }),
+    ];
+    const { embedded, standalone } = partitionTaskRunsByResultComment(tasks);
+    expect(embedded.get("reply-y")?.map((t) => t.id)).toEqual(["done"]);
+    expect(standalone.map((t) => t.id).sort()).toEqual(["active", "orphan"]);
   });
 });

--- a/apps/web/features/issues/components/agent-live-card.tsx
+++ b/apps/web/features/issues/components/agent-live-card.tsx
@@ -12,6 +12,7 @@ import {
   CheckCircle2,
   XCircle,
   Square,
+  Layers,
 } from "lucide-react";
 import { api } from "@/shared/api";
 import { useWSEvent } from "@/features/realtime";
@@ -634,6 +635,188 @@ export function groupTaskRunsByTrigger(tasks: AgentTask[]): {
   }
 
   return { issueTriggered, byCommentId };
+}
+
+/**
+ * Partition tasks into the two rendering buckets:
+ * - `embedded`: tasks with a `result_comment_id` — render inside the
+ *   corresponding agent reply comment. Tasks targeting the same comment
+ *   are grouped together (oldest first).
+ * - `standalone`: tasks without a `result_comment_id` — render as their
+ *   own card in the activity timeline (current behavior; preserves
+ *   active-run visibility and orphan tasks that never produced a reply).
+ */
+export function partitionTaskRunsByResultComment(tasks: AgentTask[]): {
+  embedded: Map<string, AgentTask[]>;
+  standalone: AgentTask[];
+} {
+  const embedded = new Map<string, AgentTask[]>();
+  const standalone: AgentTask[] = [];
+
+  const sorted = [...tasks].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+
+  for (const t of sorted) {
+    if (t.result_comment_id) {
+      const list = embedded.get(t.result_comment_id) ?? [];
+      list.push(t);
+      embedded.set(t.result_comment_id, list);
+    } else {
+      standalone.push(t);
+    }
+  }
+
+  return { embedded, standalone };
+}
+
+// ─── RunTraceGroup — multiple runs sharing one reply ───────────────────────
+
+interface RunTraceGroupProps {
+  tasks: AgentTask[];
+  fallbackAgentName?: string;
+}
+
+type GroupStatus = "active" | "all_completed" | "has_failed" | "cancelled" | "mixed";
+
+function resolveGroupStatus(tasks: AgentTask[]): GroupStatus {
+  if (tasks.some(isActiveTask)) return "active";
+  if (tasks.every((t) => t.status === "completed")) return "all_completed";
+  const failed = tasks.filter((t) => t.status === "failed").length;
+  const cancelled = tasks.filter((t) => t.status === "cancelled").length;
+  if (failed > 0) return "has_failed";
+  if (cancelled > 0 && cancelled === tasks.length) return "cancelled";
+  return "mixed";
+}
+
+function sumDurationMs(tasks: AgentTask[]): number {
+  let total = 0;
+  for (const t of tasks) {
+    if (t.started_at && t.completed_at) {
+      total += new Date(t.completed_at).getTime() - new Date(t.started_at).getTime();
+    }
+  }
+  return total;
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms <= 0) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m ${secs}s`;
+}
+
+/**
+ * RunTraceGroup wraps N≥2 task runs that share a single agent reply.
+ * Collapsed: a single summary strip (count, total duration, status badge).
+ * Expanded: each task renders as its own TaskRunCard, individually
+ * collapsible. When N=1 the caller should render a bare TaskRunCard
+ * instead — this component does not special-case the singleton path so
+ * the wrapper stays predictable.
+ */
+export function RunTraceGroup({ tasks, fallbackAgentName }: RunTraceGroupProps) {
+  const [open, setOpen] = useState(false);
+  const status = resolveGroupStatus(tasks);
+  const totalMs = sumDurationMs(tasks);
+  const runtimes = useRuntimeStore((s) => s.runtimes);
+  const daemons = useRuntimeStore((s) => s.daemons);
+
+  // Show runtime label only when every task in the group shares one — a
+  // mixed-runtime group hides it to avoid lying.
+  const runtimeIds = new Set(tasks.map((t) => t.runtime_id));
+  let runtimeLabel = "";
+  if (runtimeIds.size === 1) {
+    const runtime = runtimes.find((r) => r.id === tasks[0]!.runtime_id);
+    const daemon = runtime?.daemon_ref ? daemons.find((d) => d.id === runtime.daemon_ref) : null;
+    runtimeLabel = [daemon?.device_name || daemon?.daemon_id, runtime?.provider]
+      .filter(Boolean)
+      .join(" / ");
+  }
+
+  const failedCount = tasks.filter((t) => t.status === "failed").length;
+  const activeCount = tasks.filter(isActiveTask).length;
+
+  return (
+    <div
+      data-testid="run-trace-group"
+      data-run-count={tasks.length}
+      data-run-status={status}
+      className={cn(
+        "rounded-md border bg-muted/30",
+        status === "active" && "border-info/20 bg-info/5",
+      )}
+    >
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 text-left">
+          <ChevronRight
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-90",
+            )}
+          />
+          <Layers className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="text-xs font-medium shrink-0">{tasks.length} runs</span>
+          {totalMs > 0 && (
+            <span className="text-xs text-muted-foreground shrink-0">
+              · {formatDurationMs(totalMs)} total
+            </span>
+          )}
+          {runtimeLabel && (
+            <span className="text-xs text-muted-foreground shrink-0 truncate">
+              · {runtimeLabel}
+            </span>
+          )}
+          <span className="ml-auto flex items-center gap-1 shrink-0 text-xs">
+            {status === "active" && (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin text-info" />
+                <span className="text-info font-medium">{activeCount} running</span>
+              </>
+            )}
+            {status === "all_completed" && (
+              <>
+                <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+                <span className="text-success font-medium">All completed</span>
+              </>
+            )}
+            {status === "has_failed" && (
+              <>
+                <XCircle className="h-3.5 w-3.5 text-destructive" />
+                <span className="text-destructive font-medium">{failedCount} failed</span>
+              </>
+            )}
+            {status === "cancelled" && (
+              <span className="text-muted-foreground font-medium">Cancelled</span>
+            )}
+            {status === "mixed" && (
+              <span className="text-muted-foreground font-medium">Mixed</span>
+            )}
+          </span>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="flex flex-col gap-1.5 border-t border-border/50 p-2">
+            {tasks.map((task, idx) => (
+              <div
+                key={task.id}
+                className="flex items-center gap-1.5"
+                data-testid="run-trace-group-item"
+              >
+                <span className="shrink-0 w-10 text-[10px] uppercase tracking-wide text-muted-foreground tabular-nums">
+                  Run {idx + 1}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <TaskRunCard task={task} fallbackAgentName={fallbackAgentName} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
 }
 
 /** Programmatic helper: scroll to and expand a task run card. */

--- a/apps/web/features/issues/components/comment-card.tsx
+++ b/apps/web/features/issues/components/comment-card.tsx
@@ -53,6 +53,14 @@ interface CommentCardProps {
   onToggleReaction: (commentId: string, emoji: string) => void;
   /** ID of the comment to highlight (flash animation). */
   highlightedCommentId?: string | null;
+  /**
+   * Run trace nodes to embed inside this thread, keyed by the reply comment
+   * id they belong to. The trace renders between the header and the content
+   * body of whichever entry matches — parent or any nested reply. Used to
+   * surface "how did the agent arrive at this reply" right under the reply
+   * itself instead of as a sibling card.
+   */
+  runTraces?: Map<string, React.ReactNode>;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +120,7 @@ function CommentRow({
   onEdit,
   onDelete,
   onToggleReaction,
+  runTrace,
 }: {
   issueId: string;
   entry: TimelineEntry;
@@ -119,6 +128,7 @@ function CommentRow({
   onEdit: (commentId: string, content: string) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;
+  runTrace?: React.ReactNode;
 }) {
   const { getActorName } = useActorName();
   const [editing, setEditing] = useState(false);
@@ -231,6 +241,12 @@ function CommentRow({
         )}
       </div>
 
+      {runTrace && (
+        <div className="mt-2 pl-8 animate-in fade-in slide-in-from-top-1 duration-300">
+          {runTrace}
+        </div>
+      )}
+
       {editing ? (
         <div
           className="mt-1.5 pl-8"
@@ -297,6 +313,7 @@ function CommentCard({
   onDelete,
   onToggleReaction,
   highlightedCommentId,
+  runTraces,
 }: CommentCardProps) {
   const { getActorName } = useActorName();
   const { uploadWithToast } = useFileUpload();
@@ -471,7 +488,12 @@ function CommentCard({
               </div>
             ) : (
               <>
-                <div className="pl-10 text-sm leading-relaxed text-foreground/85">
+                {runTraces?.get(entry.id) && (
+                  <div className="mt-2 pl-10 animate-in fade-in slide-in-from-top-1 duration-300">
+                    {runTraces.get(entry.id)}
+                  </div>
+                )}
+                <div className={cn("pl-10 text-sm leading-relaxed text-foreground/85", runTraces?.get(entry.id) && "mt-2")}>
                   <ReadonlyEditor content={entry.content ?? ""} />
                 </div>
                 {(entry.attachments?.length ?? 0) > 0 && (
@@ -502,6 +524,7 @@ function CommentCard({
                 onEdit={onEdit}
                 onDelete={onDelete}
                 onToggleReaction={onToggleReaction}
+                runTrace={runTraces?.get(reply.id)}
               />
             </div>
           ))}

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -69,8 +69,10 @@ import { CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
 import {
   TaskRunCard,
+  RunTraceGroup,
   useIssueTaskRuns,
   groupTaskRunsByTrigger,
+  partitionTaskRunsByResultComment,
   isActiveTask,
   scrollToTaskRun,
 } from "./agent-live-card";
@@ -730,10 +732,21 @@ export function IssueDetail({ issueId, onDelete, onBack, defaultSidebarOpen = tr
     subscribers, loading: subscribersLoading, isSubscribed, toggleSubscribe: handleToggleSubscribe, toggleSubscriber,
   } = useIssueSubscribers(id, user?.id);
 
-  // Agent task runs for this issue — used to render run cards inline at
-  // the point that triggered them (issue or comment).
+  // Agent task runs for this issue. Split into two buckets:
+  // - Tasks with a `result_comment_id` embed inside the corresponding agent
+  //   reply (via CommentCard.runTraces). This is the new primary path.
+  // - Tasks without a `result_comment_id` (active, or finished-without-reply)
+  //   fall back to the legacy standalone rendering: at the top of the
+  //   activity feed (issue-triggered) or under the triggering comment
+  //   thread (comment-triggered), grouped by `trigger_comment_id`.
   const taskRuns = useIssueTaskRuns(id);
-  const taskRunBuckets = useMemo(() => groupTaskRunsByTrigger(taskRuns), [taskRuns]);
+  const { embeddedTaskRuns, standaloneBuckets } = useMemo(() => {
+    const { embedded, standalone } = partitionTaskRunsByResultComment(taskRuns);
+    return {
+      embeddedTaskRuns: embedded,
+      standaloneBuckets: groupTaskRunsByTrigger(standalone),
+    };
+  }, [taskRuns]);
   const activeTaskRun = useMemo(() => taskRuns.find(isActiveTask) ?? null, [taskRuns]);
 
   const loading = issueLoading;
@@ -1441,13 +1454,42 @@ export function IssueDetail({ issueId, onDelete, onBack, defaultSidebarOpen = tr
                   if (topId) topLevelOf.set(e.id, topId);
                 }
 
-                // Bucket comment-triggered task runs by their top-level
-                // comment id. Orphans (comment not in the loaded timeline)
-                // fall through to the issue-level bucket so they remain
-                // visible.
+                const fallbackAgentName =
+                  issue.assignee_type === "agent" && issue.assignee_id
+                    ? getActorName("agent", issue.assignee_id)
+                    : undefined;
+
+                // Build runTraces (commentId → React node) for tasks that
+                // have produced a reply. Tasks whose result_comment_id is
+                // not present in the loaded timeline fall through to the
+                // standalone path so the run never silently disappears.
+                const runTracesByCommentId = new Map<string, React.ReactNode>();
+                const demotedToStandalone: AgentTask[] = [];
+                for (const [commentId, runs] of embeddedTaskRuns) {
+                  if (!topLevelOf.has(commentId)) {
+                    demotedToStandalone.push(...runs);
+                    continue;
+                  }
+                  const node =
+                    runs.length === 1 ? (
+                      <TaskRunCard
+                        key={runs[0]!.id}
+                        task={runs[0]!}
+                        fallbackAgentName={fallbackAgentName}
+                      />
+                    ) : (
+                      <RunTraceGroup tasks={runs} fallbackAgentName={fallbackAgentName} />
+                    );
+                  runTracesByCommentId.set(commentId, node);
+                }
+
+                // Bucket *standalone* comment-triggered tasks by their
+                // top-level comment id (legacy fallback rendering — for
+                // active runs that haven't produced a reply yet, and
+                // failed runs that never wrote one).
                 const runsByTopLevel = new Map<string, AgentTask[]>();
                 const orphanRuns: AgentTask[] = [];
-                for (const [commentId, runs] of taskRunBuckets.byCommentId) {
+                for (const [commentId, runs] of standaloneBuckets.byCommentId) {
                   const topId = topLevelOf.get(commentId);
                   if (!topId) {
                     orphanRuns.push(...runs);
@@ -1463,14 +1505,17 @@ export function IssueDetail({ issueId, onDelete, onBack, defaultSidebarOpen = tr
                   );
                 }
 
-                const issueLevelRuns = [...taskRunBuckets.issueTriggered, ...orphanRuns].sort(
+                // Issue-level standalone runs include three sources:
+                // explicitly issue-triggered, orphans (comment-triggered
+                // but trigger comment not loaded), and demoted runs
+                // (result_comment_id present but reply not loaded).
+                const issueLevelRuns = [
+                  ...standaloneBuckets.issueTriggered,
+                  ...orphanRuns,
+                  ...demotedToStandalone,
+                ].sort(
                   (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
                 );
-
-                const fallbackAgentName =
-                  issue.assignee_type === "agent" && issue.assignee_id
-                    ? getActorName("agent", issue.assignee_id)
-                    : undefined;
 
                 // Coalesce: same actor + same action within 2 min → keep last only
                 const COALESCE_MS = 2 * 60 * 1000;
@@ -1525,6 +1570,7 @@ export function IssueDetail({ issueId, onDelete, onBack, defaultSidebarOpen = tr
                             onDelete={deleteComment}
                             onToggleReaction={handleToggleReaction}
                             highlightedCommentId={highlightedId}
+                            runTraces={runTracesByCommentId}
                           />
                         </div>
                         {triggeredRuns.length > 0 && (

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -87,6 +87,12 @@ export interface AgentTask {
   created_at: string;
   /** Comment that triggered this run; absent/null when triggered by the issue itself. */
   trigger_comment_id?: string | null;
+  /**
+   * Reply comment this run produced; absent/null while the run is still
+   * active or when it finished without writing a reply. Used by the UI to
+   * embed run traces inside their corresponding agent reply.
+   */
+  result_comment_id?: string | null;
 }
 
 export interface Agent {

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -680,6 +680,11 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	if len(attachmentIDs) > 0 {
 		body["attachment_ids"] = attachmentIDs
 	}
+	// When invoked by the daemon during task execution, link this reply back
+	// to its originating task so the UI can embed the run trace under it.
+	if taskID := os.Getenv("MULTICA_TASK_ID"); taskID != "" {
+		body["task_id"] = taskID
+	}
 	var result map[string]any
 	if err := client.PostJSON(ctx, "/api/issues/"+issueID+"/comments", body, &result); err != nil {
 		return fmt.Errorf("add comment: %w", err)

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -113,6 +113,7 @@ type AgentTaskResponse struct {
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
+	ResultCommentID  *string        `json:"result_comment_id,omitempty"`  // comment this run produced as its final reply
 	GitHubToken      string `json:"github_token,omitempty"`
 	GitHubCodeAccess string `json:"github_code_access,omitempty"`
 	ProviderAPIKey   string `json:"provider_api_key,omitempty"` // workspace-level API key for the provider
@@ -151,6 +152,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
+		ResultCommentID:  uuidToPtr(t.ResultCommentID),
 	}
 }
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -91,6 +91,10 @@ type CreateCommentRequest struct {
 	Type          string   `json:"type"`
 	ParentID      *string  `json:"parent_id"`
 	AttachmentIDs []string `json:"attachment_ids"`
+	// TaskID, when set by an agent CLI invocation, links the created comment
+	// back to the task that produced it (sets result_comment_id). Ignored for
+	// non-agent authors and tasks owned by a different agent.
+	TaskID string `json:"task_id,omitempty"`
 }
 
 func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
@@ -155,6 +159,29 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// Link uploaded attachments to this comment.
 	if len(req.AttachmentIDs) > 0 {
 		h.linkAttachmentsByIDs(r.Context(), comment.ID, issue.ID, req.AttachmentIDs)
+	}
+
+	// Link this reply back to its originating task when the agent CLI passes
+	// MULTICA_TASK_ID. Only honored for agent authors whose ID matches the
+	// task's agent_id, so a member can't hijack the link.
+	if req.TaskID != "" && authorType == "agent" && req.Type == "comment" {
+		taskUUID := parseUUID(req.TaskID)
+		if taskUUID.Valid {
+			if task, err := h.Queries.GetAgentTask(r.Context(), taskUUID); err == nil {
+				if uuidToString(task.AgentID) == authorID && uuidToString(task.IssueID) == issueID {
+					if _, err := h.Queries.SetAgentTaskResultComment(r.Context(), db.SetAgentTaskResultCommentParams{
+						ID:              taskUUID,
+						ResultCommentID: comment.ID,
+					}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+						slog.Warn("link result comment failed",
+							"task_id", req.TaskID,
+							"comment_id", uuidToString(comment.ID),
+							"error", err,
+						)
+					}
+				}
+			}
+		}
 	}
 
 	// Fetch linked attachments so the response includes them.

--- a/server/internal/handler/comment_task_link_test.go
+++ b/server/internal/handler/comment_task_link_test.go
@@ -1,0 +1,171 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+// seedAgentTaskForResultCommentTest creates an agent and an issue assigned
+// to it. The CreateIssue handler auto-enqueues a task for any agent-assigned
+// issue, so we read that task back instead of creating a second one (which
+// would trip idx_one_pending_task_per_issue). Returns agent ID, issue ID,
+// and task ID. The caller's t.Cleanup tears everything down.
+func seedAgentTaskForResultCommentTest(t *testing.T, ctx context.Context, agentName string) (string, string, string) {
+	t.Helper()
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, description, visibility, owner_id, tools, triggers, providers)
+		VALUES ($1, $2, '', 'workspace', $3, '[]'::jsonb, '[]'::jsonb, ARRAY['codex'])
+		RETURNING id
+	`, testWorkspaceID, agentName, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "result-comment-link test issue " + agentName,
+		"status":        "in_progress",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != 201 {
+		t.Fatalf("create issue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var issueResp IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&issueResp); err != nil {
+		t.Fatalf("decode issue response: %v", err)
+	}
+	issueID := issueResp.ID
+
+	// Pick up the task that CreateIssue auto-enqueued for the agent.
+	var taskID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent_task_queue WHERE issue_id = $1 ORDER BY created_at DESC LIMIT 1`,
+		issueID,
+	).Scan(&taskID); err != nil {
+		t.Fatalf("read auto-enqueued task: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	return agentID, issueID, taskID
+}
+
+// fetchTaskResultCommentID reads result_comment_id straight from the DB
+// (bypasses the API to assert what was persisted).
+func fetchTaskResultCommentID(t *testing.T, ctx context.Context, taskID string) *string {
+	t.Helper()
+	var resultID *string
+	if err := testPool.QueryRow(ctx,
+		`SELECT result_comment_id::text FROM agent_task_queue WHERE id = $1`, taskID,
+	).Scan(&resultID); err != nil {
+		t.Fatalf("read result_comment_id: %v", err)
+	}
+	return resultID
+}
+
+func TestCreateComment_AgentAuthorWithTaskID_LinksResultComment(t *testing.T) {
+	ctx := context.Background()
+	agentID, issueID, taskID := seedAgentTaskForResultCommentTest(t, ctx, "result-comment-link-happy")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "Done.",
+		"task_id": taskID,
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req = withURLParam(req, "id", issueID)
+	testHandler.CreateComment(w, req)
+	if w.Code != 201 {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode comment response: %v", err)
+	}
+
+	got := fetchTaskResultCommentID(t, ctx, taskID)
+	if got == nil {
+		t.Fatalf("expected result_comment_id to be set after agent comment with task_id, got nil")
+	}
+	if *got != resp.ID {
+		t.Fatalf("result_comment_id = %s, want %s", *got, resp.ID)
+	}
+}
+
+func TestCreateComment_MemberAuthorWithTaskID_IgnoresTaskID(t *testing.T) {
+	ctx := context.Background()
+	_, issueID, taskID := seedAgentTaskForResultCommentTest(t, ctx, "result-comment-link-member")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "Hi.",
+		"task_id": taskID,
+	})
+	// No X-Agent-ID — handler resolves the authenticated member as author.
+	req = withURLParam(req, "id", issueID)
+	testHandler.CreateComment(w, req)
+	if w.Code != 201 {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := fetchTaskResultCommentID(t, ctx, taskID); got != nil {
+		t.Fatalf("expected result_comment_id to remain NULL for member-authored comment, got %q", *got)
+	}
+}
+
+func TestCreateComment_AgentAuthorWithMismatchedTaskID_IgnoresTaskID(t *testing.T) {
+	ctx := context.Background()
+	agentA, issueA, taskA := seedAgentTaskForResultCommentTest(t, ctx, "result-comment-link-mismatch-a")
+	_ = agentA
+	_ = issueA
+	// A different agent (agent B) tries to claim taskA as its result. Should be ignored.
+	agentB, issueB, _ := seedAgentTaskForResultCommentTest(t, ctx, "result-comment-link-mismatch-b")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueB+"/comments", map[string]any{
+		"content": "Wrong task link.",
+		"task_id": taskA,
+	})
+	req.Header.Set("X-Agent-ID", agentB)
+	req = withURLParam(req, "id", issueB)
+	testHandler.CreateComment(w, req)
+	if w.Code != 201 {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := fetchTaskResultCommentID(t, ctx, taskA); got != nil {
+		t.Fatalf("expected result_comment_id to remain NULL when agent_id mismatches, got %q", *got)
+	}
+}
+
+func TestCreateComment_SystemTypeWithTaskID_IgnoresTaskID(t *testing.T) {
+	ctx := context.Background()
+	agentID, issueID, taskID := seedAgentTaskForResultCommentTest(t, ctx, "result-comment-link-system")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "System annotation.",
+		"type":    "system",
+		"task_id": taskID,
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req = withURLParam(req, "id", issueID)
+	testHandler.CreateComment(w, req)
+	if w.Code != 201 {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := fetchTaskResultCommentID(t, ctx, taskID); got != nil {
+		t.Fatalf("expected result_comment_id to remain NULL for system-type comment, got %q", *got)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -421,7 +421,8 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// Comment-triggered tasks: the agent replies via CLI with --parent, so
 	// posting here would create a duplicate.
 	if !handledByVerificationFlow && !task.TriggerCommentID.Valid && output != "" {
-		s.createAgentComment(ctx, task.IssueID, task.AgentID, output, "comment", task.TriggerCommentID)
+		reply := s.createAgentComment(ctx, task.IssueID, task.AgentID, output, "comment", task.TriggerCommentID)
+		s.linkResultComment(ctx, task.ID, reply)
 	}
 
 	// Reconcile agent status
@@ -459,7 +460,8 @@ func (s *TaskService) handleVerificationCompletion(ctx context.Context, task db.
 		if comment == "" {
 			comment = "验收标准已起草，等待确认。"
 		}
-		s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(comment), "comment", task.TriggerCommentID)
+		reply := s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(comment), "comment", task.TriggerCommentID)
+		s.linkResultComment(ctx, task.ID, reply)
 		s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text("验收标准已生成，请在 issue 详情页确认后继续。"), "system", task.TriggerCommentID)
 
 		s.broadcastIssueUpdated(issue)
@@ -471,7 +473,8 @@ func (s *TaskService) handleVerificationCompletion(ctx context.Context, task db.
 			return fmt.Errorf("load issue: %w", err)
 		}
 		if output != "" {
-			s.createAgentComment(ctx, task.IssueID, task.AgentID, output, "comment", task.TriggerCommentID)
+			reply := s.createAgentComment(ctx, task.IssueID, task.AgentID, output, "comment", task.TriggerCommentID)
+			s.linkResultComment(ctx, task.ID, reply)
 		}
 
 		if !issue.VerifierAgentID.Valid || !issue.AssigneeID.Valid ||
@@ -512,7 +515,8 @@ func (s *TaskService) handleVerificationCompletion(ctx context.Context, task db.
 			if humanOutput == "" {
 				humanOutput = "验收通过。"
 			}
-			s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(humanOutput), "comment", task.TriggerCommentID)
+			reply := s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(humanOutput), "comment", task.TriggerCommentID)
+			s.linkResultComment(ctx, task.ID, reply)
 			if issue.Status == "in_review" {
 				if updated, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{ID: issue.ID, Status: "done"}); err == nil {
 					s.broadcastIssueUpdated(updated)
@@ -534,7 +538,8 @@ func (s *TaskService) handleVerificationCompletion(ctx context.Context, task db.
 			if !strings.Contains(feedback, "mention://agent/"+util.UUIDToString(issue.AssigneeID)) {
 				feedback += "\n\n请修复后再次提交：" + assigneeMention
 			}
-			s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(feedback), "comment", task.TriggerCommentID)
+			reply := s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(feedback), "comment", task.TriggerCommentID)
+			s.linkResultComment(ctx, task.ID, reply)
 
 			round := maxRound(taskCtx.Round)
 			maxRounds := defaultVerificationRounds
@@ -871,14 +876,18 @@ func (s *TaskService) getIssuePrefix(workspaceID pgtype.UUID) string {
 	return ws.IssuePrefix
 }
 
-func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID pgtype.UUID, content, commentType string, parentID pgtype.UUID) {
+// createAgentComment creates an agent-authored comment, broadcasts the WS event,
+// and returns the created comment so callers can link it back to a task as
+// result_comment_id. Returns the zero value comment when content is empty or
+// the create call fails (the caller will see a zero ID and skip linking).
+func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID pgtype.UUID, content, commentType string, parentID pgtype.UUID) db.Comment {
 	if content == "" {
-		return
+		return db.Comment{}
 	}
 	// Look up issue to get workspace ID for mention expansion and broadcasting.
 	issue, err := s.Queries.GetIssue(ctx, issueID)
 	if err != nil {
-		return
+		return db.Comment{}
 	}
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
 	content = mention.ExpandIssueIdentifiers(ctx, s.Queries, issue.WorkspaceID, content)
@@ -891,7 +900,7 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 		ParentID:   parentID,
 	})
 	if err != nil {
-		return
+		return db.Comment{}
 	}
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventCommentCreated,
@@ -913,6 +922,32 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 			"issue_status": issue.Status,
 		},
 	})
+	return comment
+}
+
+// linkResultComment associates a task with the reply comment it produced.
+// Safe to call when comment.ID is zero (no-op). Only the first non-zero
+// comment per task wins — the SQL guard prevents accidental overwrites.
+func (s *TaskService) linkResultComment(ctx context.Context, taskID pgtype.UUID, comment db.Comment) {
+	if !comment.ID.Valid {
+		return
+	}
+	if _, err := s.Queries.SetAgentTaskResultComment(ctx, db.SetAgentTaskResultCommentParams{
+		ID:              taskID,
+		ResultCommentID: comment.ID,
+	}); err != nil {
+		// Not finding a row to update means another path already linked a
+		// reply for this task — that's the expected race for verification
+		// flows that create multiple comments. Anything else is logged but
+		// non-fatal: the run still completes, it just won't render embedded.
+		if !errors.Is(err, pgx.ErrNoRows) {
+			slog.Warn("link result comment failed",
+				"task_id", util.UUIDToString(taskID),
+				"comment_id", util.UUIDToString(comment.ID),
+				"error", err,
+			)
+		}
+	}
 }
 
 func issueToMap(issue db.Issue, issuePrefix string) map[string]any {

--- a/server/migrations/062_task_result_comment.down.sql
+++ b/server/migrations/062_task_result_comment.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_agent_task_queue_result_comment_id;
+
+ALTER TABLE agent_task_queue DROP COLUMN IF EXISTS result_comment_id;

--- a/server/migrations/062_task_result_comment.up.sql
+++ b/server/migrations/062_task_result_comment.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE agent_task_queue
+  ADD COLUMN result_comment_id UUID REFERENCES comment(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_agent_task_queue_result_comment_id
+  ON agent_task_queue (result_comment_id)
+  WHERE result_comment_id IS NOT NULL;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -54,7 +54,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -77,6 +77,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }
@@ -123,7 +124,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
 `
 
 // Claims the next queued task for an agent, enforcing per-issue serialization and
@@ -150,6 +151,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (Agen
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }
@@ -158,7 +160,7 @@ const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
 SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
 `
 
 type CompleteAgentTaskParams struct {
@@ -193,6 +195,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }
@@ -280,7 +283,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 const createAgentTask = `-- name: CreateAgentTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context)
 VALUES ($1, $2, $3, 'queued', $4, $5, $6)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
 `
 
 type CreateAgentTaskParams struct {
@@ -319,6 +322,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }
@@ -327,7 +331,7 @@ const failAgentTask = `-- name: FailAgentTask :one
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = $2
 WHERE id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
 `
 
 type FailAgentTaskParams struct {
@@ -355,6 +359,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }
@@ -473,7 +478,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -497,6 +502,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }
@@ -576,7 +582,7 @@ func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPen
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('dispatched', 'running')
 ORDER BY created_at DESC
 `
@@ -607,6 +613,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.ResultCommentID,
 		); err != nil {
 			return nil, err
 		}
@@ -619,7 +626,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listActiveTasksByWorkspace = `-- name: ListActiveTasksByWorkspace :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.result_comment_id FROM agent_task_queue atq
 JOIN issue i ON atq.issue_id = i.id
 WHERE i.workspace_id = $1 AND atq.status IN ('queued', 'dispatched', 'running')
 ORDER BY atq.created_at DESC
@@ -651,6 +658,7 @@ func (q *Queries) ListActiveTasksByWorkspace(ctx context.Context, workspaceID pg
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.ResultCommentID,
 		); err != nil {
 			return nil, err
 		}
@@ -663,7 +671,7 @@ func (q *Queries) ListActiveTasksByWorkspace(ctx context.Context, workspaceID pg
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -694,6 +702,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.ResultCommentID,
 		); err != nil {
 			return nil, err
 		}
@@ -800,7 +809,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -831,6 +840,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.ResultCommentID,
 		); err != nil {
 			return nil, err
 		}
@@ -843,7 +853,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -874,6 +884,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.ResultCommentID,
 		); err != nil {
 			return nil, err
 		}
@@ -919,11 +930,51 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 	return i, err
 }
 
+const setAgentTaskResultComment = `-- name: SetAgentTaskResultComment :one
+UPDATE agent_task_queue
+SET result_comment_id = $2
+WHERE id = $1 AND result_comment_id IS NULL
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+`
+
+type SetAgentTaskResultCommentParams struct {
+	ID              pgtype.UUID `json:"id"`
+	ResultCommentID pgtype.UUID `json:"result_comment_id"`
+}
+
+// Links a task to the comment it produced as its final reply. Only sets if
+// not already linked, so callers can safely call this even if a comment was
+// created in a transient path that already wrote the link.
+func (q *Queries) SetAgentTaskResultComment(ctx context.Context, arg SetAgentTaskResultCommentParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, setAgentTaskResultComment, arg.ID, arg.ResultCommentID)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ResultCommentID,
+	)
+	return i, err
+}
+
 const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running', started_at = now()
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
 `
 
 func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -946,6 +997,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.ResultCommentID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -82,6 +82,7 @@ type AgentTaskQueue struct {
 	SessionID        pgtype.Text        `json:"session_id"`
 	WorkDir          pgtype.Text        `json:"work_dir"`
 	TriggerCommentID pgtype.UUID        `json:"trigger_comment_id"`
+	ResultCommentID  pgtype.UUID        `json:"result_comment_id"`
 }
 
 type Attachment struct {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -114,6 +114,15 @@ SET status = 'completed', completed_at = now(), result = $2, session_id = $3, wo
 WHERE id = $1 AND status = 'running'
 RETURNING *;
 
+-- name: SetAgentTaskResultComment :one
+-- Links a task to the comment it produced as its final reply. Only sets if
+-- not already linked, so callers can safely call this even if a comment was
+-- created in a transient path that already wrote the link.
+UPDATE agent_task_queue
+SET result_comment_id = $2
+WHERE id = $1 AND result_comment_id IS NULL
+RETURNING *;
+
 -- name: GetLastTaskSession :one
 -- Returns the session_id and work_dir from the most recent completed task
 -- for a given (agent_id, issue_id) pair, used for session resumption.


### PR DESCRIPTION
## Summary

When an agent finishes a task and posts a reply comment, we now link
that reply back to the task and render the run trace **inside** the
reply itself instead of as a sibling card at the top of the activity
feed.

- Linear-style: the trace belongs to the answer, not to the issue
- Multi-run cases (agent retried before posting the final reply) collapse
  into a single `RunTraceGroup` strip
- Active runs / runs that never wrote a reply keep the existing
  standalone fallback — nothing silently disappears

### Mockups → reality

| Case | Render |
|---|---|
| 1 task → 1 reply | `TaskRunCard` embedded between the reply's header and its content |
| N tasks → 1 reply | `RunTraceGroup` summary (count · total duration · status) expandable to per-run `TaskRunCard`s |
| Active / orphan task | Standalone `TaskRunCard` (unchanged) |

### Backend

- `agent_task_queue.result_comment_id` (FK to `comment`, partial index)
- `SetAgentTaskResultComment` — idempotent linking query
- `service.CompleteTask` backfills the link on all comment-producing
  paths (success + verification approve/reject/escalate)
- `handler.CreateComment` accepts optional `task_id` from agent CLIs and
  links only when author / agent / issue all match
- `multica issue comment add` forwards `MULTICA_TASK_ID` from the daemon

### Frontend

- `AgentTask.result_comment_id` exposed on the type
- `partitionTaskRunsByResultComment` splits tasks into embedded vs
  standalone buckets
- `RunTraceGroup` aggregates multiple runs sharing one reply
- `CommentCard` accepts an optional `runTraces` map and embeds the
  matching node into each row (parent or nested reply)
- `IssueDetail` feeds the per-thread trace map to `CommentCard`

## Test plan

- [x] `make test-go` — added `comment_task_link_test.go` covering linking
  for agent author + task ownership / mismatched task / member author /
  system-type comment
- [x] `make test-ts` — extended `agent-live-card.test.ts` with cases for
  `partitionTaskRunsByResultComment` (empty / all standalone / single
  embedded / N grouped / mixed)
- [x] Manual: seeded 3 demo issues (DEV-100/101/102) covering single
  embedded, grouped, and standalone-active scenarios; verified embed,
  group expand/collapse, and standalone fallback in the dev UI
- [ ] `make test-e2e` if reviewer wants extra coverage on the comment
  ↔ task linking flow end-to-end


Made with [Cursor](https://cursor.com)