### PR TITLE
fix(routines): scope source issue links by routine

### DIFF
--- a/server/internal/handler/routine_test.go
+++ b/server/internal/handler/routine_test.go
@@ -646,6 +646,20 @@ func TestRoutineAPITriggerCreatesSeparateIssuesPerRoutineForSameSourceURL(t *tes
 	}); err != nil {
 		t.Fatalf("expected first routine to create source link: %v", err)
 	}
+	var stagingIssueID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text
+		FROM issue
+		WHERE workspace_id = $1 AND title = $2
+	`, testWorkspaceID, stagingTitle).Scan(&stagingIssueID); err != nil {
+		t.Fatalf("query staging issue: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO routine_run (routine_id, trigger_id, action_id, event_type, dedup_key, payload, status, issue_id)
+		VALUES ($1, $2, $3, 'custom', 'legacy-collapsed-prod-run', '{}'::jsonb, 'processed', $4)
+	`, prodRoutine.ID, prodRoutine.Triggers[0].ID, prodRoutine.Actions[0].ID, stagingIssueID); err != nil {
+		t.Fatalf("insert legacy collapsed prod run: %v", err)
+	}
 	ingest(prodRoutine, prodToken, "routine-scoped-prod")
 
 	assertIssueCount(t, stagingTitle, 1)

--- a/server/internal/handler/routine_test.go
+++ b/server/internal/handler/routine_test.go
@@ -559,6 +559,111 @@ func TestRoutineIssueTemplateFieldsAreApplied(t *testing.T) {
 	}
 }
 
+func TestRoutineAPITriggerCreatesSeparateIssuesPerRoutineForSameSourceURL(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+
+	ctx := context.Background()
+	var agentID string
+	if err := testPool.QueryRow(ctx, `SELECT id::text FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("find agent: %v", err)
+	}
+
+	createRoutine := func(name, title string) (RoutineResponse, string) {
+		t.Helper()
+		apiTrigger, apiToken := routineAPITokenDraft(t)
+		w := httptest.NewRecorder()
+		req := routineRequest(t, "POST", "/api/routines", map[string]any{
+			"name":          name,
+			"instructions":  "Create routine-scoped issue",
+			"assignee_type": "agent",
+			"assignee_id":   agentID,
+			"triggers":      []map[string]any{apiTrigger},
+			"actions": []map[string]any{
+				{
+					"action_type": "create_issue",
+					"config": map[string]any{
+						"title_template": title,
+					},
+				},
+			},
+		})
+		testHandler.CreateRoutine(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateRoutine %s: expected 201, got %d: %s", name, w.Code, w.Body.String())
+		}
+		var routine RoutineResponse
+		if err := json.NewDecoder(w.Body).Decode(&routine); err != nil {
+			t.Fatalf("decode routine: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = testHandler.Queries.DeleteRoutine(ctx, db.DeleteRoutineParams{
+				ID:          parseUUID(routine.ID),
+				WorkspaceID: parseUUID(testWorkspaceID),
+			})
+		})
+		return routine, apiToken
+	}
+
+	suffix := time.Now().Format("150405000000000")
+	stagingTitle := "Routine scoped links staging " + suffix
+	prodTitle := "Routine scoped links prod " + suffix
+	stagingRoutine, stagingToken := createRoutine("Routine scoped staging", stagingTitle)
+	prodRoutine, prodToken := createRoutine("Routine scoped prod", prodTitle)
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `
+			DELETE FROM issue
+			WHERE workspace_id = $1
+			  AND title = ANY($2::text[])
+		`, testWorkspaceID, []string{stagingTitle, prodTitle})
+	})
+
+	sourceURL := "https://github.com/nullne/multica/pull/routine-scoped-" + suffix
+	ingest := func(routine RoutineResponse, token, dedupKey string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/webhook/"+routine.Triggers[0].ID, map[string]any{
+			"title":     "ignored by template",
+			"dedup_key": dedupKey,
+			"fields": map[string]string{
+				"source_url":  sourceURL,
+				"source_kind": "pr",
+			},
+		})
+		req = withURLParam(req, "id", routine.Triggers[0].ID)
+		req.Header.Set("Authorization", "Bearer "+token)
+		testHandler.IngestRoutineTrigger(w, req)
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("IngestRoutineTrigger: expected 202, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	ingest(stagingRoutine, stagingToken, "routine-scoped-staging")
+	if _, err := testHandler.Queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Url:         sourceURL,
+	}); err != nil {
+		t.Fatalf("expected first routine to create source link: %v", err)
+	}
+	ingest(prodRoutine, prodToken, "routine-scoped-prod")
+
+	assertIssueCount(t, stagingTitle, 1)
+	assertIssueCount(t, prodTitle, 1)
+
+	var linkCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM issue_link
+		WHERE workspace_id = $1 AND url = $2
+	`, testWorkspaceID, sourceURL).Scan(&linkCount); err != nil {
+		t.Fatalf("count issue links: %v", err)
+	}
+	if linkCount != 2 {
+		t.Fatalf("issue link count = %d, want 2", linkCount)
+	}
+}
+
 func TestRoutineAPITriggerCanAssignIssueToMember(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("test database not available")

--- a/server/internal/service/routine.go
+++ b/server/internal/service/routine.go
@@ -77,7 +77,7 @@ func (s *RoutineService) executeCreateIssue(ctx context.Context, routine db.Rout
 		}
 	}
 
