### PR TITLE
feat(routines): add routine event log

### DIFF
--- a/apps/web/shared/types/routine.ts
+++ b/apps/web/shared/types/routine.ts
@@ -106,6 +106,7 @@ export type UpdateRoutineRequest = CreateRoutineRequest;
 export interface RoutineRun {
   id: string;
   routine_id: string;
+  routine_event_id: string | null;
   trigger_id: string | null;
   action_id: string | null;
   event_type: string;

--- a/server/internal/handler/routine.go
+++ b/server/internal/handler/routine.go
@@ -24,6 +24,21 @@ var errRoutineTriggerTokenRequired = errors.New("routine trigger token must be g
 
 const routineTriggerMaxPayloadBytes = 1 << 20
 
+type routineTriggerContext struct {
+	trigger db.RoutineTrigger
+	routine db.Routine
+	actions []db.RoutineAction
+}
+
+type routineEventOutcome struct {
+	matchedTrigger bool
+	processed      bool
+	filtered       bool
+	deduped        bool
+	errored        bool
+	errorMessage   string
+}
+
 type RoutineResponse struct {
 	ID                   string                   `json:"id"`
 	WorkspaceID          string                   `json:"workspace_id"`
@@ -83,19 +98,20 @@ type RoutineActionResponse struct {
 }
 
 type RoutineRunResponse struct {
-	ID           string         `json:"id"`
-	RoutineID    string         `json:"routine_id"`
-	TriggerID    *string        `json:"trigger_id"`
-	ActionID     *string        `json:"action_id"`
-	EventType    string         `json:"event_type"`
-	DedupKey     string         `json:"dedup_key"`
-	Payload      any            `json:"payload"`
-	Status       string         `json:"status"`
-	IssueID      *string        `json:"issue_id"`
-	CommentID    *string        `json:"comment_id"`
-	ErrorMessage *string        `json:"error_message"`
-	CreatedAt    string         `json:"created_at"`
-	Issue        *IssueResponse `json:"issue,omitempty"`
+	ID             string         `json:"id"`
+	RoutineID      string         `json:"routine_id"`
+	RoutineEventID *string        `json:"routine_event_id"`
+	TriggerID      *string        `json:"trigger_id"`
+	ActionID       *string        `json:"action_id"`
+	EventType      string         `json:"event_type"`
+	DedupKey       string         `json:"dedup_key"`
+	Payload        any            `json:"payload"`
+	Status         string         `json:"status"`
+	IssueID        *string        `json:"issue_id"`
+	CommentID      *string        `json:"comment_id"`
+	ErrorMessage   *string        `json:"error_message"`
+	CreatedAt      string         `json:"created_at"`
+	Issue          *IssueResponse `json:"issue,omitempty"`
 }
 
 type RoutineTriggerTokenResponse struct {
@@ -598,18 +614,19 @@ func routineRunToResponse(run db.RoutineRun) RoutineRunResponse {
 		_ = json.Unmarshal(run.Payload, &payload)
 	}
 	return RoutineRunResponse{
-		ID:           uuidToString(run.ID),
-		RoutineID:    uuidToString(run.RoutineID),
-		TriggerID:    uuidToPtr(run.TriggerID),
-		ActionID:     uuidToPtr(run.ActionID),
-		EventType:    run.EventType,
-		DedupKey:     run.DedupKey,
-		Payload:      payload,
-		Status:       run.Status,
-		IssueID:      uuidToPtr(run.IssueID),
-		CommentID:    uuidToPtr(run.CommentID),
-		ErrorMessage: textToPtr(run.ErrorMessage),
-		CreatedAt:    timestampToString(run.CreatedAt),
+		ID:             uuidToString(run.ID),
+		RoutineID:      uuidToString(run.RoutineID),
+		RoutineEventID: uuidToPtr(run.RoutineEventID),
+		TriggerID:      uuidToPtr(run.TriggerID),
+		ActionID:       uuidToPtr(run.ActionID),
+		EventType:      run.EventType,
+		DedupKey:       run.DedupKey,
+		Payload:        payload,
+		Status:         run.Status,
+		IssueID:        uuidToPtr(run.IssueID),
+		CommentID:      uuidToPtr(run.CommentID),
+		ErrorMessage:   textToPtr(run.ErrorMessage),
+		CreatedAt:      timestampToString(run.CreatedAt),
 	}
 }
 
@@ -651,16 +668,103 @@ func (h *Handler) ingestRoutineTriggers(ctx context.Context, triggers []db.Routi
 	if len(triggers) == 0 {
 		return 0, 0
 	}
+	triggerContexts := h.loadRoutineTriggerContexts(ctx, triggers)
+	if len(triggerContexts) == 0 {
+		return 0, 0
+	}
 	adapter, err := wh.GetAdapter(sourceType)
 	if err != nil {
+		h.logRoutineParseError(ctx, triggerContexts, sourceType, body, headers, err.Error())
 		return 0, 0
 	}
 	events, err := adapter.Parse(json.RawMessage(body), headers)
-	if err != nil || len(events) == 0 {
+	if err != nil {
+		h.logRoutineParseError(ctx, triggerContexts, sourceType, body, headers, err.Error())
+		return 0, 0
+	}
+	if len(events) == 0 {
+		return 0, 0
+	}
+	eventRecords, ok := h.createRoutineEventRecords(ctx, triggerContexts, sourceType, events, headers)
+	if !ok {
 		return 0, 0
 	}
 	routineSvc := service.NewRoutineService(h.Queries, h.TxStarter, h.TaskService)
 	ran := 0
+	outcomes := map[string]*routineEventOutcome{}
+	for i, evt := range events {
+		for _, tc := range triggerContexts {
+			record := eventRecords[i][uuidToString(tc.routine.WorkspaceID)]
+			if !record.ID.Valid {
+				continue
+			}
+			outcomeKey := uuidToString(record.ID)
+			if outcomes[outcomeKey] == nil {
+				outcomes[outcomeKey] = &routineEventOutcome{}
+			}
+			outcome := outcomes[outcomeKey]
+			if !routineTriggerMatchesEvent(tc.trigger, evt) {
+				continue
+			}
+			outcome.matchedTrigger = true
+			if evt.DedupKey != "" && tc.trigger.DedupWindowSeconds > 0 {
+				if _, err := h.Queries.FindRecentRoutineRun(ctx, db.FindRecentRoutineRunParams{
+					TriggerID:     tc.trigger.ID,
+					DedupKey:      evt.DedupKey,
+					WindowSeconds: float64(tc.trigger.DedupWindowSeconds),
+				}); err == nil {
+					outcome.deduped = true
+					_ = h.logRoutineRunWithEvent(ctx, record.ID, tc.routine.ID, tc.trigger.ID, pgtype.UUID{}, evt, "deduped", pgtype.UUID{}, pgtype.UUID{}, "")
+					continue
+				}
+			}
+			processed := false
+			for _, action := range tc.actions {
+				if !routineActionMatchesEvent(action, evt) {
+					continue
+				}
+				var didRun bool
+				var execErr error
+				if action.ActionType == "comment_issue" {
+					// comment_issue runs on the Handler so it reuses the full
+					// bot-comment + agent re-engagement pipeline.
+					didRun, execErr = h.executeRoutineCommentIssue(ctx, record.ID, tc.routine, tc.trigger, action, evt)
+				} else {
+					result, err := routineSvc.ExecuteAction(ctx, tc.routine, tc.trigger, action, service.RoutineEvent{
+						RoutineEventID: record.ID,
+						Type:           evt.Type,
+						DedupKey:       evt.DedupKey,
+						Data:           evt.Data,
+						Payload:        evt.RawPayload,
+					})
+					didRun, execErr = result.Ran, err
+				}
+				if execErr != nil {
+					outcome.errored = true
+					if outcome.errorMessage == "" {
+						outcome.errorMessage = execErr.Error()
+					}
+					_ = h.logRoutineRunWithEvent(ctx, record.ID, tc.routine.ID, tc.trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, execErr.Error())
+					continue
+				}
+				if didRun {
+					processed = true
+					outcome.processed = true
+					ran++
+				}
+			}
+			if !processed {
+				outcome.filtered = true
+				_ = h.logRoutineRunWithEvent(ctx, record.ID, tc.routine.ID, tc.trigger.ID, pgtype.UUID{}, evt, "filtered", pgtype.UUID{}, pgtype.UUID{}, "no matching action")
+			}
+		}
+	}
+	h.updateRoutineEventStatuses(ctx, eventRecords, outcomes)
+	return len(events), ran
+}
+
+func (h *Handler) loadRoutineTriggerContexts(ctx context.Context, triggers []db.RoutineTrigger) []routineTriggerContext {
+	contexts := make([]routineTriggerContext, 0, len(triggers))
 	for _, trigger := range triggers {
 		routine, err := h.Queries.GetRoutine(ctx, trigger.RoutineID)
 		if err != nil || !routine.Enabled || !trigger.Enabled {
@@ -670,55 +774,131 @@ func (h *Handler) ingestRoutineTriggers(ctx context.Context, triggers []db.Routi
 		if err != nil {
 			continue
 		}
-		for _, evt := range events {
-			if !routineTriggerMatchesEvent(trigger, evt) {
-				continue
+		contexts = append(contexts, routineTriggerContext{
+			trigger: trigger,
+			routine: routine,
+			actions: actions,
+		})
+	}
+	return contexts
+}
+
+func (h *Handler) createRoutineEventRecords(ctx context.Context, triggerContexts []routineTriggerContext, sourceType string, events []wh.Event, headers http.Header) ([]map[string]db.RoutineEvent, bool) {
+	workspaces := uniqueRoutineEventWorkspaces(triggerContexts)
+	records := make([]map[string]db.RoutineEvent, len(events))
+	for i, evt := range events {
+		records[i] = make(map[string]db.RoutineEvent, len(workspaces))
+		for _, workspaceID := range workspaces {
+			record, err := h.createRoutineEventRecord(ctx, workspaceID, sourceType, evt, headers, "received", "")
+			if err != nil {
+				return nil, false
 			}
-			if evt.DedupKey != "" && trigger.DedupWindowSeconds > 0 {
-				if _, err := h.Queries.FindRecentRoutineRun(ctx, db.FindRecentRoutineRunParams{
-					TriggerID:     trigger.ID,
-					DedupKey:      evt.DedupKey,
-					WindowSeconds: float64(trigger.DedupWindowSeconds),
-				}); err == nil {
-					_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, pgtype.UUID{}, evt, "deduped", pgtype.UUID{}, pgtype.UUID{}, "")
-					continue
-				}
-			}
-			processed := false
-			for _, action := range actions {
-				if !routineActionMatchesEvent(action, evt) {
-					continue
-				}
-				var didRun bool
-				var execErr error
-				if action.ActionType == "comment_issue" {
-					// comment_issue runs on the Handler so it reuses the full
-					// bot-comment + agent re-engagement pipeline.
-					didRun, execErr = h.executeRoutineCommentIssue(ctx, routine, trigger, action, evt)
-				} else {
-					result, err := routineSvc.ExecuteAction(ctx, routine, trigger, action, service.RoutineEvent{
-						Type:     evt.Type,
-						DedupKey: evt.DedupKey,
-						Data:     evt.Data,
-						Payload:  evt.RawPayload,
-					})
-					didRun, execErr = result.Ran, err
-				}
-				if execErr != nil {
-					_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, execErr.Error())
-					continue
-				}
-				if didRun {
-					processed = true
-					ran++
-				}
-			}
-			if !processed {
-				_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, pgtype.UUID{}, evt, "filtered", pgtype.UUID{}, pgtype.UUID{}, "no matching action")
-			}
+			records[i][uuidToString(workspaceID)] = record
 		}
 	}
-	return len(events), ran
+	return records, true
+}
+
+func uniqueRoutineEventWorkspaces(triggerContexts []routineTriggerContext) []pgtype.UUID {
+	seen := map[string]bool{}
+	workspaces := make([]pgtype.UUID, 0, len(triggerContexts))
+	for _, tc := range triggerContexts {
+		key := uuidToString(tc.routine.WorkspaceID)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		workspaces = append(workspaces, tc.routine.WorkspaceID)
+	}
+	return workspaces
+}
+
+func (h *Handler) logRoutineParseError(ctx context.Context, triggerContexts []routineTriggerContext, sourceType string, body []byte, headers http.Header, message string) {
+	for _, workspaceID := range uniqueRoutineEventWorkspaces(triggerContexts) {
+		_, _ = h.createRoutineEventRecord(ctx, workspaceID, sourceType, wh.Event{
+			RawPayload: json.RawMessage(body),
+			Data:       map[string]string{},
+		}, headers, "parse_error", message)
+	}
+}
+
+func (h *Handler) createRoutineEventRecord(ctx context.Context, workspaceID pgtype.UUID, sourceType string, evt wh.Event, headers http.Header, status string, errorMessage string) (db.RoutineEvent, error) {
+	if evt.Data == nil {
+		evt.Data = map[string]string{}
+	}
+	data, err := json.Marshal(evt.Data)
+	if err != nil {
+		data = []byte("{}")
+	}
+	payload := evt.RawPayload
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	return h.Queries.CreateRoutineEvent(ctx, db.CreateRoutineEventParams{
+		WorkspaceID:        workspaceID,
+		SourceType:         sourceType,
+		EventType:          evt.Type,
+		DedupKey:           evt.DedupKey,
+		ExternalDeliveryID: routineEventDeliveryID(sourceType, headers),
+		Data:               data,
+		Payload:            payload,
+		Status:             status,
+		ErrorMessage:       routineEventErrorText(errorMessage),
+	})
+}
+
+func routineEventDeliveryID(sourceType string, headers http.Header) pgtype.Text {
+	if sourceType == "github" {
+		if deliveryID := strings.TrimSpace(headers.Get("X-GitHub-Delivery")); deliveryID != "" {
+			return pgtype.Text{String: deliveryID, Valid: true}
+		}
+	}
+	for _, name := range []string{"X-Request-ID", "X-Request-Id"} {
+		if requestID := strings.TrimSpace(headers.Get(name)); requestID != "" {
+			return pgtype.Text{String: requestID, Valid: true}
+		}
+	}
+	return pgtype.Text{}
+}
+
+func (h *Handler) updateRoutineEventStatuses(ctx context.Context, records []map[string]db.RoutineEvent, outcomes map[string]*routineEventOutcome) {
+	for _, perWorkspace := range records {
+		for _, record := range perWorkspace {
+			outcome := outcomes[uuidToString(record.ID)]
+			status, message := routineEventStatus(outcome)
+			_, _ = h.Queries.UpdateRoutineEventStatus(ctx, db.UpdateRoutineEventStatusParams{
+				ID:           record.ID,
+				Status:       status,
+				ErrorMessage: routineEventErrorText(message),
+			})
+		}
+	}
+}
+
+func routineEventErrorText(message string) pgtype.Text {
+	if message == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: message, Valid: true}
+}
+
+func routineEventStatus(outcome *routineEventOutcome) (string, string) {
+	if outcome == nil || !outcome.matchedTrigger {
+		return "no_matching_trigger", ""
+	}
+	if outcome.processed {
+		return "processed", ""
+	}
+	if outcome.errored {
+		return "error", outcome.errorMessage
+	}
+	if outcome.filtered {
+		return "filtered", ""
+	}
+	if outcome.deduped {
+		return "deduped", ""
+	}
+	return "filtered", ""
 }
 
 func routineActionMatchesEvent(action db.RoutineAction, evt wh.Event) bool {
@@ -840,21 +1020,26 @@ func splitRoutineTriggerFilterValues(value string) []string {
 }
 
 func (h *Handler) logRoutineRun(ctx context.Context, routineID, triggerID, actionID pgtype.UUID, evt wh.Event, status string, issueID, commentID pgtype.UUID, errorMessage string) error {
+	return h.logRoutineRunWithEvent(ctx, pgtype.UUID{}, routineID, triggerID, actionID, evt, status, issueID, commentID, errorMessage)
+}
+
+func (h *Handler) logRoutineRunWithEvent(ctx context.Context, routineEventID, routineID, triggerID, actionID pgtype.UUID, evt wh.Event, status string, issueID, commentID pgtype.UUID, errorMessage string) error {
 	errText := pgtype.Text{}
 	if errorMessage != "" {
 		errText = pgtype.Text{String: errorMessage, Valid: true}
 	}
 	_, err := h.Queries.CreateRoutineRun(ctx, db.CreateRoutineRunParams{
-		RoutineID:    routineID,
-		TriggerID:    triggerID,
-		ActionID:     actionID,
-		EventType:    evt.Type,
-		DedupKey:     evt.DedupKey,
-		Payload:      evt.RawPayload,
-		Status:       status,
-		IssueID:      issueID,
-		CommentID:    commentID,
-		ErrorMessage: errText,
+		RoutineEventID: routineEventID,
+		RoutineID:      routineID,
+		TriggerID:      triggerID,
+		ActionID:       actionID,
+		EventType:      evt.Type,
+		DedupKey:       evt.DedupKey,
+		Payload:        evt.RawPayload,
+		Status:         status,
+		IssueID:        issueID,
+		CommentID:      commentID,
+		ErrorMessage:   errText,
 	})
 	return err
 }

--- a/server/internal/handler/routine_autofix.go
+++ b/server/internal/handler/routine_autofix.go
@@ -30,26 +30,26 @@ const (
 // (publish, on_comment, on_mention). It iterates every issue linked to the
 // event's source URL, applies the optional per-issue auto-fix gate, and posts
 // the rendered comment. Returns whether at least one comment was posted.
-func (h *Handler) executeRoutineCommentIssue(ctx context.Context, routine db.Routine, trigger db.RoutineTrigger, action db.RoutineAction, evt wh.Event) (bool, error) {
+func (h *Handler) executeRoutineCommentIssue(ctx context.Context, routineEventID pgtype.UUID, routine db.Routine, trigger db.RoutineTrigger, action db.RoutineAction, evt wh.Event) (bool, error) {
 	var cfg CommentIssueActionConfig
 	if err := json.Unmarshal(action.Config, &cfg); err != nil {
-		_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, "invalid comment_issue config: "+err.Error())
+		_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, "invalid comment_issue config: "+err.Error())
 		return false, fmt.Errorf("invalid comment_issue config: %w", err)
 	}
 	botUserID := parseUUID(cfg.BotUserID)
 	if !botUserID.Valid {
 		err := fmt.Errorf("comment_issue requires bot_user_id")
-		_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, err.Error())
+		_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, err.Error())
 		return false, err
 	}
 
 	links, err := h.findIssueLinksForEvent(ctx, routine.WorkspaceID, evt)
 	if err != nil {
-		_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, err.Error())
+		_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "error", pgtype.UUID{}, pgtype.UUID{}, err.Error())
 		return false, err
 	}
 	if len(links) == 0 {
-		_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "filtered", pgtype.UUID{}, pgtype.UUID{}, "no matching issue link")
+		_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "filtered", pgtype.UUID{}, pgtype.UUID{}, "no matching issue link")
 		return false, nil
 	}
 
