### PR TITLE
feat(web): dispatch-after picker relative/absolute tabs with confirm flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,3 +268,14 @@ test("example", async ({ page }) => {
   // api.cleanup() in afterEach removes the issue
 });
 ```
+
+## Targeted UI Verification (Playwright Screenshots)
+
+To manually verify a single UI feature against the running `make dev` environment (e.g. after building a component, or to capture screenshots for a PR), drive the browser with Playwright and take step-by-step screenshots instead of writing a full E2E test. Full guide: `docs/ui-verification-playwright.md`.
+
+Short version:
+
+1. Log in by calling `POST /auth/dev` from the page and storing `multica_token` + `multica_workspace_id` in localStorage (mirrors `loginAsDefault` in `e2e/helpers.ts`).
+2. Seed exactly the data the feature needs via the REST API (`Authorization: Bearer` + `X-Workspace-ID` headers), then reload so stores hydrate.
+3. Interact via accessibility snapshots/roles, capture one screenshot per meaningful step (a 3–5 screenshot sequence reads like a recording; the Playwright MCP plugin cannot record video — use a throwaway spec with `video: "on"` if a real video is required).
+4. Assert against the DOM (text, disabled states) as well as the screenshot, clean up created data afterwards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,3 +273,14 @@ test("example", async ({ page }) => {
   // api.cleanup() in afterEach removes the issue
 });
 ```
+
+## Targeted UI Verification (Playwright Screenshots)
+
+To manually verify a single UI feature against the running `make dev` environment (e.g. after building a component, or to capture screenshots for a PR), drive the browser with Playwright and take step-by-step screenshots instead of writing a full E2E test. Full guide: `docs/ui-verification-playwright.md`.
+
+Short version:
+
+1. Log in by calling `POST /auth/dev` from the page and storing `multica_token` + `multica_workspace_id` in localStorage (mirrors `loginAsDefault` in `e2e/helpers.ts`).
+2. Seed exactly the data the feature needs via the REST API (`Authorization: Bearer` + `X-Workspace-ID` headers), then reload so stores hydrate.
+3. Interact via accessibility snapshots/roles, capture one screenshot per meaningful step (a 3–5 screenshot sequence reads like a recording; the Playwright MCP plugin cannot record video — use a throwaway spec with `video: "on"` if a real video is required).
+4. Assert against the DOM (text, disabled states) as well as the screenshot, clean up created data afterwards.

--- a/apps/web/components/pwa/service-worker-registration.tsx
+++ b/apps/web/components/pwa/service-worker-registration.tsx
@@ -8,6 +8,22 @@ export function ServiceWorkerRegistration() {
       return;
     }
 
