### PR TITLE
fix(issues): prevent workspace revert when switching from issue detail page

### DIFF
--- a/apps/web/app/(dashboard)/issues/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/issues/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect } from "react";
+import { use, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { IssueDetail } from "@/features/issues/components";
 import { useWorkspaceStore } from "@/features/workspace";
@@ -15,11 +15,16 @@ export default function LegacyIssueDetailPage({
   const router = useRouter();
   const workspace = useWorkspaceStore((s) => s.workspace);
 
-  // Resolve the issue's workspace in background. If it belongs to a different
-  // workspace than the active one, redirect to the canonical workspace-aware URL
-  // so the correct workspace context is loaded before rendering.
+  // Resolve the issue's workspace once on initial load. The ref prevents
+  // re-running after a user-initiated workspace switch, which would otherwise
+  // redirect back to the issue's original workspace.
+  const resolved = useRef(false);
+
   useEffect(() => {
+    if (resolved.current) return;
     if (!workspace?.slug) return;
+
+    resolved.current = true;
 
     api
       .resolveIssueWorkspace(id)

--- a/apps/web/app/(dashboard)/w/[workspaceSlug]/issues/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/w/[workspaceSlug]/issues/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect } from "react";
+import { use, useEffect, useRef, useState } from "react";
 import { IssueDetail } from "@/features/issues/components";
 import { useWorkspaceStore } from "@/features/workspace";
 import { MulticaIcon } from "@/components/multica-icon";
@@ -15,17 +15,32 @@ export default function WorkspaceIssueDetailPage({
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const switchWorkspace = useWorkspaceStore((s) => s.switchWorkspace);
 
+  // Prevent re-running the URL-based workspace sync after the initial load.
+  // Without this guard, a user-initiated workspace switch would be undone
+  // because the stale URL slug would trigger another switchWorkspace call.
+  const syncInitiated = useRef(false);
+  const [ready, setReady] = useState(false);
+
   useEffect(() => {
+    if (syncInitiated.current) return;
     if (!workspace || workspaces.length === 0) return;
-    if (workspace.slug === workspaceSlug) return;
+
+    syncInitiated.current = true;
+
+    if (workspace.slug === workspaceSlug) {
+      setReady(true);
+      return;
+    }
 
     const target = workspaces.find((w) => w.slug === workspaceSlug);
     if (target) {
-      void switchWorkspace(target.id);
+      void switchWorkspace(target.id).then(() => setReady(true));
+    } else {
+      setReady(true);
     }
   }, [workspace, workspaces, workspaceSlug, switchWorkspace]);
 
-  if (!workspace || workspace.slug !== workspaceSlug) {
+  if (!ready) {
     return (
       <div className="flex h-full items-center justify-center">
         <MulticaIcon className="size-6 animate-pulse" />

--- a/e2e/workspace-switch.spec.ts
+++ b/e2e/workspace-switch.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { loginAsDefault, createTestApi, openWorkspaceMenu } from "./helpers";
+import type { TestApiClient } from "./fixtures";
+
+test.describe("Workspace switch from issue detail", () => {
+  let api: TestApiClient;
+
+  test.beforeEach(async ({ page }) => {
+    api = await createTestApi();
+    await loginAsDefault(page, api);
+  });
+
+  test.afterEach(async () => {
+    await api.cleanup();
+  });
+
+  test("switching workspace from workspace-aware issue URL keeps the new workspace active", async ({
+    page,
+  }) => {
+    // Get primary workspace info before we touch workspaceId.
+    const primaryWsId = api.getWorkspaceId()!;
+    const allWorkspaces = await api.getWorkspaces();
+    const primaryWs = allWorkspaces.find((ws) => ws.id === primaryWsId)!;
+
+    // Create an issue in the primary workspace.
+    const issue = await api.createIssue("Workspace Switch Test " + Date.now());
+
+    // Ensure a second workspace exists (this updates api.workspaceId to it).
+    const secondWs = await api.ensureWorkspace("E2E Workspace 2", "e2e-workspace-2");
+    // Restore primary workspace context for any further api calls.
+    api.setWorkspaceId(primaryWsId);
+
+    // Navigate directly to the workspace-aware issue URL.
+    await page.goto(`/w/${primaryWs.slug}/issues/${issue.id}`);
+    await page.waitForURL(`**/w/${primaryWs.slug}/issues/${issue.id}`, { timeout: 10000 });
+    await expect(page.locator("text=Properties").first()).toBeVisible({ timeout: 10000 });
+
+    // Switch to the second workspace via the sidebar switcher.
+    await openWorkspaceMenu(page);
+    const menuItem = page.locator(`[role="menu"]`).getByText(secondWs.name).first();
+    await menuItem.waitFor({ state: "visible", timeout: 5000 });
+    await menuItem.click();
+
+    // Allow time for any unintended revert to happen.
+    await page.waitForTimeout(800);
+
+    // The second workspace should remain active — not reverted to primary.
+    const sidebar = page.locator('[data-slot="sidebar"]').first();
+    await expect(sidebar).toContainText(secondWs.name, { timeout: 5000 });
+    await expect(sidebar).not.toContainText(primaryWs.name);
+  });
+
+  test("switching workspace from legacy issue URL keeps the new workspace active", async ({
+    page,
+  }) => {
+    // Get primary workspace info.
+    const primaryWsId = api.getWorkspaceId()!;
+    const allWorkspaces = await api.getWorkspaces();
+    const primaryWs = allWorkspaces.find((ws) => ws.id === primaryWsId)!;
+
+    // Create an issue in the primary workspace.
+    const issue = await api.createIssue("Legacy Route Switch Test " + Date.now());
+
+    // Ensure a second workspace exists.
+    const secondWs = await api.ensureWorkspace("E2E Workspace 2", "e2e-workspace-2");
+    api.setWorkspaceId(primaryWsId);
+
+    // Navigate via the legacy /issues/:id route.
+    await page.goto(`/issues/${issue.id}`);
+    // Legacy route may redirect to workspace-aware URL — wait for either form.
+    await page.waitForURL(
+      (url) =>
+        url.pathname === `/issues/${issue.id}` ||
+        url.pathname === `/w/${primaryWs.slug}/issues/${issue.id}`,
+      { timeout: 10000 },
+    );
+    await expect(page.locator("text=Properties").first()).toBeVisible({ timeout: 10000 });
+
+    // Switch to the second workspace.
+    await openWorkspaceMenu(page);
+    const menuItem = page.locator(`[role="menu"]`).getByText(secondWs.name).first();
+    await menuItem.waitFor({ state: "visible", timeout: 5000 });
+    await menuItem.click();
+
+    // Allow time for any unintended revert.
+    await page.waitForTimeout(800);
+
+    // The second workspace should remain active.
+    const sidebar = page.locator('[data-slot="sidebar"]').first();
+    await expect(sidebar).toContainText(secondWs.name, { timeout: 5000 });
+    await expect(sidebar).not.toContainText(primaryWs.name);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #220

When a user switches workspace while viewing a workspace-aware issue URL (`/w/:workspaceSlug/issues/:id`), the page's `useEffect` re-fires on every workspace store update. Because the URL slug still points to the old workspace, the effect calls `switchWorkspace` again and reverts the user's selection.

The legacy `/issues/:id` route had the same class of bug: its `useEffect` re-ran on workspace changes and redirected back to the issue's original workspace URL, which then triggered the same revert on the workspace-aware page.

## Fix

**`w/[workspaceSlug]/issues/[id]/page.tsx`**
- Added a `syncInitiated` ref that is set to `true` the first time the URL-based workspace sync runs.
- Subsequent effect invocations (caused by user-driven workspace switches) return early, so the stale URL slug can never override the user's choice.
- Replaced the workspace-slug equality guard for the loading spinner with a `ready` state that is set after the initial sync completes (either immediately if already correct, or after `switchWorkspace` resolves).

**`issues/[id]/page.tsx` (legacy route)**
- Added a `resolved` ref with the same one-shot pattern, preventing the redirect from re-firing when the active workspace changes after the initial resolution.

## Test plan

- [x] Direct navigation to `/w/:slug/issues/:id` still syncs to the URL workspace and renders the issue
- [x] Switching workspace from a workspace-aware issue detail page keeps the newly selected workspace active
- [x] Switching workspace from the legacy `/issues/:id` route keeps the newly selected workspace active
- [x] E2E regression tests added in `e2e/workspace-switch.spec.ts` covering both routes

https://claude.ai/code/session_01D8Uu7wyfaJnG5JsD1MKe6F

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8Uu7wyfaJnG5JsD1MKe6F)_