### PR TITLE
fix(web): navigate to parent issue on click instead of opening picker

### DIFF
--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   MoreHorizontal,
   PanelRight,
+  Pencil,
   Plus,
   Trash2,
   UserMinus,
@@ -399,6 +400,7 @@ function ParentIssuePicker({
   onUpdate: (parentId: string | null) => void;
 }) {
   const allIssues = useIssueStore((s) => s.issues);
+  const workspaceSlug = useWorkspaceStore((s) => s.workspace?.slug ?? "");
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
 
@@ -410,16 +412,27 @@ function ParentIssuePicker({
 
   return (
     <Popover open={open} onOpenChange={(v) => { setOpen(v); if (!v) setFilter(""); }}>
-      <PopoverTrigger className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden min-w-0 max-w-full">
-        {parentIssue ? (
-          <>
+      {parentIssue ? (
+        <div className="group flex items-center gap-1 overflow-hidden min-w-0 max-w-full">
+          <Link
+            href={issueUrl(parentIssue.id, workspaceSlug)}
+            className="flex items-center gap-1.5 rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden min-w-0"
+          >
             <StatusIcon status={parentIssue.status} className="h-3 w-3 shrink-0" />
             <span className="truncate text-xs">{parentIssue.identifier} {parentIssue.title}</span>
-          </>
-        ) : (
+          </Link>
+          <PopoverTrigger
+            className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent/30 transition-all"
+            aria-label="Change parent issue"
+          >
+            <Pencil className="h-3 w-3" />
+          </PopoverTrigger>
+        </div>
+      ) : (
+        <PopoverTrigger className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden min-w-0 max-w-full">
           <span className="text-muted-foreground text-xs">None</span>
-        )}
-      </PopoverTrigger>
+        </PopoverTrigger>
+      )}
       <PopoverContent align="start" className="w-64 p-0">
         <div className="px-2 py-1.5 border-b">
           <input


### PR DESCRIPTION
## Summary

- Clicking the **Parent** row in the issue properties panel previously opened the change/remove-parent picker; it now navigates to the parent issue's detail page.
- Changing or removing the parent is still available via a small pencil icon that appears on hover next to the parent link.
- When no parent is set, clicking "None" still opens the picker to set one (unchanged).

## Test plan

- [ ] Open an issue with a parent → click the parent in the Properties panel → navigates to the parent issue.
- [ ] Hover the Parent row → pencil icon appears → click it → picker opens, can change or remove parent.
- [ ] Open an issue without a parent → click "None" → picker opens to set a parent.

Made with [Cursor](https://cursor.com)