+    // In dev, the service worker must not intercept requests: cached
+    // /_next/ chunks would keep serving stale code across rebuilds.
+    // Unregister any previously installed worker and drop its caches.
+    if (process.env.NODE_ENV !== "production") {
+      const cleanup = async () => {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((r) => r.unregister()));
+        if ("caches" in window) {
+          const keys = await caches.keys();
+          await Promise.all(keys.map((key) => caches.delete(key)));
+        }
+      };
+      cleanup().catch(() => {});
+      return;
+    }
+
     const register = async () => {
       try {
         await navigator.serviceWorker.register("/sw.js", { scope: "/" });

--- a/apps/web/features/issues/components/pickers/dispatch-after-picker.tsx
+++ b/apps/web/features/issues/components/pickers/dispatch-after-picker.tsx
@@ -9,9 +9,32 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
-import { formatAbsoluteTime } from "@/shared/utils";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@/components/ui/native-select";
+import { formatAbsoluteTime, formatRelativeTime } from "@/shared/utils";
 
 const DEFAULT_HOUR = 9;
+
+const MINUTES_PER_UNIT = {
+  minutes: 1,
+  hours: 60,
+  days: 60 * 24,
+} as const;
+
+type DurationUnit = keyof typeof MINUTES_PER_UNIT;
+
+const RELATIVE_PRESETS: { label: string; amount: number; unit: DurationUnit }[] = [
+  { label: "15 minutes", amount: 15, unit: "minutes" },
+  { label: "30 minutes", amount: 30, unit: "minutes" },
+  { label: "1 hour", amount: 1, unit: "hours" },
+  { label: "3 hours", amount: 3, unit: "hours" },
+  { label: "1 day", amount: 1, unit: "days" },
+  { label: "3 days", amount: 3, unit: "days" },
+];
 
 function combineDateAndTime(date: Date, time: string): Date {
   const next = new Date(date);
@@ -27,8 +50,9 @@ function toTimeInputValue(date: Date): string {
 }
 
 // DispatchAfterPicker selects the time before which an agent assignment is
-// not dispatched. Unlike DueDatePicker it needs minute precision, so it pairs
-// the calendar with a time input.
+// not dispatched. It offers a relative "in N minutes/hours/days" tab (default)
+// and an absolute calendar + time tab. Both tabs stage a pending value and
+// only commit it when the Set button is pressed.
 export function DispatchAfterPicker({
   dispatchAfter,
   onChange,
@@ -41,11 +65,46 @@ export function DispatchAfterPicker({
   triggerRender?: React.ReactElement;
 }) {
   const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<"relative" | "absolute">("relative");
+  const [customAmount, setCustomAmount] = useState("30");
+  const [customUnit, setCustomUnit] = useState<DurationUnit>("minutes");
+  // Pending absolute selection — committed via the Set button.
+  const [pendingDate, setPendingDate] = useState<Date | undefined>(undefined);
   const date = dispatchAfter ? new Date(dispatchAfter) : undefined;
   const isPending = date ? date > new Date() : false;
 
+  const customMinutes =
+    Number.parseFloat(customAmount) * MINUTES_PER_UNIT[customUnit];
+  const customValid = Number.isFinite(customMinutes) && customMinutes > 0;
+
+  const commitRelative = () => {
+    if (!customValid) return;
+    onChange(new Date(Date.now() + customMinutes * 60_000).toISOString());
+    setOpen(false);
+  };
+
+  // A pending absolute time must be in the future to be committable.
+  const pendingInFuture = pendingDate ? pendingDate > new Date() : false;
+
+  const commitAbsolute = () => {
+    if (!pendingDate || !pendingInFuture) return;
+    onChange(pendingDate.toISOString());
+    setOpen(false);
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) {
+          // Stage the current value when the popover opens. A stored value is
+          // an absolute timestamp, so land on the tab that can display it.
+          setPendingDate(date);
+          setTab(date ? "absolute" : "relative");
+        }
+      }}
+    >
       <PopoverTrigger
         className={triggerRender ? undefined : "flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors"}
         render={triggerRender}
@@ -53,9 +112,10 @@ export function DispatchAfterPicker({
         {customTrigger ?? (
           <>
             <Timer className="h-3.5 w-3.5 text-muted-foreground" />
-            {date ? (
+            {date && dispatchAfter ? (
               <span className={isPending ? "text-primary" : "text-muted-foreground"}>
                 {formatAbsoluteTime(dispatchAfter, "shortDateTime")}
+                <span className="text-muted-foreground"> ({formatRelativeTime(dispatchAfter)})</span>
               </span>
             ) : (
               <span className="text-muted-foreground">Dispatch after</span>
@@ -64,33 +124,114 @@ export function DispatchAfterPicker({
         )}
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
-        <Calendar
-          mode="single"
-          selected={date}
-          onSelect={(d: Date | undefined) => {
-            if (!d) return;
-            // Keep the previously selected time when changing the date.
-            const next = new Date(d);
-            if (date) {
-              next.setHours(date.getHours(), date.getMinutes(), 0, 0);
-            } else {
-              next.setHours(DEFAULT_HOUR, 0, 0, 0);
-            }
-            onChange(next.toISOString());
-          }}
-        />
-        <div className="border-t px-3 py-2 flex items-center justify-between gap-2">
-          <input
-            type="time"
-            value={date ? toTimeInputValue(date) : `${String(DEFAULT_HOUR).padStart(2, "0")}:00`}
-            disabled={!date}
-            onChange={(e) => {
-              if (!date || !e.target.value) return;
-              onChange(combineDateAndTime(date, e.target.value).toISOString());
-            }}
-            className="rounded border px-1.5 py-0.5 text-xs bg-transparent outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
-          />
-          {date && (
+        <Tabs
+          value={tab}
+          onValueChange={(value) => setTab(value as "relative" | "absolute")}
+        >
+          <div className="border-b px-2 pt-2 pb-1.5">
+            <TabsList className="w-full">
+              <TabsTrigger value="relative" className="text-xs">
+                In…
+              </TabsTrigger>
+              <TabsTrigger value="absolute" className="text-xs">
+                At time
+              </TabsTrigger>
+            </TabsList>
+          </div>
+          <TabsContent value="relative" className="w-60 p-2">
+            <div className="grid grid-cols-2 gap-1">
+              {RELATIVE_PRESETS.map((preset) => {
+                const selected =
+                  customUnit === preset.unit &&
+                  Number.parseFloat(customAmount) === preset.amount;
+                return (
+                  <Button
+                    key={preset.label}
+                    variant={selected ? "secondary" : "ghost"}
+                    size="xs"
+                    onClick={() => {
+                      setCustomAmount(String(preset.amount));
+                      setCustomUnit(preset.unit);
+                    }}
+                    className="justify-start font-normal"
+                  >
+                    {preset.label}
+                  </Button>
+                );
+              })}
+            </div>
+            <div className="mt-2 flex items-center gap-1.5 border-t pt-2">
+              <Input
+                type="number"
+                min={1}
+                value={customAmount}
+                onChange={(e) => setCustomAmount(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") commitRelative();
+                }}
+                className="h-7 w-16 px-2 text-xs"
+                aria-label="Duration amount"
+              />
+              <NativeSelect
+                size="sm"
+                className="flex-1"
+                value={customUnit}
+                onChange={(e) => setCustomUnit(e.target.value as DurationUnit)}
+                aria-label="Duration unit"
+              >
+                <NativeSelectOption value="minutes">minutes</NativeSelectOption>
+                <NativeSelectOption value="hours">hours</NativeSelectOption>
+                <NativeSelectOption value="days">days</NativeSelectOption>
+              </NativeSelect>
+              <Button size="xs" disabled={!customValid} onClick={commitRelative}>
+                Set
+              </Button>
+            </div>
+          </TabsContent>
+          <TabsContent value="absolute">
+            <Calendar
+              mode="single"
+              selected={pendingDate}
+              disabled={{ before: new Date() }}
+              onSelect={(d: Date | undefined) => {
+                if (!d) return;
+                // Keep the previously selected time when changing the date.
+                const next = new Date(d);
+                if (pendingDate) {
+                  next.setHours(pendingDate.getHours(), pendingDate.getMinutes(), 0, 0);
+                } else {
+                  next.setHours(DEFAULT_HOUR, 0, 0, 0);
+                }
+                setPendingDate(next);
+              }}
+            />
+            <div className="border-t px-3 py-2 flex items-center gap-1.5">
+              <input
+                type="time"
+                value={pendingDate ? toTimeInputValue(pendingDate) : `${String(DEFAULT_HOUR).padStart(2, "0")}:00`}
+                disabled={!pendingDate}
+                onChange={(e) => {
+                  if (!pendingDate || !e.target.value) return;
+                  setPendingDate(combineDateAndTime(pendingDate, e.target.value));
+                }}
+                className="rounded border px-1.5 py-0.5 text-xs bg-transparent outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+              />
+              <Button
+                size="xs"
+                disabled={!pendingInFuture}
+                onClick={commitAbsolute}
+                className="ml-auto"
+              >
+                Set
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+        {date && (
+          <div className="border-t px-2 py-1.5 flex items-center justify-between gap-2">
+            <span className="text-xs text-muted-foreground truncate">
+              {formatAbsoluteTime(dispatchAfter, "shortDateTime")}
+            </span>
             <Button
               variant="ghost"
               size="xs"
@@ -102,8 +243,8 @@ export function DispatchAfterPicker({
             >
               Clear
             </Button>
-          )}
-        </div>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/shared/utils.ts
+++ b/apps/web/shared/utils.ts
@@ -9,6 +9,27 @@ export function timeAgo(dateStr: string): string {
   return `${days}d ago`;
 }
 
+// Relative time with minute precision, e.g. "in 28m", "in 3h 5m",
+// "in 2d 4h", "15m ago". Computed once at render — not live-updating.
+export function formatRelativeTime(dateStr: string): string {
+  const diffMs = new Date(dateStr).getTime() - Date.now();
+  const future = diffMs > 0;
+  const totalMinutes = Math.round(Math.abs(diffMs) / 60000);
+  if (totalMinutes < 1) return future ? "in <1m" : "just now";
+
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts: string[] = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes && !days) parts.push(`${minutes}m`);
+
+  const text = parts.join(" ");
+  return future ? `in ${text}` : `${text} ago`;
+}
+
 export type AbsoluteTimeStyle = "shortDate" | "shortDateTime" | "localeDate" | "localeDateTime";
 
 const absoluteTimeFormats: Record<AbsoluteTimeStyle, Intl.DateTimeFormatOptions | undefined> = {

--- a/docs/ui-verification-playwright.md
+++ b/docs/ui-verification-playwright.md
@@ -1,0 +1,125 @@
+# Targeted UI Verification with Playwright (Screenshots / Recording)
+
+How to manually verify a single UI feature against the running dev environment
+using Playwright browser automation — taking step-by-step screenshots to walk
+through a flow. This complements (does not replace) the E2E suite: use it to
+eyeball a feature you just built, reproduce a UI bug, or capture screenshots
+for a PR description.
+
+Agents with Playwright MCP tools (`browser_navigate`, `browser_snapshot`,
+`browser_click`, `browser_take_screenshot`, `browser_run_code_unsafe`, ...)
+should follow this flow. The same steps work from a hand-written Playwright
+script.
+
+## 1. Prerequisites
+
+- `make dev` is running: frontend on `http://localhost:3000`, backend on
+  `http://localhost:8080`.
+- Dev auth bypass is enabled on the backend (default in `make dev`), so
+  `POST /auth/dev` issues a token without a real login.
+
+## 2. Log in (inject a dev token)
+
+Navigate to `http://localhost:3000` first (any page on the origin), then run
+in the page context:
+
+```js
+const r = await fetch("http://localhost:8080/auth/dev", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ email: "e2e@multica.ai", name: "E2E User" }),
+});
+const { token } = await r.json();
+localStorage.setItem("multica_token", token);
+
+const workspaces = await (
+  await fetch("http://localhost:8080/api/workspaces", {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+).json();
+localStorage.setItem("multica_workspace_id", workspaces[0].id);
+```
+
+Then navigate to `/issues` and wait for `[data-slot="sidebar"]` to become
+visible (auth init settled). This mirrors `loginAsDefault` in `e2e/helpers.ts`.
+
+## 3. Create exactly the data the feature needs
+
+Call the REST API from the page context with the token from localStorage.
+Always send `Authorization: Bearer <token>` and `X-Workspace-ID`:
+
+```js
+const headers = {
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${localStorage.getItem("multica_token")}`,
+  "X-Workspace-ID": localStorage.getItem("multica_workspace_id"),
+};
+
+// e.g. an agent assignee (needed by agent-only UI such as dispatch-after)
+await fetch("http://localhost:8080/api/agents", {
+  method: "POST",
+  headers,
+  body: JSON.stringify({ name: "Claude", providers: ["claude"] }),
+});
+
+// e.g. an issue in a specific state
+await fetch("http://localhost:8080/api/issues", {
+  method: "POST",
+  headers,
+  body: JSON.stringify({ title: "Demo", assignee_type: "agent", assignee_id: "..." }),
+});
+```
+
+Reload the page after seeding so the zustand stores pick the data up.
+
+## 4. Drive the UI
+
+- Take an accessibility snapshot first and interact via element refs/roles —
+  do not guess selectors from pixels.
+- Useful entry points:
+  - `Cmd/Ctrl+Shift+O` — open the create-issue modal.
+  - `/issues/<id>` — issue detail page (properties panel pickers).
+- For icon-only buttons, locate by the lucide icon class, e.g.
+  `svg.lucide-timer` then `xpath=ancestor::button[1]`.
+
+## 5. Capture evidence
+
+- **Screenshots**: capture one per meaningful step (before / interaction /
+  after). A sequence of 3–5 screenshots reads like a short recording and is
+  usually enough to demonstrate a flow.
+- **Recording**: the Playwright MCP plugin cannot record video. If a real
+  video is required, write a throwaway spec and run it with video enabled:
+
+```bash
+pnpm exec playwright test e2e/tests/my-demo.spec.ts --headed
+# playwright.config: use: { video: "on" } → video saved under test-results/
+```
+
+- Verify outcomes with both the DOM (text content, disabled states) and the
+  screenshot — a screenshot alone can hide a wrong state.
+
+## 6. Clean up
+
+Delete whatever you created (`DELETE /api/issues/<id>`, archive agents) so
+the shared dev workspace stays clean. Screenshots saved into the repo root
+are untracked artifacts — delete them after use.
+
+## Gotchas
+
+- **Stale JS from the PWA service worker**: in older builds the service
+  worker cached `/_next/` chunks and kept serving outdated code even after
+  container restarts. Dev now auto-unregisters the worker, but if a browser
+  profile still shows old UI, clear it manually:
+
+```js
+for (const r of await navigator.serviceWorker.getRegistrations()) await r.unregister();
+for (const k of await caches.keys()) await caches.delete(k);
+```
+
+- **Verify the served bundle when behavior looks impossible**: fetch the page
+  chunks with `cache: "no-store"` and grep for a symbol you just added. If
+  the symbol is missing the browser is running old code — fix the caching
+  problem before debugging your feature.
+- **Time-dependent UI**: the dev backend runs schedulers on real time (e.g.
+  the issue dispatch scheduler ticks every 60s) — seed timestamps far enough
+  in the future that the state does not flip mid-verification.


### PR DESCRIPTION
## Summary

- Rework the dispatch-after picker into two tabs: a default **"In…"** relative tab (duration presets that fill a custom amount/unit input) and an **"At time"** absolute tab (calendar + time input). Both stage a pending value and only commit on **Set**.
- Reopening the picker with an existing value lands on the **At time** tab, since the stored value is an absolute timestamp that cannot be mapped back to a relative duration.
- Past times can no longer be selected: past calendar days are disabled and **Set** stays disabled until the pending time is in the future.
- The default trigger now appends a minute-precision relative time after the absolute one, e.g. `Jun 10, 09:56 PM (in 3h 25m)` — computed at render, no live refresh.
- Fix: in dev, the PWA service worker cached `/_next/` chunks and kept serving stale code across rebuilds. The worker is now only registered in production; dev unregisters any previously installed worker and drops its caches.
- Docs: add `docs/ui-verification-playwright.md` — how to verify a single UI feature with Playwright screenshots against `make dev` — plus a short section in CLAUDE.md/AGENTS.md.

## Test plan

- [x] `make test` — typecheck, 207 TS tests, Go tests, 20 E2E tests all pass
- [x] Verified in the dev environment via browser: preset fills inputs without committing, Set commits and closes, reopen lands on the correct tab, past days/times are not selectable, stale SW gets unregistered on load

Made with [Cursor](https://cursor.com)