### PR TITLE
feat(routines): add event log browsing

### DIFF
--- a/apps/web/app/(dashboard)/routines/events/page.test.tsx
+++ b/apps/web/app/(dashboard)/routines/events/page.test.tsx
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    listRoutineEvents: vi.fn(),
+  },
+  clipboardWriteText: vi.fn(),
+}));
+
+vi.mock("@/shared/api", () => ({
+  api: mocks.api,
+}));
+
+import RoutineEventsPage from "./page";
+
+describe("RoutineEventsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: mocks.clipboardWriteText.mockResolvedValue(undefined),
+      },
+    });
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: mocks.clipboardWriteText,
+      },
+    });
+  });
+
+  it("loads recent routine events and fetches the next page when scrolled near the bottom", async () => {
+    mocks.api.listRoutineEvents
+      .mockResolvedValueOnce(
+        Array.from({ length: 20 }, (_, index) => ({
+          id: `event-${index + 1}`,
+          workspace_id: "ws-1",
+          source_type: "github",
+          event_type: index === 0 ? "github.pull_request.opened" : "github.pull_request.synchronize",
+          dedup_key: `delivery-${index + 1}`,
+          external_delivery_id: `delivery-${index + 1}`,
+          data: { action: "opened" },
+          payload: { title: "Open PR" },
+          status: "processed",
+          error_message: null,
+          created_at: "2026-06-09T08:00:00Z",
+          updated_at: "2026-06-09T08:00:00Z",
+        })),
+      )
+      .mockResolvedValueOnce([
+        {
+          id: "event-2",
+          workspace_id: "ws-1",
+          source_type: "api",
+          event_type: "custom",
+          dedup_key: "delivery-2",
+          external_delivery_id: null,
+          data: {},
+          payload: { title: "API call" },
+          status: "no_matching_trigger",
+          error_message: null,
+          created_at: "2026-06-09T07:00:00Z",
+          updated_at: "2026-06-09T07:00:00Z",
+        },
+      ]);
+
+    render(<RoutineEventsPage />);
+
+    expect(await screen.findByText("Routine events")).toBeInTheDocument();
+    expect(await screen.findByText("github.pull_request.opened")).toBeInTheDocument();
+    expect(screen.getAllByText("processed").length).toBeGreaterThan(0);
+    expect(mocks.api.listRoutineEvents).toHaveBeenCalledWith({ limit: 20, offset: 0 });
+
+    const scrollContainer = screen.getByTestId("routine-events-scroll");
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1000 });
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 480 });
+    fireEvent.scroll(scrollContainer);
+
+    await waitFor(() => {
+      expect(mocks.api.listRoutineEvents).toHaveBeenCalledWith({ limit: 20, offset: 20 });
+    });
+    expect(await screen.findByText("no_matching_trigger")).toBeInTheDocument();
+  });
+
+  it("toggles the payload preview by clicking the event card", async () => {
+    const user = userEvent.setup();
+    mocks.api.listRoutineEvents.mockResolvedValueOnce([
+      {
+        id: "event-1",
+        workspace_id: "ws-1",
+        source_type: "api",
+        event_type: "custom.demo_event",
+        dedup_key: "seed-routine-events-1",
+        external_delivery_id: null,
+        data: { seeded: true },
+        payload: { title: "Copy me" },
+        status: "processed",
+        error_message: null,
+        created_at: "2026-06-09T08:00:00Z",
+        updated_at: "2026-06-09T08:00:00Z",
+      },
+    ]);
+
+    render(<RoutineEventsPage />);
+
+    expect(screen.queryByRole("button", { name: "Copy payload preview" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Copy me/)).not.toBeInTheDocument();
+    const eventCard = await screen.findByRole("button", { name: /custom.demo_event/i });
+
+    await user.click(eventCard);
+
+    expect(screen.getByRole("button", { name: "Copy payload preview" })).toBeInTheDocument();
+    expect(screen.getByText(/Copy me/)).toBeInTheDocument();
+
+    await user.click(eventCard);
+
+    expect(screen.queryByRole("button", { name: "Copy payload preview" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Copy me/)).not.toBeInTheDocument();
+  });
+
+  it("does not toggle the payload preview while text is selected", async () => {
+    const user = userEvent.setup();
+    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "custom.demo_event",
+    } as Selection);
+    mocks.api.listRoutineEvents.mockResolvedValueOnce([
+      {
+        id: "event-1",
+        workspace_id: "ws-1",
+        source_type: "api",
+        event_type: "custom.demo_event",
+        dedup_key: "seed-routine-events-1",
+        external_delivery_id: null,
+        data: { seeded: true },
+        payload: { title: "Copy me" },
+        status: "processed",
+        error_message: null,
+        created_at: "2026-06-09T08:00:00Z",
+        updated_at: "2026-06-09T08:00:00Z",
+      },
+    ]);
+
+    render(<RoutineEventsPage />);
+
+    await user.click(await screen.findByRole("button", { name: /custom.demo_event/i }));
+
+    expect(screen.queryByText(/Copy me/)).not.toBeInTheDocument();
+    getSelectionSpy.mockRestore();
+  });
+
+  it("reloads events with status source and event type filters", async () => {
+    const user = userEvent.setup();
+    mocks.api.listRoutineEvents
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([]);
+
+    render(<RoutineEventsPage />);
+
+    await screen.findByText("No routine events yet");
+    await user.selectOptions(screen.getByLabelText("Status"), "error");
+    await user.selectOptions(screen.getByLabelText("Source"), "github");
+    await user.type(screen.getByLabelText("Event type"), "github.pull_request.opened");
+
+    await waitFor(() => {
+      expect(mocks.api.listRoutineEvents).toHaveBeenLastCalledWith({
+        limit: 20,
+        offset: 0,
+        status: "error",
+        source_type: "github",
+        event_type: "github.pull_request.opened",
+      });
+    });
+  });
+});