@@ -65,21 +65,21 @@ func (h *Handler) executeRoutineCommentIssue(ctx context.Context, routine db.Rou
 	for _, link := range links {
 		issue, err := h.Queries.GetIssue(ctx, link.IssueID)
 		if err != nil {
-			_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", link.IssueID, pgtype.UUID{}, "load issue: "+err.Error())
+			_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "error", link.IssueID, pgtype.UUID{}, "load issue: "+err.Error())
 			continue
 		}
 		if cfg.OnlyIfIssueAutoFixEnabled && !issue.GithubAutoFixEnabled {
-			_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "filtered", link.IssueID, pgtype.UUID{}, "issue auto-fix disabled")
+			_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "filtered", link.IssueID, pgtype.UUID{}, "issue auto-fix disabled")
 			continue
 		}
 		commentID, posted, err := h.createBotCommentOnIssue(ctx, issue, botUserID, content, cfg.MentionAgentID)
 		if err != nil {
-			_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "error", link.IssueID, pgtype.UUID{}, err.Error())
+			_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "error", link.IssueID, pgtype.UUID{}, err.Error())
 			continue
 		}
 		if posted {
 			ran = true
-			_ = h.logRoutineRun(ctx, routine.ID, trigger.ID, action.ID, evt, "processed", link.IssueID, commentID, "")
+			_ = h.logRoutineRunWithEvent(ctx, routineEventID, routine.ID, trigger.ID, action.ID, evt, "processed", link.IssueID, commentID, "")
 		}
 	}
 	return ran, nil

