### PR TITLE
fix(web): preserve schedule trigger content when editing a routine

### DIFF
--- a/apps/web/app/(dashboard)/routines/page.test.tsx
+++ b/apps/web/app/(dashboard)/routines/page.test.tsx
@@ -930,6 +930,155 @@ describe("RoutinesPage", () => {
     expect(screen.getByText("sk-new-token-full")).toBeInTheDocument();
   });
 
+  it("preserves a recurring schedule trigger when editing without changes", async () => {
+    const user = userEvent.setup();
+    mocks.searchParams = new URLSearchParams("new=1&id=routine-1");
+    mocks.api.getRoutine.mockResolvedValue({
+      id: "routine-1",
+      workspace_id: "ws-1",
+      name: "Daily review",
+      instructions: "Review the code every day",
+      priority: "medium",
+      assignee_id: "agent-1",
+      assignee_type: "agent",
+      triggers: [
+        {
+          id: "trigger-1",
+          trigger_type: "schedule",
+          schedule: "30 18 * * *",
+          timezone: "America/New_York",
+          dedup_window_seconds: 120,
+          max_runs: 5,
+          config: { mode: "daily" },
+        },
+      ],
+      actions: [],
+      subscriber_ids: [],
+      label_ids: [],
+      enabled: true,
+    });
+
+    render(<RoutinesPage />);
+
+    expect(await screen.findByRole("heading", { name: "Edit routine" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Runs daily at 18:30/ })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Update routine/i }));
+
+    await waitFor(() => {
+      expect(mocks.api.updateRoutine).toHaveBeenCalledWith(
+        "routine-1",
+        expect.objectContaining({
+          triggers: [
+            expect.objectContaining({
+              id: "trigger-1",
+              trigger_type: "schedule",
+              schedule: "30 18 * * *",
+              timezone: "America/New_York",
+              dedup_window_seconds: 120,
+              max_runs: 5,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it("preserves a once schedule trigger run_at when editing without changes", async () => {
+    const user = userEvent.setup();
+    mocks.searchParams = new URLSearchParams("new=1&id=routine-1");
+    mocks.api.getRoutine.mockResolvedValue({
+      id: "routine-1",
+      workspace_id: "ws-1",
+      name: "One-off task",
+      instructions: "Run once",
+      priority: "medium",
+      assignee_id: "agent-1",
+      assignee_type: "agent",
+      triggers: [
+        {
+          id: "trigger-1",
+          trigger_type: "schedule",
+          run_at: "2026-07-01T02:30:00Z",
+          timezone: "UTC",
+          dedup_window_seconds: 600,
+          config: { mode: "once" },
+        },
+      ],
+      actions: [],
+      subscriber_ids: [],
+      label_ids: [],
+      enabled: true,
+    });
+
+    render(<RoutinesPage />);
+
+    expect(await screen.findByRole("heading", { name: "Edit routine" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Update routine/i }));
+
+    await waitFor(() => {
+      expect(mocks.api.updateRoutine).toHaveBeenCalledWith(
+        "routine-1",
+        expect.objectContaining({
+          triggers: [
+            expect.objectContaining({
+              trigger_type: "schedule",
+              run_at: "2026-07-01T02:30:00.000Z",
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it("falls back to custom mode for crons the editor cannot decompose", async () => {
+    const user = userEvent.setup();
+    mocks.searchParams = new URLSearchParams("new=1&id=routine-1");
+    mocks.api.getRoutine.mockResolvedValue({
+      id: "routine-1",
+      workspace_id: "ws-1",
+      name: "Quarter-hourly check",
+      instructions: "Check often",
+      priority: "medium",
+      assignee_id: "agent-1",
+      assignee_type: "agent",
+      triggers: [
+        {
+          id: "trigger-1",
+          trigger_type: "schedule",
+          schedule: "*/15 2 * * *",
+          timezone: "UTC",
+          dedup_window_seconds: 600,
+          config: { mode: "daily" },
+        },
+      ],
+      actions: [],
+      subscriber_ids: [],
+      label_ids: [],
+      enabled: true,
+    });
+
+    render(<RoutinesPage />);
+
+    expect(await screen.findByRole("heading", { name: "Edit routine" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Runs on cron \*\/15 2 \* \* \*/ })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Update routine/i }));
+
+    await waitFor(() => {
+      expect(mocks.api.updateRoutine).toHaveBeenCalledWith(
+        "routine-1",
+        expect.objectContaining({
+          triggers: [
+            expect.objectContaining({
+              trigger_type: "schedule",
+              schedule: "*/15 2 * * *",
+              config: { mode: "custom" },
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
   it("loads an existing routine in edit mode and updates it", async () => {
     const user = userEvent.setup();
     mocks.searchParams = new URLSearchParams("new=1&id=routine-1");

--- a/apps/web/app/(dashboard)/routines/page.tsx
+++ b/apps/web/app/(dashboard)/routines/page.tsx
@@ -114,6 +114,9 @@ interface RoutineTriggerDraft {
   githubEventValue: string;
   githubFilters: GitHubFilterCondition[];
   apiCredential: ApiTriggerCredential | null;
+  timezone?: string;
+  dedupWindowSeconds?: number;
+  maxRuns?: number | null;
 }
 
 interface TriggerOption {
@@ -1557,15 +1560,12 @@ function createRoutineTriggerDraft(type: TriggerType): RoutineTriggerDraft {
 function routineTriggerToDraft(trigger: Routine["triggers"][number]): RoutineTriggerDraft {
   const draft = createRoutineTriggerDraft(trigger.trigger_type as TriggerType);
   draft.id = trigger.id;
+  draft.timezone = trigger.timezone;
+  draft.dedupWindowSeconds = trigger.dedup_window_seconds;
+  draft.maxRuns = trigger.max_runs ?? null;
 
   if (trigger.trigger_type === "schedule") {
-    const mode = getScheduleMode(trigger.config?.mode);
-    draft.schedule = {
-      ...draft.schedule,
-      mode: mode ?? (trigger.run_at ? "once" : "custom"),
-      runAt: trigger.run_at ?? draft.schedule.runAt,
-      cronExpression: trigger.schedule ?? draft.schedule.cronExpression,
-    };
+    draft.schedule = scheduleTriggerToConfig(trigger);
   }
 
   if (trigger.trigger_type === "github") {
@@ -1601,6 +1601,57 @@ function createDefaultScheduleConfig(): ScheduleTriggerConfig {
 
 function getScheduleMode(value: unknown): ScheduleMode | null {
   return scheduleModes.some((mode) => mode.value === value) ? (value as ScheduleMode) : null;
+}
+
+// Inverse of buildRoutineTrigger for schedule triggers: rebuild the form fields
+// from the persisted run_at / cron so editing does not reset them to defaults.
+function scheduleTriggerToConfig(trigger: Routine["triggers"][number]): ScheduleTriggerConfig {
+  const config = createDefaultScheduleConfig();
+  if (trigger.run_at) {
+    const runAt = new Date(trigger.run_at);
+    return {
+      ...config,
+      mode: "once",
+      runAt: Number.isNaN(runAt.getTime()) ? config.runAt : formatLocalDateTime(runAt),
+    };
+  }
+  const cron = trigger.schedule?.trim() ?? "";
+  if (!cron) return config;
+  const parsed = parseCronSchedule(cron);
+  if (!parsed) {
+    return { ...config, mode: "custom", cronExpression: cron };
+  }
+  const mode = getScheduleMode(trigger.config?.mode) === "custom" ? "custom" : parsed.mode;
+  return { ...config, ...parsed, mode, cronExpression: cron };
+}
+
+// Inverse of scheduleToCron: recognizes the cron shapes that the editor
+// generates. Anything else is edited as a custom cron expression.
+function parseCronSchedule(
+  cron: string,
+): (Partial<ScheduleTriggerConfig> & { mode: Exclude<ScheduleMode, "once" | "custom"> }) | null {
+  const parts = cron.split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [minute = "", hour = "", dayOfMonth = "", month = "", dayOfWeek = ""] = parts;
+  if (!/^\d+$/.test(minute) || dayOfMonth !== "*" || month !== "*") return null;
+  if (hour === "*") {
+    return dayOfWeek === "*" ? { mode: "hourly", hourlyMinute: minute } : null;
+  }
+  if (!/^\d+$/.test(hour)) return null;
+  const timeOfDay = `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
+  if (dayOfWeek === "*") return { mode: "daily", timeOfDay };
+  if (dayOfWeek === "1-5") return { mode: "weekdays", timeOfDay };
+  if (/^[0-7]$/.test(dayOfWeek)) {
+    // weekDays is Monday-first; cron uses 0 or 7 for Sunday.
+    const index = dayOfWeek === "0" || dayOfWeek === "7" ? 6 : Number(dayOfWeek) - 1;
+    return { mode: "weekly", timeOfDay, weeklyDay: weekDays[index]! };
+  }
+  return null;
+}
+
+function formatLocalDateTime(date: Date) {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())}, ${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
 function getTriggerOption(type: TriggerType) {
@@ -1964,14 +2015,19 @@ function buildRoutinePayload({
 }
 
 function buildRoutineTrigger(triggerDraft: RoutineTriggerDraft): RoutineTriggerRequest {
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  const preserved: Pick<RoutineTriggerRequest, "dedup_window_seconds" | "max_runs"> = {
+    dedup_window_seconds: triggerDraft.dedupWindowSeconds,
+    max_runs: triggerDraft.maxRuns,
+  };
   if (triggerDraft.type === "schedule") {
     const trigger: RoutineTriggerRequest = {
       id: triggerDraft.id,
       trigger_type: "schedule",
-      timezone,
+      timezone: triggerDraft.timezone ?? browserTimezone,
       config: { mode: triggerDraft.schedule.mode },
       enabled: true,
+      ...preserved,
     };
     if (triggerDraft.schedule.mode === "once") {
       trigger.run_at = parseLocalDateTime(triggerDraft.schedule.runAt)?.toISOString() ?? null;
@@ -2001,6 +2057,7 @@ function buildRoutineTrigger(triggerDraft: RoutineTriggerDraft): RoutineTriggerR
       trigger_type: "github",
       config,
       enabled: true,
+      ...preserved,
     };
   }
   return {
@@ -2010,6 +2067,7 @@ function buildRoutineTrigger(triggerDraft: RoutineTriggerDraft): RoutineTriggerR
     token_draft_id: triggerDraft.apiCredential?.tokenDraftId,
     config: {},
     enabled: true,
+    ...preserved,
   };
 }
 


### PR DESCRIPTION
## Summary

Editing a routine silently destroyed schedule trigger content. The edit form is a round-trip (server data → form drafts → save payload), but the load side was not the inverse of the save side:

- **Recurring schedules**: `routineTriggerToDraft` restored only `mode` and the raw cron, never the mode-specific fields (`timeOfDay`, `hourlyMinute`, `weeklyDay`). On save, `scheduleToCron` rebuilds the cron from those fields for non-custom modes — so e.g. a daily `30 18 * * *` schedule displayed as "Runs daily at 09:00" and was overwritten with the default time on update.
- **Once schedules**: the server returns `run_at` as RFC3339, but `parseLocalDateTime` only accepts `YYYY/MM/DD, HH:MM`, so saving wiped `run_at` to `null`, leaving the trigger with neither a cron nor a run time.
- **Trigger settings**: `timezone` was overwritten with the browser timezone, and `dedup_window_seconds` / `max_runs` were never sent, resetting to server defaults on every edit.

### Fix

- Add `scheduleTriggerToConfig` + `parseCronSchedule` as the true inverse of `scheduleToCron`: recognized cron shapes are decomposed back into editor fields; unrecognized crons fall back to custom mode with the raw expression preserved.
- Format `run_at` into the local datetime format the form expects (`formatLocalDateTime`).
- Carry `timezone`, `dedup_window_seconds`, and `max_runs` through the draft so edits no longer reset them.

## Test plan

- [x] New regression tests: recurring (daily) round-trip preserves cron/timezone/dedup/max_runs; once round-trip preserves `run_at`; unrecognized cron falls back to custom mode and keeps the expression
- [x] `make test` (typecheck + Vitest + Go + E2E) passes

Made with [Cursor](https://cursor.com)