--- a/apps/web/app/(dashboard)/routines/events/page.test.tsx
+++ b/apps/web/app/(dashboard)/routines/events/page.test.tsx
@@ -162,7 +162,7 @@ describe("RoutineEventsPage", () => {
 
     await screen.findByText("No routine events yet");
     await user.selectOptions(screen.getByLabelText("Status"), "error");
-    await user.selectOptions(screen.getByLabelText("Source"), "github");
+    await user.selectOptions(screen.getByLabelText("Source"), "standard");
     await user.type(screen.getByLabelText("Event type"), "github.pull_request.opened");
 
     await waitFor(() => {
@@ -170,8 +170,36 @@ describe("RoutineEventsPage", () => {
         limit: 20,
         offset: 0,
         status: "error",
-        source_type: "github",
+        source_type: "standard",
         event_type: "github.pull_request.opened",
+      });
+    });
+  });
+
+  it("uses stored source type values for API and alert filters", async () => {
+    const user = userEvent.setup();
+    mocks.api.listRoutineEvents.mockResolvedValue([]);
+
+    render(<RoutineEventsPage />);
+
+    await screen.findByText("No routine events yet");
+    await user.selectOptions(screen.getByLabelText("Source"), "standard");
+
+    await waitFor(() => {
+      expect(mocks.api.listRoutineEvents).toHaveBeenLastCalledWith({
+        limit: 20,
+        offset: 0,
+        source_type: "standard",
+      });
+    });
+
+    await user.selectOptions(screen.getByLabelText("Source"), "oss-alert");
+
+    await waitFor(() => {
+      expect(mocks.api.listRoutineEvents).toHaveBeenLastCalledWith({
+        limit: 20,
+        offset: 0,
+        source_type: "oss-alert",
       });
     });
   });