--- a/server/internal/handler/routine_test.go
+++ b/server/internal/handler/routine_test.go
@@ -263,6 +263,113 @@ func TestRoutineAPITriggerIngestCreatesIssue(t *testing.T) {
 	}
 }
 
+func TestRoutineAPITriggerStoresOneRoutineEventForMultipleRuns(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+
+	ctx := context.Background()
+	var agentID string
+	if err := testPool.QueryRow(ctx, `SELECT id::text FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("find agent: %v", err)
+	}
+	apiTrigger, apiToken := routineAPITokenDraft(t)
+	suffix := time.Now().Format("150405000000000")
+	firstTitle := "Routine event log first " + suffix
+	secondTitle := "Routine event log second " + suffix
+
+	w := httptest.NewRecorder()
+	req := routineRequest(t, "POST", "/api/routines", map[string]any{
+		"name":          "Routine event log fanout",
+		"instructions":  "Create multiple issues from one event",
+		"priority":      "medium",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+		"enabled":       true,
+		"triggers":      []map[string]any{apiTrigger},
+		"actions": []map[string]any{
+			{
+				"action_type": "create_issue",
+				"config": map[string]any{
+					"title_template": firstTitle,
+				},
+			},
+			{
+				"action_type": "create_issue",
+				"config": map[string]any{
+					"title_template": secondTitle,
+				},
+			},
+		},
+	})
+	testHandler.CreateRoutine(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateRoutine: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var routine RoutineResponse
+	if err := json.NewDecoder(w.Body).Decode(&routine); err != nil {
+		t.Fatalf("decode routine: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = testHandler.Queries.DeleteRoutine(ctx, db.DeleteRoutineParams{
+			ID:          parseUUID(routine.ID),
+			WorkspaceID: parseUUID(testWorkspaceID),
+		})
+		_, _ = testPool.Exec(ctx, `
+			DELETE FROM issue
+			WHERE workspace_id = $1 AND title = ANY($2::text[])
+		`, testWorkspaceID, []string{firstTitle, secondTitle})
+	})
+
+	dedupKey := "routine-event-log-fanout-" + suffix
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/webhook/"+routine.Triggers[0].ID, map[string]any{
+		"title":     "Fanout source event",
+		"body":      "One event should back both runs",
+		"dedup_key": dedupKey,
+	})
+	req = withURLParam(req, "id", routine.Triggers[0].ID)
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	testHandler.IngestRoutineTrigger(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("IngestRoutineTrigger: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var eventID string
+	var eventStatus string
+	var eventData []byte
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text, status, data
+		FROM routine_event
+		WHERE workspace_id = $1 AND dedup_key = $2
+	`, testWorkspaceID, dedupKey).Scan(&eventID, &eventStatus, &eventData); err != nil {
+		t.Fatalf("query routine_event: %v", err)
+	}
+	if eventStatus != "processed" {
+		t.Fatalf("routine_event status = %q, want processed", eventStatus)
+	}
+	var data map[string]string
+	if err := json.Unmarshal(eventData, &data); err != nil {
+		t.Fatalf("unmarshal routine_event data: %v", err)
+	}
+	if data["title"] != "Fanout source event" {
+		t.Fatalf("routine_event data title = %q", data["title"])
+	}
+
+	var runCount int
+	var linkedEventCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*), count(DISTINCT routine_event_id)
+		FROM routine_run
+		WHERE routine_id = $1 AND routine_event_id = $2
+	`, routine.ID, eventID).Scan(&runCount, &linkedEventCount); err != nil {
+		t.Fatalf("count routine runs linked to event: %v", err)
+	}
+	if runCount != 2 || linkedEventCount != 1 {
+		t.Fatalf("runs linked to event count = %d distinct events = %d, want 2/1", runCount, linkedEventCount)
+	}
+}
+
 func TestRoutineAPITriggerAcceptsFlexibleJSONPayload(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("test database not available")
@@ -1293,6 +1400,20 @@ func TestRoutineGitHubTriggerConfigFiltersEventsBeforeActions(t *testing.T) {
 	}
 	if len(runs) != 0 {
 		t.Fatalf("unmatched trigger event should not create routine runs, got %+v", runs)
+	}
+	var eventStatus string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status
+		FROM routine_event
+		WHERE workspace_id = $1
+		  AND source_type = 'github'
+		  AND event_type = 'github.pull_request.opened'
+		  AND dedup_key = 'github:pull_request:opened:https://github.com/acme/widgets/pull/901'
+	`, testWorkspaceID).Scan(&eventStatus); err != nil {
+		t.Fatalf("query routine_event for unmatched trigger event: %v", err)
+	}
+	if eventStatus != "no_matching_trigger" {
+		t.Fatalf("unmatched trigger event status = %q, want no_matching_trigger", eventStatus)
 	}
 
 	mergedBody := []byte(`{"action":"closed","pull_request":{"number":2,"title":"Merge target","merged":true,"html_url":"https://github.com/acme/widgets/pull/902","user":{"login":"bob"},"head":{"ref":"feat"},"base":{"ref":"main"},"body":"body"},"repository":{"full_name":"acme/widgets"}}`)