-	if link, ok, err := s.findIssueLinkForEvent(ctx, routine.WorkspaceID, evt); err != nil {
+	if link, ok, err := s.findIssueLinkForEvent(ctx, routine.ID, routine.WorkspaceID, evt); err != nil {
 		_ = s.logRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, err.Error())
 		return RoutineActionResult{}, err
 	} else if ok {
@@ -208,7 +208,7 @@ func (s *RoutineService) executeCommentIssue(ctx context.Context, routine db.Rou
 		return RoutineActionResult{}, err
 	}
 
-	link, ok, err := s.findIssueLinkForEvent(ctx, routine.WorkspaceID, evt)
+	link, ok, err := s.findIssueLinkForEvent(ctx, routine.ID, routine.WorkspaceID, evt)
 	if err != nil {
 		_ = s.logRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, err.Error())
 		return RoutineActionResult{}, err
@@ -252,9 +252,13 @@ func (s *RoutineService) executeCommentIssue(ctx context.Context, routine db.Rou
 	return RoutineActionResult{Ran: true, IssueID: link.IssueID, CommentID: comment.ID}, nil
 }
 
-func (s *RoutineService) findIssueLinkForEvent(ctx context.Context, workspaceID pgtype.UUID, evt RoutineEvent) (db.IssueLink, bool, error) {
+func (s *RoutineService) findIssueLinkForEvent(ctx context.Context, routineID, workspaceID pgtype.UUID, evt RoutineEvent) (db.IssueLink, bool, error) {
 	for _, sourceURL := range routineEventSourceURLs(evt) {
-		link, err := s.Queries.GetIssueLinkByURL(ctx, db.GetIssueLinkByURLParams{WorkspaceID: workspaceID, Url: sourceURL})
+		link, err := s.Queries.GetRoutineIssueLinkByURL(ctx, db.GetRoutineIssueLinkByURLParams{
+			RoutineID:   routineID,
+			WorkspaceID: workspaceID,
+			Url:         sourceURL,
+		})
 		if err == nil {
 			return link, true, nil
 		}

--- a/server/internal/service/routine_test.go
+++ b/server/internal/service/routine_test.go
@@ -82,6 +82,12 @@ func TestRoutineServiceCommentIssueCreatesCommentOnLinkedIssue(t *testing.T) {
 	`, routineID, cfg).Scan(&actionID); err != nil {
 		t.Fatalf("insert action: %v", err)
 	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO routine_run (routine_id, trigger_id, action_id, event_type, dedup_key, payload, status, issue_id)
+		VALUES ($1, $2, $3, 'github.pull_request.opened', 'routine-comment-linked-issue', '{}'::jsonb, 'processed', $4)
+	`, routineID, triggerID, actionID, issueID); err != nil {
+		t.Fatalf("insert routine run: %v", err)
+	}
 
 	routine, err := queries.GetRoutine(ctx, parseUUID(routineID))
 	if err != nil {

--- a/server/pkg/db/generated/routine.sql.go
+++ b/server/pkg/db/generated/routine.sql.go
@@ -626,6 +626,14 @@ WHERE rr.routine_id = $1
   AND il.workspace_id = $2
   AND il.url = $3
   AND rr.status = 'processed'
+  AND rr.id = (
+    SELECT rr_origin.id
+    FROM routine_run rr_origin
+    WHERE rr_origin.issue_id = il.issue_id
+      AND rr_origin.status = 'processed'
+    ORDER BY rr_origin.created_at ASC
+    LIMIT 1
+  )
 ORDER BY rr.created_at ASC
 LIMIT 1
 `

--- a/server/pkg/db/generated/routine.sql.go
+++ b/server/pkg/db/generated/routine.sql.go
@@ -618,6 +618,41 @@ func (q *Queries) GetRoutineInWorkspace(ctx context.Context, arg GetRoutineInWor
 	return i, err
 }
 
+const getRoutineIssueLinkByURL = `-- name: GetRoutineIssueLinkByURL :one
+SELECT il.id, il.issue_id, il.workspace_id, il.source_type, il.kind, il.direction, il.url, il.external_id, il.created_at
+FROM issue_link il
+JOIN routine_run rr ON rr.issue_id = il.issue_id
+WHERE rr.routine_id = $1
+  AND il.workspace_id = $2
+  AND il.url = $3
+  AND rr.status = 'processed'
+ORDER BY rr.created_at ASC
+LIMIT 1
+`
+
+type GetRoutineIssueLinkByURLParams struct {
+	RoutineID   pgtype.UUID `json:"routine_id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Url         string      `json:"url"`
+}
+
+func (q *Queries) GetRoutineIssueLinkByURL(ctx context.Context, arg GetRoutineIssueLinkByURLParams) (IssueLink, error) {
+	row := q.db.QueryRow(ctx, getRoutineIssueLinkByURL, arg.RoutineID, arg.WorkspaceID, arg.Url)
+	var i IssueLink
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.WorkspaceID,
+		&i.SourceType,
+		&i.Kind,
+		&i.Direction,
+		&i.Url,
+		&i.ExternalID,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getRoutineOriginForIssue = `-- name: GetRoutineOriginForIssue :one
 SELECT
     rr.issue_id,

--- a/server/pkg/db/queries/routine.sql
+++ b/server/pkg/db/queries/routine.sql
@@ -289,6 +289,17 @@ WHERE rr.issue_id = ANY(sqlc.arg('issue_ids')::uuid[])
   AND rr.status = 'processed'
 ORDER BY rr.issue_id, rr.created_at ASC;
 
+-- name: GetRoutineIssueLinkByURL :one
+SELECT il.*
+FROM issue_link il
+JOIN routine_run rr ON rr.issue_id = il.issue_id
+WHERE rr.routine_id = $1
+  AND il.workspace_id = $2
+  AND il.url = $3
+  AND rr.status = 'processed'
+ORDER BY rr.created_at ASC
+LIMIT 1;
+
 -- name: FindRecentRoutineRun :one
 SELECT id FROM routine_run
 WHERE trigger_id = $1

--- a/server/pkg/db/queries/routine.sql
+++ b/server/pkg/db/queries/routine.sql
@@ -297,6 +297,14 @@ WHERE rr.routine_id = $1
   AND il.workspace_id = $2
   AND il.url = $3
   AND rr.status = 'processed'
+  AND rr.id = (
+    SELECT rr_origin.id
+    FROM routine_run rr_origin
+    WHERE rr_origin.issue_id = il.issue_id
+      AND rr_origin.status = 'processed'
+    ORDER BY rr_origin.created_at ASC
+    LIMIT 1
+  )
 ORDER BY rr.created_at ASC
 LIMIT 1;
 


### PR DESCRIPTION
## Summary
- Scope routine source URL reuse to issues previously processed by the same routine.
- Allow independent routines, such as staging and prod automations for the same PR, to each create and dispatch their own issue.
- Add regression coverage for two API routines receiving the same source URL.

## Test plan
- `docker compose -f docker-compose.test.yml -p <tmp> run --rm go-test go test ./internal/handler ./internal/service`
- `docker compose -f docker-compose.test.yml -p <tmp> run --rm go-test sh -c 'apk add --no-cache git >/dev/null && go test ./...'`
- `make test-go` currently fails in `cmd/multica` because the stock Go test container does not include the `git` binary; the full Go test command above passes after installing `git` in the ephemeral container.

Made with [Cursor](https://cursor.com)