--- a/apps/web/app/(dashboard)/routines/events/page.tsx
+++ b/apps/web/app/(dashboard)/routines/events/page.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ChevronLeft, Copy, History, Loader2 } from "lucide-react";
+import { AbsoluteTime } from "@/components/common/absolute-time";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
+import { api } from "@/shared/api";
+import type { RoutineEvent } from "@/shared/types";
+import { toast } from "sonner";
+
+const PAGE_SIZE = 20;
+
+const STATUS_FILTERS = [
+  { value: "", label: "All statuses" },
+  { value: "received", label: "Received" },
+  { value: "processed", label: "Processed" },
+  { value: "filtered", label: "Filtered" },
+  { value: "deduped", label: "Deduped" },
+  { value: "no_matching_trigger", label: "No matching trigger" },
+  { value: "parse_error", label: "Parse error" },
+  { value: "error", label: "Error" },
+];
+
+const SOURCE_FILTERS = [
+  { value: "", label: "All sources" },
+  { value: "github", label: "GitHub" },
+  { value: "api", label: "API" },
+  { value: "schedule", label: "Schedule" },
+  { value: "alert", label: "Alert" },
+];
+
+export default function RoutineEventsPage() {
+  const [events, setEvents] = useState<RoutineEvent[]>([]);
+  const [nextOffset, setNextOffset] = useState(0);
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("");
+  const [sourceFilter, setSourceFilter] = useState("");
+  const [eventTypeFilter, setEventTypeFilter] = useState("");
+
+  const loadPage = useCallback(async (offset: number) => {
+    const isInitial = offset === 0;
+    if (isInitial) {
+      setLoadingInitial(true);
+    } else {
+      setLoadingMore(true);
+    }
+    try {
+      const page = await api.listRoutineEvents({
+        limit: PAGE_SIZE,
+        offset,
+        status: statusFilter || undefined,
+        source_type: sourceFilter || undefined,
+        event_type: eventTypeFilter.trim() || undefined,
+      });
+      setEvents((current) => (isInitial ? page : [...current, ...page]));
+      setNextOffset(offset + PAGE_SIZE);
+      setHasMore(page.length === PAGE_SIZE);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to load routine events");
+    } finally {
+      if (isInitial) {
+        setLoadingInitial(false);
+      } else {
+        setLoadingMore(false);
+      }
+    }
+  }, [eventTypeFilter, sourceFilter, statusFilter]);
+
+  useEffect(() => {
+    void loadPage(0);
+  }, [loadPage]);
+
+  const handleScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      if (loadingInitial || loadingMore || !hasMore) return;
+      const target = event.currentTarget;
+      const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
+      if (distanceFromBottom < 160) {
+        void loadPage(nextOffset);
+      }
+    },
+    [hasMore, loadPage, loadingInitial, loadingMore, nextOffset],
+  );
+
+  return (
+    <main
+      data-testid="routine-events-scroll"
+      onScroll={handleScroll}
+      className="h-full min-h-0 overflow-y-auto bg-background"
+    >
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-6 py-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <History className="size-4" />
+              <a href="/routines" className="hover:text-foreground">Routines</a>
+              <span>/</span>
+              <span>Events</span>
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight">Routine events</h1>
+            <p className="text-sm text-muted-foreground">
+              Recent routine event log entries across this workspace.
+            </p>
+          </div>
+          <a href="/routines" className={buttonVariants({ variant: "outline" })}>
+            <ChevronLeft className="size-4" />
+            Back to routines
+          </a>
+        </div>
+
+        <section className="grid gap-3 rounded-xl border bg-muted/20 p-4 md:grid-cols-[1fr_1fr_2fr]">
+          <div className="grid gap-1.5">
+            <Label htmlFor="routine-event-status-filter">Status</Label>
+            <NativeSelect
+              id="routine-event-status-filter"
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value)}
+            >
+              {STATUS_FILTERS.map((option) => (
+                <NativeSelectOption key={option.value || "all"} value={option.value}>
+                  {option.label}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="routine-event-source-filter">Source</Label>
+            <NativeSelect
+              id="routine-event-source-filter"
+              value={sourceFilter}
+              onChange={(event) => setSourceFilter(event.target.value)}
+            >
+              {SOURCE_FILTERS.map((option) => (
+                <NativeSelectOption key={option.value || "all"} value={option.value}>
+                  {option.label}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="routine-event-type-filter">Event type</Label>
+            <Input
+              id="routine-event-type-filter"
+              value={eventTypeFilter}
+              onChange={(event) => setEventTypeFilter(event.target.value)}
+              placeholder="github.pull_request.opened"
+            />
+          </div>
+        </section>
+
+        {loadingInitial ? (
+          <div className="rounded-xl border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+            Loading routine events...
+          </div>
+        ) : events.length === 0 ? (
+          <div className="rounded-xl border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+            No routine events yet
+          </div>
+        ) : (
+          <section className="space-y-2">
+            {events.map((event) => (
+              <RoutineEventRow key={event.id} event={event} />
+            ))}
+          </section>
+        )}
+
+        {!loadingInitial && (
+          <div className="flex justify-center py-4 text-sm text-muted-foreground">
+            {loadingMore ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="size-4 animate-spin" />
+                Loading more events...
+              </span>
+            ) : hasMore ? (
+              "Scroll to load more"
+            ) : (
+              "No more events"
+            )}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function RoutineEventRow({ event }: { event: RoutineEvent }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const body = formatEventBody(event.payload, event.data);
+  const copyPayload = () => {
+    void window.navigator.clipboard.writeText(body).then(() => {
+      toast.success("Payload copied");
+    });
+  };
+  return (
+    <article
+      className="cursor-pointer rounded-xl border bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/30"
+      role="button"
+      tabIndex={0}
+      aria-expanded={isOpen}
+      onClick={() => {
+        if (hasSelectedText()) return;
+        setIsOpen((open) => !open);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          setIsOpen((open) => !open);
+        }
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <Badge variant="secondary">{event.source_type || "routine"}</Badge>
+            <span className="truncate text-sm font-medium">{event.event_type || "routine"}</span>
+          </div>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <AbsoluteTime value={event.created_at} style="shortDateTime" />
+            {event.dedup_key && <span className="truncate">Dedup: {event.dedup_key}</span>}
+            {event.external_delivery_id && <span className="truncate">Delivery: {event.external_delivery_id}</span>}
+          </div>
+          {event.error_message && (
+            <p className="text-sm text-destructive">{event.error_message}</p>
+          )}
+        </div>
+        <Badge variant={event.status === "error" || event.status === "parse_error" ? "destructive" : "outline"}>
+          {event.status}
+        </Badge>
+      </div>
+      {isOpen && (
+        <div className="mt-3">
+          <div className="mb-2 flex justify-end">
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              copyPayload();
+            }}
+            aria-label="Copy payload preview"
+              className="inline-flex h-6 items-center gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Copy className="size-3.5" />
+            Copy
+          </button>
+          </div>
+          <div className="overflow-hidden rounded-lg bg-background">
+          <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words p-3 text-xs text-muted-foreground">
+            {body}
+          </pre>
+        </div>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function hasSelectedText() {
+  return (window.getSelection()?.toString().trim().length ?? 0) > 0;
+}
+
+function formatEventBody(payload: unknown, data: unknown) {
+  return JSON.stringify({ payload, data }, null, 2);
+}

--- a/apps/web/app/(dashboard)/routines/events/page.tsx
+++ b/apps/web/app/(dashboard)/routines/events/page.tsx
@@ -28,9 +28,9 @@ const STATUS_FILTERS = [
 const SOURCE_FILTERS = [
   { value: "", label: "All sources" },
   { value: "github", label: "GitHub" },
-  { value: "api", label: "API" },
+  { value: "standard", label: "API" },
   { value: "schedule", label: "Schedule" },
-  { value: "alert", label: "Alert" },
+  { value: "oss-alert", label: "Alert" },
 ];
 
 export default function RoutineEventsPage() {

--- a/apps/web/app/(dashboard)/routines/page.test.tsx
+++ b/apps/web/app/(dashboard)/routines/page.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useAuthStore } from "@/features/auth";
 import { useRoutineStore } from "@/features/routines";
@@ -256,6 +256,7 @@ describe("RoutinesPage", () => {
     expect(screen.getByRole("heading", { name: "Routines" })).toBeInTheDocument();
     expect(screen.getByText("Loading routines...")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /New/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Events/i })).toHaveAttribute("href", "/routines/events");
   });
 
   it("renders routines returned by the API", async () => {
@@ -297,6 +298,166 @@ describe("RoutinesPage", () => {
     await user.click(row);
 
     expect(await screen.findByText("Review incoming work")).toBeInTheDocument();
+    expect(mocks.api.listRoutineRuns).toHaveBeenCalledWith("routine-1", { limit: 10, offset: 0 });
+    expect(screen.getByRole("switch", { name: "Routine enabled" })).toBeChecked();
+    expect(screen.queryByRole("button", { name: /Pause routine/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps inactive routines hidden until the inactive filter is enabled", async () => {
+    const user = userEvent.setup();
+    mocks.searchParams = new URLSearchParams();
+    mocks.api.listRoutines.mockResolvedValue([
+      {
+        id: "routine-active",
+        workspace_id: "ws-1",
+        name: "Active routine",
+        triggers: [],
+        actions: [],
+        subscriber_ids: [],
+        label_ids: [],
+        enabled: true,
+        managed: false,
+        github_auto_fix_enabled: false,
+      },
+      {
+        id: "routine-paused",
+        workspace_id: "ws-1",
+        name: "Paused routine",
+        triggers: [],
+        actions: [],
+        subscriber_ids: [],
+        label_ids: [],
+        enabled: false,
+        managed: false,
+        github_auto_fix_enabled: false,
+      },
+    ]);
+
+    render(<RoutinesPage />);
+
+    expect(await screen.findByRole("button", { name: /Active routine/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Paused routine/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Show inactive/i }));
+
+    expect(screen.getByRole("button", { name: /Paused routine/i })).toBeInTheDocument();
+  });
+
+  it("expands system routines in a separate section instead of merging them into the main list", async () => {
+    const user = userEvent.setup();
+    mocks.searchParams = new URLSearchParams();
+    mocks.api.listRoutines.mockResolvedValue([
+      {
+        id: "routine-normal",
+        workspace_id: "ws-1",
+        name: "Normal routine",
+        triggers: [],
+        actions: [],
+        subscriber_ids: [],
+        label_ids: [],
+        enabled: true,
+        managed: false,
+        github_auto_fix_enabled: false,
+      },
+      {
+        id: "routine-system",
+        workspace_id: "ws-1",
+        name: "System routine",
+        triggers: [],
+        actions: [],
+        subscriber_ids: [],
+        label_ids: [],
+        enabled: true,
+        managed: true,
+        github_auto_fix_enabled: false,
+      },
+    ]);
+
+    render(<RoutinesPage />);
+
+    expect(await screen.findByRole("button", { name: /Normal routine/i })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "System routines" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Show system routines/i }));
+
+    const systemSection = screen.getByRole("region", { name: "System routines" });
+    expect(within(systemSection).getByRole("button", { name: /System routine/i })).toBeInTheDocument();
+  });
+
+  it("loads more routine runs when the detail page scrolls near the bottom", async () => {
+    mocks.searchParams = new URLSearchParams();
+    mocks.api.listRoutines.mockResolvedValue([
+      {
+        id: "routine-1",
+        workspace_id: "ws-1",
+        name: "Daily code review",
+        triggers: [{ id: "trigger-1" }],
+        actions: [],
+        subscriber_ids: [],
+        label_ids: [],
+        enabled: true,
+        github_auto_fix_enabled: false,
+      },
+    ]);
+    mocks.api.getRoutine.mockResolvedValue({
+      id: "routine-1",
+      workspace_id: "ws-1",
+      name: "Daily code review",
+      instructions: "Review incoming work",
+      priority: "medium",
+      triggers: [{ id: "trigger-1", trigger_type: "schedule", schedule: "0 9 * * 1", timezone: "UTC", config: {} }],
+      actions: [],
+      subscriber_ids: [],
+      label_ids: [],
+      enabled: true,
+      github_auto_fix_enabled: false,
+    });
+    mocks.api.listRoutineRuns
+      .mockResolvedValueOnce(Array.from({ length: 10 }, (_, index) => ({
+        id: `run-${index + 1}`,
+        routine_id: "routine-1",
+        routine_event_id: null,
+        trigger_id: "trigger-1",
+        action_id: null,
+        event_type: "manual",
+        dedup_key: `run-${index + 1}`,
+        payload: {},
+        status: "processed",
+        issue_id: null,
+        comment_id: null,
+        error_message: null,
+        created_at: "2026-05-22T08:00:00Z",
+      })))
+      .mockResolvedValueOnce([
+        {
+          id: "run-11",
+          routine_id: "routine-1",
+          routine_event_id: null,
+          trigger_id: "trigger-1",
+          action_id: null,
+          event_type: "manual",
+          dedup_key: "run-11",
+          payload: {},
+          status: "processed",
+          issue_id: null,
+          comment_id: null,
+          error_message: null,
+          created_at: "2026-05-22T07:00:00Z",
+        },
+      ]);
+    const user = userEvent.setup();
+    render(<RoutinesPage />);
+
+    await user.click(await screen.findByRole("button", { name: /Daily code review/i }));
+    const scrollContainer = await screen.findByTestId("routine-detail-scroll");
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1000 });
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 480 });
+    fireEvent.scroll(scrollContainer);
+
+    await waitFor(() => {
+      expect(mocks.api.listRoutineRuns).toHaveBeenCalledWith("routine-1", { limit: 10, offset: 10 });
+    });
   });
 
   it("hides creation entry points for regular members", async () => {
@@ -347,8 +508,8 @@ describe("RoutinesPage", () => {
 
     expect(screen.queryByText(/Runs once on/)).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Once" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Run on a recurring cron schedule or once at a future time")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /GitHub event/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Run on a recurring cron schedule or once at a future time")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /GitHub event/i })).toBeInTheDocument();
     const addTrigger = screen.getByRole("button", { name: /Add another trigger/i });
 
     await user.click(addTrigger);

--- a/apps/web/app/(dashboard)/routines/page.tsx
+++ b/apps/web/app/(dashboard)/routines/page.tsx
@@ -14,8 +14,10 @@ import {
   Code2,
   Copy,
   GitBranch as Github,
+  History,
   Plus,
   Save,
+  SlidersHorizontal,
   Sparkles,
   Tag,
   Users,
@@ -23,7 +25,7 @@ import {
 } from "lucide-react";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -431,10 +433,17 @@ export default function RoutinesPage() {
   const fetchRoutines = useRoutineStore((s) => s.fetch);
   const selectRoutine = useRoutineStore((s) => s.select);
   const [showSystemRoutines, setShowSystemRoutines] = useState(false);
+  const [showInactiveRoutines, setShowInactiveRoutines] = useState(false);
   const currentMember = members.find((member) => member.user_id === currentUser?.id);
   const canManageRoutines = currentMember?.role === "owner" || currentMember?.role === "admin";
   const managedCount = routines.filter((routine) => routine.managed).length;
-  const visibleRoutines = showSystemRoutines ? routines : routines.filter((routine) => !routine.managed);
+  const visibleUserRoutines = routines.filter(
+    (routine) => !routine.managed && (showInactiveRoutines || routine.enabled),
+  );
+  const visibleSystemRoutines = routines.filter(
+    (routine) => routine.managed && (showInactiveRoutines || routine.enabled),
+  );
+  const hasUserRoutines = routines.some((routine) => !routine.managed);
   const urlRoutine = searchParams.get("routine");
   const editRoutineID = searchParams.get("edit") ?? searchParams.get("id");
   const isCreateMode = searchParams.get("new") === "1";
@@ -495,80 +504,118 @@ export default function RoutinesPage() {
     return <RoutineCreatePage routineID={queryPane.routineId} />;
   }
 
+  const renderRoutineRows = (items: Routine[]) => (
+    <div>
+      {items.map((routine) => {
+        const isSelected = activePane.routineId === routine.id;
+        return (
+          <button
+            key={routine.id}
+            type="button"
+            aria-current={isSelected ? "true" : undefined}
+            data-active={isSelected || undefined}
+            onClick={() => setPane({ type: "detail", routineId: routine.id })}
+            className={`group relative flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left transition-colors ${
+              isSelected
+                ? "bg-accent text-accent-foreground before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[3px] before:rounded-r before:bg-primary"
+                : "hover:bg-accent/50"
+            }`}
+          >
+            <span className="min-w-0">
+              <span className="flex min-w-0 items-center gap-2">
+                <span className="truncate text-sm font-medium">{routine.name}</span>
+                {routine.managed && (
+                  <Badge variant="secondary" className="shrink-0 text-[10px]">
+                    System
+                  </Badge>
+                )}
+              </span>
+              <span className="block truncate text-xs text-muted-foreground">
+                {routine.triggers.length} trigger{routine.triggers.length === 1 ? "" : "s"}
+                {" · "}
+                {routine.enabled ? "Enabled" : "Paused"}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+
   const listPane = (
     <div className="flex h-full flex-col border-r">
       <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
         <div className="min-w-0">
           <h1 className="truncate text-sm font-semibold">Routines</h1>
         </div>
-        {canManageRoutines && (
-          <Button size="sm" onClick={() => setPane({ type: "new", routineId: null })}>
-            <Plus className="size-4" />
-            New
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant={showInactiveRoutines ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setShowInactiveRoutines((value) => !value)}
+          >
+            <SlidersHorizontal className="size-4" />
+            {showInactiveRoutines ? "Hide inactive" : "Show inactive"}
           </Button>
-        )}
+          <a href="/routines/events" className={buttonVariants({ variant: "outline", size: "sm" })}>
+            <History className="size-4" />
+            Events
+          </a>
+          {canManageRoutines && (
+            <Button size="sm" onClick={() => setPane({ type: "new", routineId: null })}>
+              <Plus className="size-4" />
+              New
+            </Button>
+          )}
+        </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
         {loading ? (
           <div className="p-4 text-sm text-muted-foreground">Loading routines...</div>
-        ) : visibleRoutines.length === 0 ? (
+        ) : visibleUserRoutines.length === 0 ? (
           <div className="flex flex-col items-center justify-center px-4 py-16 text-center text-muted-foreground">
             <Sparkles className="mb-3 size-8 text-muted-foreground/50" />
-            <p className="text-sm font-medium text-foreground">No routines yet</p>
+            <p className="text-sm font-medium text-foreground">
+              {hasUserRoutines ? "No active routines" : "No routines yet"}
+            </p>
             <p className="mt-1 max-w-64 text-xs">
-              {canManageRoutines
-                ? "Create your first routine to schedule work or react to external events."
-                : "Ask an owner or admin to create routines for this workspace."}
+              {hasUserRoutines
+                ? "Use the inactive filter to show paused routines."
+                : canManageRoutines
+                  ? "Create your first routine to schedule work or react to external events."
+                  : "Ask an owner or admin to create routines for this workspace."}
             </p>
           </div>
         ) : (
-          <div>
-            {visibleRoutines.map((routine) => {
-              const isSelected = activePane.routineId === routine.id;
-              return (
-                <button
-                  key={routine.id}
-                  type="button"
-                  aria-current={isSelected ? "true" : undefined}
-                  data-active={isSelected || undefined}
-                  onClick={() => setPane({ type: "detail", routineId: routine.id })}
-                  className={`group relative flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left transition-colors ${
-                    isSelected
-                      ? "bg-accent text-accent-foreground before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[3px] before:rounded-r before:bg-primary"
-                      : "hover:bg-accent/50"
-                  }`}
-                >
-                  <span className="min-w-0">
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-sm font-medium">{routine.name}</span>
-                      {routine.managed && (
-                        <Badge variant="secondary" className="shrink-0 text-[10px]">
-                          System
-                        </Badge>
-                      )}
-                    </span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {routine.triggers.length} trigger{routine.triggers.length === 1 ? "" : "s"}
-                      {" · "}
-                      {routine.enabled ? "Enabled" : "Paused"}
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
-          </div>
+          renderRoutineRows(visibleUserRoutines)
         )}
 
         {managedCount > 0 && (
-          <button
-            type="button"
-            onClick={() => setShowSystemRoutines((value) => !value)}
-            className="self-start text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {showSystemRoutines
-              ? "Hide system routines"
-              : `Show system routines (${managedCount})`}
-          </button>
+          <div className="border-t">
+            <button
+              type="button"
+              onClick={() => setShowSystemRoutines((value) => !value)}
+              className="flex w-full items-center justify-between px-4 py-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span>{showSystemRoutines ? "Hide system routines" : `Show system routines (${managedCount})`}</span>
+              <ChevronDown className={`size-3.5 transition-transform ${showSystemRoutines ? "rotate-180" : ""}`} />
+            </button>
+            {showSystemRoutines && (
+              <section role="region" aria-label="System routines" className="border-t bg-muted/10">
+                <div className="px-4 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  System routines
+                </div>
+                {visibleSystemRoutines.length > 0 ? (
+                  renderRoutineRows(visibleSystemRoutines)
+                ) : (
+                  <div className="px-4 pb-3 text-xs text-muted-foreground">
+                    No active system routines
+                  </div>
+                )}
+              </section>
+            )}
+          </div>
         )}
       </div>
     </div>
@@ -683,6 +730,7 @@ function RoutineCreatePage({
   const effectiveTriggerDrafts = triggerDrafts.filter(
     (trigger) => trigger.type !== "api" || trigger.apiCredential !== null,
   );
+  const showTriggerOptions = addingTrigger || (!routineID && triggerDrafts.length === 0);
   const canSubmitRoutine =
     name.trim() !== "" &&
     instructions.trim() !== "" &&
@@ -1145,7 +1193,7 @@ function RoutineCreatePage({
               })}
             </div>
 
-            {addingTrigger && (
+            {showTriggerOptions && (
               <div className="space-y-2 pl-3">
                 {triggerOptions.map((option) => (
                     <AvailableTriggerRow
@@ -1160,6 +1208,11 @@ function RoutineCreatePage({
             <button
               type="button"
               onClick={() => {
+                if (!routineID && triggerDrafts.length === 0) {
+                  setAddingTrigger(true);
+                  setOpenTriggerId(null);
+                  return;
+                }
                 setAddingTrigger((open) => {
                   const next = !open;
                   if (next) setOpenTriggerId(null);

--- a/apps/web/app/(dashboard)/routines/routine-view-page.tsx
+++ b/apps/web/app/(dashboard)/routines/routine-view-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import {
@@ -20,14 +20,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
 import { RoutineRunList } from "@/features/routines";
 import { useRoutineStore } from "@/features/routines";
 import { useAuthStore } from "@/features/auth";
 import { useActorName, useWorkspaceStore } from "@/features/workspace";
-import { MoreHorizontal, Pencil, Play, Sparkles, Trash2 } from "lucide-react";
+import { Loader2, MoreHorizontal, Pencil, Play, Sparkles, Trash2 } from "lucide-react";
 import { api } from "@/shared/api";
 import type { Routine, RoutineRun } from "@/shared/types";
 import { toast } from "sonner";
+
+const ROUTINE_RUN_PAGE_SIZE = 10;
+
 export function RoutineViewPage({ routineID }: { routineID: string }) {
   const router = useRouter();
   const currentUser = useAuthStore((s) => s.user);
@@ -41,18 +45,37 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
   const [deleting, setDeleting] = useState(false);
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [loadingMoreRuns, setLoadingMoreRuns] = useState(false);
+  const [hasMoreRuns, setHasMoreRuns] = useState(true);
+  const [nextRunOffset, setNextRunOffset] = useState(0);
   const currentMember = members.find((member) => member.user_id === currentUser?.id);
   const canManageRoutines =
     (currentMember?.role === "owner" || currentMember?.role === "admin") && !routine?.managed;
 
+  const loadRuns = useCallback(async (offset: number, replace = false) => {
+    const page = await api.listRoutineRuns(routineID, {
+      limit: ROUTINE_RUN_PAGE_SIZE,
+      offset,
+    });
+    setRuns((current) => (replace ? page : [...current, ...page]));
+    setNextRunOffset(offset + ROUTINE_RUN_PAGE_SIZE);
+    setHasMoreRuns(page.length === ROUTINE_RUN_PAGE_SIZE);
+    return page;
+  }, [routineID]);
+
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    Promise.all([api.getRoutine(routineID), api.listRoutineRuns(routineID)])
+    Promise.all([
+      api.getRoutine(routineID),
+      api.listRoutineRuns(routineID, { limit: ROUTINE_RUN_PAGE_SIZE, offset: 0 }),
+    ])
       .then(([routineResult, runResult]) => {
         if (cancelled) return;
         setRoutine(routineResult);
         setRuns(runResult);
+        setNextRunOffset(ROUTINE_RUN_PAGE_SIZE);
+        setHasMoreRuns(runResult.length === ROUTINE_RUN_PAGE_SIZE);
       })
       .catch((error) => {
         if (!cancelled) toast.error(error instanceof Error ? error.message : "Failed to load routine");
@@ -65,12 +88,28 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
     };
   }, [routineID, workspaceId]);
 
+  const handleScroll = useCallback(
+    (event: React.UIEvent<HTMLElement>) => {
+      if (loading || loadingMoreRuns || !hasMoreRuns) return;
+      const target = event.currentTarget;
+      const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
+      if (distanceFromBottom >= 160) return;
+      setLoadingMoreRuns(true);
+      void loadRuns(nextRunOffset)
+        .catch((error) => {
+          toast.error(error instanceof Error ? error.message : "Failed to load routine runs");
+        })
+        .finally(() => setLoadingMoreRuns(false));
+    },
+    [hasMoreRuns, loadRuns, loading, loadingMoreRuns, nextRunOffset],
+  );
+
   async function handleTrigger() {
     if (!routine) return;
     setTriggering(true);
     try {
       await api.triggerRoutine(routine.id);
-      setRuns(await api.listRoutineRuns(routine.id));
+      await loadRuns(0, true);
       toast.success("Routine triggered");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to trigger routine");
@@ -111,7 +150,11 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
 
   return (
     <>
-      <main className="h-full min-h-0 overflow-y-auto bg-background">
+      <main
+        data-testid="routine-detail-scroll"
+        onScroll={handleScroll}
+        className="h-full min-h-0 overflow-y-auto bg-background"
+      >
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-6 py-5">
           <div className="flex items-start justify-between gap-4 md:items-center">
             <div className="space-y-1">
@@ -189,15 +232,12 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
                     <span className="flex items-center gap-2">
                       <span>{routine.enabled ? "Enabled" : "Paused"}</span>
                       {canManageRoutines && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="xs"
-                          onClick={handleToggleStatus}
+                        <Switch
+                          checked={routine.enabled}
+                          onCheckedChange={handleToggleStatus}
                           disabled={updatingStatus}
-                        >
-                          {routine.enabled ? "Pause routine" : "Enable routine"}
-                        </Button>
+                          aria-label="Routine enabled"
+                        />
                       )}
                     </span>
                   }
@@ -244,6 +284,14 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
               </section>
 
               <RoutineRunList runs={runs} />
+              {loadingMoreRuns && (
+                <div className="flex justify-center py-2 text-sm text-muted-foreground">
+                  <span className="inline-flex items-center gap-2">
+                    <Loader2 className="size-4 animate-spin" />
+                    Loading more runs...
+                  </span>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -49,6 +49,7 @@ import type {
   Routine,
   CreateRoutineRequest,
   UpdateRoutineRequest,
+  RoutineEvent,
   RoutineRun,
 } from "@/shared/types";
 import { type Logger, noopLogger } from "@/shared/logger";
@@ -985,7 +986,28 @@ export class ApiClient {
     });
   }
 
-  async listRoutineRuns(id: string): Promise<RoutineRun[]> {
-    return this.fetch(`/api/routines/${id}/runs`);
+  async listRoutineRuns(id: string, params: { limit?: number; offset?: number } = {}): Promise<RoutineRun[]> {
+    const searchParams = new URLSearchParams();
+    if (params.limit !== undefined) searchParams.set("limit", String(params.limit));
+    if (params.offset !== undefined) searchParams.set("offset", String(params.offset));
+    const query = searchParams.toString();
+    return this.fetch(`/api/routines/${id}/runs${query ? `?${query}` : ""}`);
+  }
+
+  async listRoutineEvents(params: {
+    limit?: number;
+    offset?: number;
+    status?: string;
+    source_type?: string;
+    event_type?: string;
+  } = {}): Promise<RoutineEvent[]> {
+    const searchParams = new URLSearchParams();
+    if (params.limit !== undefined) searchParams.set("limit", String(params.limit));
+    if (params.offset !== undefined) searchParams.set("offset", String(params.offset));
+    if (params.status) searchParams.set("status", params.status);
+    if (params.source_type) searchParams.set("source_type", params.source_type);
+    if (params.event_type) searchParams.set("event_type", params.event_type);
+    const query = searchParams.toString();
+    return this.fetch(`/api/routine-events${query ? `?${query}` : ""}`);
   }
 }

--- a/apps/web/shared/types/index.ts
+++ b/apps/web/shared/types/index.ts
@@ -45,6 +45,8 @@ export type {
   RoutineTriggerType,
   RoutineAction,
   RoutineActionType,
+  RoutineEvent,
+  RoutineEventStatus,
   RoutineRun,
   RoutineRunStatus,
   CreateRoutineRequest,

--- a/apps/web/shared/types/routine.ts
+++ b/apps/web/shared/types/routine.ts
@@ -3,6 +3,7 @@ import type { Issue, IssueAssigneeType, IssuePriority } from "./issue";
 export type RoutineTriggerType = "schedule" | "api" | "github";
 export type RoutineActionType = "create_issue" | "comment_issue";
 export type RoutineRunStatus = "processed" | "filtered" | "deduped" | "error";
+export type RoutineEventStatus = "received" | "processed" | "filtered" | "deduped" | "no_matching_trigger" | "parse_error" | "error";
 
 export interface RoutineTrigger {
   id: string;
@@ -118,4 +119,19 @@ export interface RoutineRun {
   error_message: string | null;
   created_at: string;
   issue?: Issue;
+}
+
+export interface RoutineEvent {
+  id: string;
+  workspace_id: string;
+  source_type: string;
+  event_type: string;
+  dedup_key: string;
+  external_delivery_id: string | null;
+  data: unknown;
+  payload: unknown;
+  status: RoutineEventStatus;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -305,6 +305,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 
 			// Routines
 			r.With(middleware.RequireWorkspaceRole(queries, "owner", "admin")).Post("/api/routine-trigger-token-drafts", h.GenerateRoutineTriggerTokenDraft)
+			r.Get("/api/routine-events", h.ListRoutineEvents)
 			r.Route("/api/routines", func(r chi.Router) {
 				r.Get("/", h.ListRoutines)
 				r.With(middleware.RequireWorkspaceRole(queries, "owner", "admin")).Post("/", h.CreateRoutine)

--- a/server/internal/handler/routine.go
+++ b/server/internal/handler/routine.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -112,6 +113,21 @@ type RoutineRunResponse struct {
 	ErrorMessage   *string        `json:"error_message"`
 	CreatedAt      string         `json:"created_at"`
 	Issue          *IssueResponse `json:"issue,omitempty"`
+}
+
+type RoutineEventResponse struct {
+	ID                 string  `json:"id"`
+	WorkspaceID        string  `json:"workspace_id"`
+	SourceType         string  `json:"source_type"`
+	EventType          string  `json:"event_type"`
+	DedupKey           string  `json:"dedup_key"`
+	ExternalDeliveryID *string `json:"external_delivery_id"`
+	Data               any     `json:"data"`
+	Payload            any     `json:"payload"`
+	Status             string  `json:"status"`
+	ErrorMessage       *string `json:"error_message"`
+	CreatedAt          string  `json:"created_at"`
+	UpdatedAt          string  `json:"updated_at"`
 }
 
 type RoutineTriggerTokenResponse struct {
@@ -577,6 +593,79 @@ func validateRoutineRequest(req CreateRoutineRequest) string {
 	return ""
 }
 
+func (h *Handler) ListRoutineEvents(w http.ResponseWriter, r *http.Request) {
+	workspaceID := ctxWorkspaceID(r.Context())
+	limit := 20
+	offset := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v > 0 {
+			offset = v
+		}
+	}
+	statusFilter := optionalTextQuery(r, "status")
+	sourceTypeFilter := optionalTextQuery(r, "source_type")
+	eventTypeFilter := optionalTextQuery(r, "event_type")
+
+	events, err := h.Queries.ListRoutineEvents(r.Context(), db.ListRoutineEventsParams{
+		WorkspaceID: parseUUID(workspaceID),
+		Limit:       int32(limit),
+		Offset:      int32(offset),
+		Status:      statusFilter,
+		SourceType:  sourceTypeFilter,
+		EventType:   eventTypeFilter,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list routine events")
+		return
+	}
+	resp := make([]RoutineEventResponse, 0, len(events))
+	for _, event := range events {
+		resp = append(resp, routineEventToResponse(event))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func optionalTextQuery(r *http.Request, key string) pgtype.Text {
+	value := strings.TrimSpace(r.URL.Query().Get(key))
+	if value == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: value, Valid: true}
+}
+
+func routineEventToResponse(event db.RoutineEvent) RoutineEventResponse {
+	var data any
+	if len(event.Data) > 0 {
+		_ = json.Unmarshal(event.Data, &data)
+	}
+	var payload any
+	if len(event.Payload) > 0 {
+		_ = json.Unmarshal(event.Payload, &payload)
+	}
+	return RoutineEventResponse{
+		ID:                 uuidToString(event.ID),
+		WorkspaceID:        uuidToString(event.WorkspaceID),
+		SourceType:         event.SourceType,
+		EventType:          event.EventType,
+		DedupKey:           event.DedupKey,
+		ExternalDeliveryID: textToPtr(event.ExternalDeliveryID),
+		Data:               data,
+		Payload:            payload,
+		Status:             event.Status,
+		ErrorMessage:       textToPtr(event.ErrorMessage),
+		CreatedAt:          timestampToString(event.CreatedAt),
+		UpdatedAt:          timestampToString(event.UpdatedAt),
+	}
+}
+
 func (h *Handler) ListRoutineRuns(w http.ResponseWriter, r *http.Request) {
 	workspaceID := ctxWorkspaceID(r.Context())
 	id := parseUUID(chi.URLParam(r, "id"))
@@ -584,10 +673,25 @@ func (h *Handler) ListRoutineRuns(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "routine not found")
 		return
 	}
+	limit := 100
+	offset := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v > 0 {
+			offset = v
+		}
+	}
 	runs, err := h.Queries.ListRoutineRuns(r.Context(), db.ListRoutineRunsParams{
 		RoutineID: id,
-		Limit:     100,
-		Offset:    0,
+		Limit:     int32(limit),
+		Offset:    int32(offset),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list routine runs")

--- a/server/internal/handler/routine_test.go
+++ b/server/internal/handler/routine_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/nullne/multica/server/internal/middleware"
 	db "github.com/nullne/multica/server/pkg/db/generated"
 )
@@ -112,6 +113,110 @@ func TestRoutineCRUD_CreateGetAndRunList(t *testing.T) {
 	testHandler.ListRoutineRuns(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("ListRoutineRuns: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListRoutineEventsPaginatesWorkspaceEventLog(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+
+	ctx := context.Background()
+	created := make([]db.RoutineEvent, 0, 3)
+	for i, eventType := range []string{"routine.test.first", "routine.test.second", "routine.test.third"} {
+		event, err := testHandler.Queries.CreateRoutineEvent(ctx, db.CreateRoutineEventParams{
+			WorkspaceID:        parseUUID(testWorkspaceID),
+			SourceType:         "api",
+			EventType:          eventType,
+			DedupKey:           eventType,
+			ExternalDeliveryID: pgtype.Text{String: "delivery-" + eventType, Valid: true},
+			Data:               []byte(`{"headers":{"x-test":"true"}}`),
+			Payload:            []byte(`{"title":"Routine event page"}`),
+			Status:             "processed",
+		})
+		if err != nil {
+			t.Fatalf("create routine event %d: %v", i, err)
+		}
+		created = append(created, event)
+	}
+
+	w := httptest.NewRecorder()
+	req := routineRequest(t, "GET", "/api/routine-events?limit=2&offset=1", nil)
+	testHandler.ListRoutineEvents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListRoutineEvents: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var events []RoutineEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&events); err != nil {
+		t.Fatalf("decode routine events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].ID != uuidToString(created[1].ID) || events[1].ID != uuidToString(created[0].ID) {
+		t.Fatalf("unexpected paginated order: got %q, %q", events[0].EventType, events[1].EventType)
+	}
+	if events[0].Payload.(map[string]any)["title"] != "Routine event page" {
+		t.Fatalf("payload not decoded: %+v", events[0].Payload)
+	}
+}
+
+func TestListRoutineEventsFiltersByStatusSourceAndEventType(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+
+	ctx := context.Background()
+	matching, err := testHandler.Queries.CreateRoutineEvent(ctx, db.CreateRoutineEventParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		SourceType:  "github",
+		EventType:   "github.pull_request.opened",
+		DedupKey:    "routine-event-filter-match",
+		Data:        []byte(`{}`),
+		Payload:     []byte(`{"title":"Matched event"}`),
+		Status:      "error",
+	})
+	if err != nil {
+		t.Fatalf("create matching routine event: %v", err)
+	}
+	for _, fixture := range []struct {
+		sourceType string
+		eventType  string
+		status     string
+		dedupKey   string
+	}{
+		{"github", "github.pull_request.closed", "error", "routine-event-filter-wrong-event"},
+		{"api", "github.pull_request.opened", "error", "routine-event-filter-wrong-source"},
+		{"github", "github.pull_request.opened", "processed", "routine-event-filter-wrong-status"},
+	} {
+		_, err := testHandler.Queries.CreateRoutineEvent(ctx, db.CreateRoutineEventParams{
+			WorkspaceID: parseUUID(testWorkspaceID),
+			SourceType:  fixture.sourceType,
+			EventType:   fixture.eventType,
+			DedupKey:    fixture.dedupKey,
+			Data:        []byte(`{}`),
+			Payload:     []byte(`{}`),
+			Status:      fixture.status,
+		})
+		if err != nil {
+			t.Fatalf("create routine event fixture %s: %v", fixture.dedupKey, err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	req := routineRequest(t, "GET", "/api/routine-events?status=error&source_type=github&event_type=github.pull_request.opened", nil)
+	testHandler.ListRoutineEvents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListRoutineEvents: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var events []RoutineEventResponse
+	if err := json.NewDecoder(w.Body).Decode(&events); err != nil {
+		t.Fatalf("decode routine events: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != uuidToString(matching.ID) {
+		t.Fatalf("expected only matching event, got %+v", events)
 	}
 }
 

--- a/server/pkg/db/generated/routine.sql.go
+++ b/server/pkg/db/generated/routine.sql.go
@@ -1152,6 +1152,9 @@ func (q *Queries) ListRoutineActions(ctx context.Context, routineID pgtype.UUID)
 const listRoutineEvents = `-- name: ListRoutineEvents :many
 SELECT id, workspace_id, source_type, event_type, dedup_key, external_delivery_id, data, payload, status, error_message, created_at, updated_at FROM routine_event
 WHERE workspace_id = $1
+  AND ($4::text IS NULL OR status = $4)
+  AND ($5::text IS NULL OR source_type = $5)
+  AND ($6::text IS NULL OR event_type = $6)
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
 `
@@ -1160,10 +1163,20 @@ type ListRoutineEventsParams struct {
 	WorkspaceID pgtype.UUID `json:"workspace_id"`
 	Limit       int32       `json:"limit"`
 	Offset      int32       `json:"offset"`
+	Status      pgtype.Text `json:"status"`
+	SourceType  pgtype.Text `json:"source_type"`
+	EventType   pgtype.Text `json:"event_type"`
 }
 
 func (q *Queries) ListRoutineEvents(ctx context.Context, arg ListRoutineEventsParams) ([]RoutineEvent, error) {
-	rows, err := q.db.Query(ctx, listRoutineEvents, arg.WorkspaceID, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, listRoutineEvents,
+		arg.WorkspaceID,
+		arg.Limit,
+		arg.Offset,
+		arg.Status,
+		arg.SourceType,
+		arg.EventType,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/routine.sql
+++ b/server/pkg/db/queries/routine.sql
@@ -259,6 +259,9 @@ RETURNING *;
 -- name: ListRoutineEvents :many
 SELECT * FROM routine_event
 WHERE workspace_id = $1
+  AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status'))
+  AND (sqlc.narg('source_type')::text IS NULL OR source_type = sqlc.narg('source_type'))
+  AND (sqlc.narg('event_type')::text IS NULL OR event_type = sqlc.narg('event_type'))
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
 


### PR DESCRIPTION
## Summary
- Add a workspace-level routine event log page with infinite loading, payload preview/copy, and status/source/event type filters.
- Add the backend routine event listing API and query filtering support.
- Refine routines UX: separate system routine expansion, hide inactive routines by default, switch-based status control, paginated routine runs, and default trigger options for new routines.

## Test plan
- `pnpm --filter @multica/web exec vitest run 'app/(dashboard)/routines/page.test.tsx'`
- `pnpm --filter @multica/web exec vitest run 'app/(dashboard)/routines/events/page.test.tsx'`
- `go test ./internal/handler -run 'TestListRoutineEvents(Filters|Paginates)'`
- `go test ./internal/handler -run 'TestRoutineCRUD_CreateGetAndRunList|TestListRoutineEvents'`
- `make check`


Made with [Cursor](https://cursor.com)