--- a/server/internal/service/routine.go
+++ b/server/internal/service/routine.go
@@ -32,10 +32,11 @@ func NewRoutineService(queries *db.Queries, txStarter routineTxStarter, taskServ
 }
 
 type RoutineEvent struct {
-	Type     string
-	DedupKey string
-	Data     map[string]string
-	Payload  []byte
+	RoutineEventID pgtype.UUID
+	Type           string
+	DedupKey       string
+	Data           map[string]string
+	Payload        []byte
 }
 
 type RoutineCreateIssueConfig struct {
@@ -328,16 +329,17 @@ func (s *RoutineService) logRun(ctx context.Context, routineID, triggerID, actio
 		payload = []byte("{}")
 	}
 	_, err := s.Queries.CreateRoutineRun(ctx, db.CreateRoutineRunParams{
-		RoutineID:    routineID,
-		TriggerID:    triggerID,
-		ActionID:     actionID,
-		EventType:    evt.Type,
-		DedupKey:     evt.DedupKey,
-		Payload:      payload,
-		Status:       status,
-		IssueID:      issueID,
-		CommentID:    commentID,
-		ErrorMessage: util.StrToText(errorMessage),
+		RoutineEventID: evt.RoutineEventID,
+		RoutineID:      routineID,
+		TriggerID:      triggerID,
+		ActionID:       actionID,
+		EventType:      evt.Type,
+		DedupKey:       evt.DedupKey,
+		Payload:        payload,
+		Status:         status,
+		IssueID:        issueID,
+		CommentID:      commentID,
+		ErrorMessage:   util.StrToText(errorMessage),
 	})
 	return err
 }

