### PR TITLE
fix(server): skip unmatched routine trigger runs

### DIFF
--- a/server/internal/handler/routine.go
+++ b/server/internal/handler/routine.go
@@ -645,7 +645,6 @@ func (h *Handler) ingestRoutineTriggers(ctx context.Context, triggers []db.Routi
 		}
 		for _, evt := range events {
 			if !routineTriggerMatchesEvent(trigger, evt) {
-				_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, pgtype.UUID{}, evt, "filtered", pgtype.UUID{}, pgtype.UUID{}, "trigger filters did not match")
 				continue
 			}
 			if evt.DedupKey != "" && trigger.DedupWindowSeconds > 0 {

--- a/server/internal/handler/routine_test.go
+++ b/server/internal/handler/routine_test.go
@@ -1164,6 +1164,17 @@ func TestRoutineGitHubTriggerConfigFiltersEventsBeforeActions(t *testing.T) {
 	if received != 1 || ran != 0 {
 		t.Fatalf("opened PR received=%d ran=%d, want 1/0", received, ran)
 	}
+	runs, err := testHandler.Queries.ListRoutineRuns(ctx, db.ListRoutineRunsParams{
+		RoutineID: parseUUID(routine.ID),
+		Limit:     10,
+		Offset:    0,
+	})
+	if err != nil {
+		t.Fatalf("ListRoutineRuns after unmatched trigger event: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("unmatched trigger event should not create routine runs, got %+v", runs)
+	}
 
 	mergedBody := []byte(`{"action":"closed","pull_request":{"number":2,"title":"Merge target","merged":true,"html_url":"https://github.com/acme/widgets/pull/902","user":{"login":"bob"},"head":{"ref":"feat"},"base":{"ref":"main"},"body":"body"},"repository":{"full_name":"acme/widgets"}}`)
 	received, ran = testHandler.ingestRoutineTriggers(ctx, []db.RoutineTrigger{trigger}, "github", mergedBody, headers)


### PR DESCRIPTION
## Summary
- Stop recording routine runs when a GitHub webhook fails the routine trigger-level filters.
- Add a regression assertion so unmatched trigger events do not appear in routine run history.

## Test plan
- [x] go test ./internal/handler -run TestRoutineGitHubTriggerConfigFiltersEventsBeforeActions -count=1
- [x] make test


Made with [Cursor](https://cursor.com)