### PR TITLE
feat(web): surface webhook events in settings

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/webhooks-tab.test.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/webhooks-tab.test.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockListWebhooks = vi.fn();
+const mockListWebhookEvents = vi.fn();
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/shared/api", () => ({
+  api: {
+    listWebhooks: (...args: any[]) => mockListWebhooks(...args),
+    listWebhookEvents: (...args: any[]) => mockListWebhookEvents(...args),
+  },
+}));
+
+import { WebhooksTab } from "./webhooks-tab";
+
+describe("WebhooksTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListWebhooks.mockResolvedValue([
+      {
+        webhook: {
+          id: "wh-1",
+          workspace_id: "ws-1",
+          name: "Grafana Alerts",
+          source_type: "oss-alert",
+          token_prefix: "whk_123",
+          status: "active",
+          dedup_window_seconds: 600,
+          bot_user_id: null,
+          installation_id: null,
+          created_by: "u-1",
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+        },
+        event_count: 1,
+        actions: [],
+      },
+    ]);
+    mockListWebhookEvents.mockResolvedValue([
+      {
+        id: "ev-1",
+        webhook_id: "wh-1",
+        dedup_key: "alert-42",
+        payload: { alert: "HighCPU", value: 99 },
+        status: "processed",
+        issue_id: "iss-9",
+        error_message: null,
+        created_at: "2026-05-29T10:00:00Z",
+      },
+    ]);
+  });
+
+  it("renders received events with their webhook name and status", async () => {
+    render(<WebhooksTab />);
+
+    expect(await screen.findByText("Grafana Alerts")).toBeInTheDocument();
+    expect(screen.getByText("oss-alert")).toBeInTheDocument();
+    expect(screen.getByText("processed")).toBeInTheDocument();
+  });
+
+  it("links a processed event to its created issue", async () => {
+    render(<WebhooksTab />);
+
+    const link = await screen.findByRole("link");
+    expect(link).toHaveAttribute("href", "/issues/iss-9");
+  });
+
+  it("expands a row to reveal the raw payload", async () => {
+    render(<WebhooksTab />);
+
+    const row = await screen.findByText("Grafana Alerts");
+    expect(screen.queryByText(/HighCPU/)).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByText(/HighCPU/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an empty state when there are no events", async () => {
+    mockListWebhookEvents.mockResolvedValue([]);
+    render(<WebhooksTab />);
+
+    expect(await screen.findByText(/no webhook events/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/webhooks-tab.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { Fragment, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ChevronRight, ExternalLink, Webhook as WebhookIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AbsoluteTime } from "@/components/common/absolute-time";
+import { cn } from "@/lib/utils";
+import { api } from "@/shared/api";
+import type {
+  WebhookEvent,
+  WebhookEventStatus,
+  WebhookListItem,
+} from "@/shared/types";
+
+// Tailwind classes per event status, using shadcn design tokens.
+const STATUS_STYLES: Record<WebhookEventStatus, string> = {
+  processed: "bg-primary/10 text-primary border-primary/20",
+  filtered: "bg-muted text-muted-foreground border-transparent",
+  deduped: "bg-muted text-muted-foreground border-transparent",
+  error: "bg-destructive/10 text-destructive border-destructive/20",
+};
+
+function StatusBadge({ status }: { status: WebhookEventStatus }) {
+  return (
+    <Badge variant="outline" className={cn("text-xs font-normal", STATUS_STYLES[status])}>
+      {status}
+    </Badge>
+  );
+}
+
+export function WebhooksTab() {
+  const [webhooks, setWebhooks] = useState<WebhookListItem[]>([]);
+  const [events, setEvents] = useState<WebhookEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [hooks, evts] = await Promise.all([
+          api.listWebhooks(),
+          api.listWebhookEvents(),
+        ]);
+        if (cancelled) return;
+        setWebhooks(hooks);
+        setEvents(evts);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load webhook events");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Resolve each event's originating webhook for display.
+  const webhookById = useMemo(() => {
+    const map = new Map<string, WebhookListItem["webhook"]>();
+    for (const item of webhooks) map.set(item.webhook.id, item.webhook);
+    return map;
+  }, [webhooks]);
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold">Webhook events</h2>
+        <p className="text-xs text-muted-foreground">
+          Incoming events received from GitHub and custom webhooks, including their
+          processing status and any issue they created.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="space-y-2 p-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-full" />
+              ))}
+            </div>
+          ) : error ? (
+            <p className="p-6 text-sm text-destructive">{error}</p>
+          ) : events.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-center">
+              <WebhookIcon className="h-6 w-6 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">No webhook events yet.</p>
+              <p className="text-xs text-muted-foreground">
+                Events appear here once a configured webhook receives a request.
+              </p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Source</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Issue</TableHead>
+                  <TableHead className="text-right">Received</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {events.map((event) => {
+                  const hook = webhookById.get(event.webhook_id);
+                  const isOpen = expanded.has(event.id);
+                  return (
+                    <Fragment key={event.id}>
+                      <TableRow
+                        className="cursor-pointer"
+                        onClick={() => toggle(event.id)}
+                      >
+                        <TableCell className="align-top">
+                          <ChevronRight
+                            className={cn(
+                              "h-4 w-4 text-muted-foreground transition-transform",
+                              isOpen && "rotate-90",
+                            )}
+                          />
+                        </TableCell>
+                        <TableCell className="align-top">
+                          <div className="flex flex-col gap-1">
+                            <span className="text-sm font-medium">
+                              {hook?.name ?? "Unknown webhook"}
+                            </span>
+                            {hook && (
+                              <Badge
+                                variant="secondary"
+                                className="w-fit text-xs font-normal"
+                              >
+                                {hook.source_type}
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top">
+                          <StatusBadge status={event.status} />
+                        </TableCell>
+                        <TableCell className="align-top">
+                          {event.issue_id ? (
+                            <Link
+                              href={`/issues/${event.issue_id}`}
+                              onClick={(e) => e.stopPropagation()}
+                              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                            >
+                              View
+                              <ExternalLink className="h-3 w-3" />
+                            </Link>
+                          ) : (
+                            <span className="text-sm text-muted-foreground">—</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right align-top text-sm text-muted-foreground">
+                          <AbsoluteTime value={event.created_at} style="shortDateTime" />
+                        </TableCell>
+                      </TableRow>
+                      {isOpen && (
+                        <TableRow className="hover:bg-transparent">
+                          <TableCell colSpan={5} className="bg-muted/30">
+                            {event.error_message && (
+                              <p className="mb-2 text-sm text-destructive">
+                                {event.error_message}
+                              </p>
+                            )}
+                            <pre className="max-h-80 overflow-auto rounded bg-background p-3 text-xs">
+                              {JSON.stringify(event.payload, null, 2)}
+                            </pre>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Settings, Users, FolderGit2, Cpu, Tag } from "lucide-react";
+import { Settings, Users, FolderGit2, Cpu, Tag, Webhook } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useWorkspaceStore } from "@/features/workspace";
 import { WorkspaceTab } from "./_components/workspace-tab";
@@ -8,12 +8,14 @@ import { MembersTab } from "./_components/members-tab";
 import { RepositoriesTab } from "./_components/repositories-tab";
 import { ProvidersTab } from "./_components/providers-tab";
 import { LabelsTab } from "./_components/labels-tab";
+import { WebhooksTab } from "./_components/webhooks-tab";
 
 const workspaceTabs = [
   { value: "workspace", label: "General", icon: Settings },
   { value: "labels", label: "Labels", icon: Tag },
   { value: "providers", label: "Providers", icon: Cpu },
   { value: "repositories", label: "Repositories", icon: FolderGit2 },
+  { value: "webhooks", label: "Webhooks", icon: Webhook },
   { value: "members", label: "Members", icon: Users },
 ];
 
@@ -45,6 +47,7 @@ export default function SettingsPage() {
           <TabsContent value="labels"><LabelsTab /></TabsContent>
           <TabsContent value="providers"><ProvidersTab /></TabsContent>
           <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
+          <TabsContent value="webhooks"><WebhooksTab /></TabsContent>
           <TabsContent value="members"><MembersTab /></TabsContent>
         </div>
       </div>

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -46,6 +46,8 @@ import type {
   Attachment,
   BotUser,
   CreateBotUserRequest,
+  WebhookListItem,
+  WebhookEvent,
   Routine,
   CreateRoutineRequest,
   UpdateRoutineRequest,
@@ -660,6 +662,16 @@ export class ApiClient {
 
   async deleteLabel(id: string): Promise<void> {
     await this.fetch(`/api/labels/${id}`, { method: "DELETE" });
+  }
+
+  // Webhooks (read-only). Both endpoints resolve the workspace from the
+  // X-Workspace-ID header set by the client.
+  async listWebhooks(): Promise<WebhookListItem[]> {
+    return this.fetch("/api/webhooks");
+  }
+
+  async listWebhookEvents(): Promise<WebhookEvent[]> {
+    return this.fetch("/api/webhooks/events");
   }
 
   async setIssueLabels(issueId: string, labelIds: string[]): Promise<Label[]> {

--- a/apps/web/shared/types/index.ts
+++ b/apps/web/shared/types/index.ts
@@ -55,4 +55,10 @@ export type {
 export type {
   BotUser,
   CreateBotUserRequest,
+  Webhook,
+  WebhookAction,
+  WebhookListItem,
+  WebhookEvent,
+  WebhookSourceType,
+  WebhookEventStatus,
 } from "./webhook";

--- a/apps/web/shared/types/webhook.ts
+++ b/apps/web/shared/types/webhook.ts
@@ -14,3 +14,56 @@ export interface CreateBotUserRequest {
   name: string;
   avatar_url?: string;
 }
+
+// Adapter type that produced a webhook's events.
+export type WebhookSourceType = "standard" | "oss-alert" | "github";
+
+// Status of a single received webhook event.
+export type WebhookEventStatus = "processed" | "filtered" | "deduped" | "error";
+
+// A configured webhook endpoint in the workspace.
+export interface Webhook {
+  id: string;
+  workspace_id: string;
+  name: string;
+  source_type: WebhookSourceType;
+  token_prefix: string;
+  status: "active" | "paused";
+  dedup_window_seconds: number;
+  bot_user_id: string | null;
+  installation_id: number | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WebhookAction {
+  id: string;
+  webhook_id: string;
+  action_type: string;
+  config: unknown;
+  enabled: boolean;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// One entry of the webhook list endpoint (GET /api/webhooks).
+export interface WebhookListItem {
+  webhook: Webhook;
+  event_count: number;
+  actions: WebhookAction[];
+}
+
+// A single received webhook event from the audit log
+// (GET /api/webhooks/events).
+export interface WebhookEvent {
+  id: string;
+  webhook_id: string;
+  dedup_key: string;
+  payload: unknown;
+  status: WebhookEventStatus;
+  issue_id: string | null;
+  error_message: string | null;
+  created_at: string;
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -243,6 +243,13 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 				})
 			})
 
+			// Webhooks (read-only views over configured webhooks and the
+			// events they have received).
+			r.Route("/api/webhooks", func(r chi.Router) {
+				r.Get("/", h.ListWebhooks)
+				r.Get("/events", h.ListWorkspaceWebhookEvents)
+			})
+
 			// Attachments
 			r.Delete("/api/attachments/{id}", h.DeleteAttachment)
 


### PR DESCRIPTION
## Summary
- Add a Webhooks tab to workspace settings that lists recent received webhook events.
- Wire the web UI to existing read-only webhook list and event APIs, including shared response types.
- Expose protected read-only webhook routes from the server router.

## Test plan
- `make test`


Made with [Cursor](https://cursor.com)