--- a/server/migrations/068_routine_event_log.down.sql
+++ b/server/migrations/068_routine_event_log.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_routine_run_routine_event;
+
+ALTER TABLE routine_run
+    DROP COLUMN IF EXISTS routine_event_id;
+
+DROP INDEX IF EXISTS idx_routine_event_delivery;
+DROP INDEX IF EXISTS idx_routine_event_workspace_source;
+DROP INDEX IF EXISTS idx_routine_event_workspace_created;
+
+DROP TABLE IF EXISTS routine_event;

--- a/server/migrations/068_routine_event_log.up.sql
+++ b/server/migrations/068_routine_event_log.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE routine_event (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id         UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    source_type          TEXT NOT NULL,
+    event_type           TEXT NOT NULL DEFAULT '',
+    dedup_key            TEXT NOT NULL DEFAULT '',
+    external_delivery_id TEXT,
+    data                 JSONB NOT NULL DEFAULT '{}',
+    payload              JSONB NOT NULL DEFAULT '{}',
+    status               TEXT NOT NULL CHECK (status IN (
+        'received',
+        'processed',
+        'filtered',
+        'deduped',
+        'no_matching_trigger',
+        'parse_error',
+        'error'
+    )),
+    error_message        TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_routine_event_workspace_created ON routine_event(workspace_id, created_at DESC);
+CREATE INDEX idx_routine_event_workspace_source ON routine_event(workspace_id, source_type, event_type, created_at DESC);
+CREATE INDEX idx_routine_event_delivery ON routine_event(source_type, external_delivery_id)
+    WHERE external_delivery_id IS NOT NULL;
+
+ALTER TABLE routine_run
+    ADD COLUMN routine_event_id UUID REFERENCES routine_event(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_routine_run_routine_event ON routine_run(routine_event_id)
+    WHERE routine_event_id IS NOT NULL;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -316,6 +316,21 @@ type RoutineAction struct {
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
+type RoutineEvent struct {
+	ID                 pgtype.UUID        `json:"id"`
+	WorkspaceID        pgtype.UUID        `json:"workspace_id"`
+	SourceType         string             `json:"source_type"`
+	EventType          string             `json:"event_type"`
+	DedupKey           string             `json:"dedup_key"`
+	ExternalDeliveryID pgtype.Text        `json:"external_delivery_id"`
+	Data               []byte             `json:"data"`
+	Payload            []byte             `json:"payload"`
+	Status             string             `json:"status"`
+	ErrorMessage       pgtype.Text        `json:"error_message"`
+	CreatedAt          pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+}
+
 type RoutineLabel struct {
 	RoutineID pgtype.UUID        `json:"routine_id"`
 	LabelID   pgtype.UUID        `json:"label_id"`
@@ -323,18 +338,19 @@ type RoutineLabel struct {
 }
 
 type RoutineRun struct {
-	ID           pgtype.UUID        `json:"id"`
-	RoutineID    pgtype.UUID        `json:"routine_id"`
-	TriggerID    pgtype.UUID        `json:"trigger_id"`
-	ActionID     pgtype.UUID        `json:"action_id"`
-	EventType    string             `json:"event_type"`
-	DedupKey     string             `json:"dedup_key"`
-	Payload      []byte             `json:"payload"`
-	Status       string             `json:"status"`
-	IssueID      pgtype.UUID        `json:"issue_id"`
-	CommentID    pgtype.UUID        `json:"comment_id"`
-	ErrorMessage pgtype.Text        `json:"error_message"`
-	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	ID             pgtype.UUID        `json:"id"`
+	RoutineID      pgtype.UUID        `json:"routine_id"`
+	TriggerID      pgtype.UUID        `json:"trigger_id"`
+	ActionID       pgtype.UUID        `json:"action_id"`
+	EventType      string             `json:"event_type"`
+	DedupKey       string             `json:"dedup_key"`
+	Payload        []byte             `json:"payload"`
+	Status         string             `json:"status"`
+	IssueID        pgtype.UUID        `json:"issue_id"`
+	CommentID      pgtype.UUID        `json:"comment_id"`
+	ErrorMessage   pgtype.Text        `json:"error_message"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	RoutineEventID pgtype.UUID        `json:"routine_event_id"`
 }
 
 type RoutineSubscriber struct {

--- a/server/pkg/db/generated/routine.sql.go
+++ b/server/pkg/db/generated/routine.sql.go
@@ -293,31 +293,85 @@ func (q *Queries) CreateRoutineAction(ctx context.Context, arg CreateRoutineActi
 	return i, err
 }
 
+const createRoutineEvent = `-- name: CreateRoutineEvent :one
+INSERT INTO routine_event (
+    workspace_id, source_type, event_type, dedup_key,
+    external_delivery_id, data, payload, status, error_message
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+RETURNING id, workspace_id, source_type, event_type, dedup_key, external_delivery_id, data, payload, status, error_message, created_at, updated_at
+`
+
+type CreateRoutineEventParams struct {
+	WorkspaceID        pgtype.UUID `json:"workspace_id"`
+	SourceType         string      `json:"source_type"`
+	EventType          string      `json:"event_type"`
+	DedupKey           string      `json:"dedup_key"`
+	ExternalDeliveryID pgtype.Text `json:"external_delivery_id"`
+	Data               []byte      `json:"data"`
+	Payload            []byte      `json:"payload"`
+	Status             string      `json:"status"`
+	ErrorMessage       pgtype.Text `json:"error_message"`
+}
+
+func (q *Queries) CreateRoutineEvent(ctx context.Context, arg CreateRoutineEventParams) (RoutineEvent, error) {
+	row := q.db.QueryRow(ctx, createRoutineEvent,
+		arg.WorkspaceID,
+		arg.SourceType,
+		arg.EventType,
+		arg.DedupKey,
+		arg.ExternalDeliveryID,
+		arg.Data,
+		arg.Payload,
+		arg.Status,
+		arg.ErrorMessage,
+	)
+	var i RoutineEvent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.SourceType,
+		&i.EventType,
+		&i.DedupKey,
+		&i.ExternalDeliveryID,
+		&i.Data,
+		&i.Payload,
+		&i.Status,
+		&i.ErrorMessage,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createRoutineRun = `-- name: CreateRoutineRun :one
 INSERT INTO routine_run (
-    routine_id, trigger_id, action_id, event_type, dedup_key,
+    routine_event_id, routine_id, trigger_id, action_id, event_type, dedup_key,
     payload, status, issue_id, comment_id, error_message
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
-RETURNING id, routine_id, trigger_id, action_id, event_type, dedup_key, payload, status, issue_id, comment_id, error_message, created_at
+RETURNING id, routine_id, trigger_id, action_id, event_type, dedup_key, payload, status, issue_id, comment_id, error_message, created_at, routine_event_id
 `
 
 type CreateRoutineRunParams struct {
-	RoutineID    pgtype.UUID `json:"routine_id"`
-	TriggerID    pgtype.UUID `json:"trigger_id"`
-	ActionID     pgtype.UUID `json:"action_id"`
-	EventType    string      `json:"event_type"`
-	DedupKey     string      `json:"dedup_key"`
-	Payload      []byte      `json:"payload"`
-	Status       string      `json:"status"`
-	IssueID      pgtype.UUID `json:"issue_id"`
-	CommentID    pgtype.UUID `json:"comment_id"`
-	ErrorMessage pgtype.Text `json:"error_message"`
+	RoutineEventID pgtype.UUID `json:"routine_event_id"`
+	RoutineID      pgtype.UUID `json:"routine_id"`
+	TriggerID      pgtype.UUID `json:"trigger_id"`
+	ActionID       pgtype.UUID `json:"action_id"`
+	EventType      string      `json:"event_type"`
+	DedupKey       string      `json:"dedup_key"`
+	Payload        []byte      `json:"payload"`
+	Status         string      `json:"status"`
+	IssueID        pgtype.UUID `json:"issue_id"`
+	CommentID      pgtype.UUID `json:"comment_id"`
+	ErrorMessage   pgtype.Text `json:"error_message"`
 }
 
 func (q *Queries) CreateRoutineRun(ctx context.Context, arg CreateRoutineRunParams) (RoutineRun, error) {
 	row := q.db.QueryRow(ctx, createRoutineRun,
+		arg.RoutineEventID,
 		arg.RoutineID,
 		arg.TriggerID,
 		arg.ActionID,
@@ -343,6 +397,7 @@ func (q *Queries) CreateRoutineRun(ctx context.Context, arg CreateRoutineRunPara
 		&i.CommentID,
 		&i.ErrorMessage,
 		&i.CreatedAt,
+		&i.RoutineEventID,
 	)
 	return i, err
 }
@@ -1094,6 +1149,52 @@ func (q *Queries) ListRoutineActions(ctx context.Context, routineID pgtype.UUID)
 	return items, nil
 }
 
+const listRoutineEvents = `-- name: ListRoutineEvents :many
+SELECT id, workspace_id, source_type, event_type, dedup_key, external_delivery_id, data, payload, status, error_message, created_at, updated_at FROM routine_event
+WHERE workspace_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListRoutineEventsParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Limit       int32       `json:"limit"`
+	Offset      int32       `json:"offset"`
+}
+
+func (q *Queries) ListRoutineEvents(ctx context.Context, arg ListRoutineEventsParams) ([]RoutineEvent, error) {
+	rows, err := q.db.Query(ctx, listRoutineEvents, arg.WorkspaceID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []RoutineEvent{}
+	for rows.Next() {
+		var i RoutineEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.SourceType,
+			&i.EventType,
+			&i.DedupKey,
+			&i.ExternalDeliveryID,
+			&i.Data,
+			&i.Payload,
+			&i.Status,
+			&i.ErrorMessage,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRoutineLabels = `-- name: ListRoutineLabels :many
 SELECT routine_id, label_id, created_at FROM routine_label
 WHERE routine_id = $1
@@ -1207,7 +1308,7 @@ func (q *Queries) ListRoutineOriginsByIssues(ctx context.Context, arg ListRoutin
 }
 
 const listRoutineRuns = `-- name: ListRoutineRuns :many
-SELECT id, routine_id, trigger_id, action_id, event_type, dedup_key, payload, status, issue_id, comment_id, error_message, created_at FROM routine_run
+SELECT id, routine_id, trigger_id, action_id, event_type, dedup_key, payload, status, issue_id, comment_id, error_message, created_at, routine_event_id FROM routine_run
 WHERE routine_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -1241,6 +1342,7 @@ func (q *Queries) ListRoutineRuns(ctx context.Context, arg ListRoutineRunsParams
 			&i.CommentID,
 			&i.ErrorMessage,
 			&i.CreatedAt,
+			&i.RoutineEventID,
 		); err != nil {
 			return nil, err
 		}
@@ -1585,6 +1687,41 @@ func (q *Queries) UpdateRoutineAction(ctx context.Context, arg UpdateRoutineActi
 		&i.Config,
 		&i.Enabled,
 		&i.Position,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const updateRoutineEventStatus = `-- name: UpdateRoutineEventStatus :one
+UPDATE routine_event SET
+    status = $2,
+    error_message = $3,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, source_type, event_type, dedup_key, external_delivery_id, data, payload, status, error_message, created_at, updated_at
+`
+
+type UpdateRoutineEventStatusParams struct {
+	ID           pgtype.UUID `json:"id"`
+	Status       string      `json:"status"`
+	ErrorMessage pgtype.Text `json:"error_message"`
+}
+
+func (q *Queries) UpdateRoutineEventStatus(ctx context.Context, arg UpdateRoutineEventStatusParams) (RoutineEvent, error) {
+	row := q.db.QueryRow(ctx, updateRoutineEventStatus, arg.ID, arg.Status, arg.ErrorMessage)
+	var i RoutineEvent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.SourceType,
+		&i.EventType,
+		&i.DedupKey,
+		&i.ExternalDeliveryID,
+		&i.Data,
+		&i.Payload,
+		&i.Status,
+		&i.ErrorMessage,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/pkg/db/queries/routine.sql
+++ b/server/pkg/db/queries/routine.sql
@@ -239,12 +239,35 @@ ON CONFLICT (routine_id, label_id) DO NOTHING;
 DELETE FROM routine_label
 WHERE routine_id = $1;
 
+-- name: CreateRoutineEvent :one
+INSERT INTO routine_event (
+    workspace_id, source_type, event_type, dedup_key,
+    external_delivery_id, data, payload, status, error_message
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+RETURNING *;
+
+-- name: UpdateRoutineEventStatus :one
+UPDATE routine_event SET
+    status = $2,
+    error_message = $3,
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: ListRoutineEvents :many
+SELECT * FROM routine_event
+WHERE workspace_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3;
+
 -- name: CreateRoutineRun :one
 INSERT INTO routine_run (
-    routine_id, trigger_id, action_id, event_type, dedup_key,
+    routine_event_id, routine_id, trigger_id, action_id, event_type, dedup_key,
     payload, status, issue_id, comment_id, error_message
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING *;
 


### PR DESCRIPTION
## Summary
- Add a normalized `routine_event` table and link new `routine_run` rows via `routine_event_id`.
- Persist adapter-parsed API/GitHub events once before routine matching, including no-match and parse-error states when a trusted workspace/source can be resolved.
- Preserve existing routine Runs API/UI behavior while exposing `routine_event_id` for future event-centric views.

## Test plan
- [x] `go test ./...` from `server`
- [x] `make check`
- [x] `git diff --check`
- [ ] `make test` failed in Docker because `cmd/multica` tests require `git`, but the test container reported `exec: "git": executable file not found in $PATH`


Made with [Cursor](https://cursor.com)