### PR TITLE
feat: per-provider agent model selection, daemon auto-update, and production-grade agent backends

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import type {
   Agent,
+  AgentModelConfig,
   AgentStatus,
   AgentVisibility,
   AgentTool,
@@ -78,7 +79,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore } from "@/features/workspace";
 import { useIssueStore } from "@/features/issues";
-import { useRuntimeStore } from "@/features/runtimes";
+import { ModelPicker, useRuntimeStore } from "@/features/runtimes";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import { useFileUpload } from "@/shared/hooks/use-file-upload";
 import { cn } from "@/lib/utils";
@@ -133,17 +134,27 @@ function CreateAgentDialog({
   const [description, setDescription] = useState("");
   const [selectedProviders, setSelectedProviders] = useState<string[]>([SUPPORTED_PROVIDERS[0].key]);
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
+  const [modelConfig, setModelConfig] = useState<Record<string, AgentModelConfig>>({});
   const [creating, setCreating] = useState(false);
 
   const handleSubmit = async () => {
     if (!name.trim() || selectedProviders.length === 0) return;
     setCreating(true);
     try {
+      // Only include model selections for providers that are still selected.
+      const effectiveModelConfig: Record<string, AgentModelConfig> = {};
+      for (const provider of selectedProviders) {
+        const cfg = modelConfig[provider];
+        if (cfg && (cfg.model || cfg.thinking_level)) {
+          effectiveModelConfig[provider] = cfg;
+        }
+      }
       await onCreate({
         name: name.trim(),
         description: description.trim(),
         providers: selectedProviders,
         visibility,
+        model_config: effectiveModelConfig,
         triggers: [
           { id: generateId(), type: "on_assign", enabled: true, config: {} },
           { id: generateId(), type: "on_comment", enabled: true, config: {} },
@@ -221,6 +232,28 @@ function CreateAgentDialog({
             <p className="mt-1.5 text-xs text-muted-foreground">
               Select one or more providers. Tasks will be dispatched to any online environment.
             </p>
+          </div>
+
+          <div>
+            <Label className="text-xs text-muted-foreground">Model</Label>
+            <p className="text-xs text-muted-foreground mt-0.5 mb-1.5">
+              Defaults to the latest model per provider; you can change it later in Settings.
+            </p>
+            <div className="mt-1.5 space-y-2">
+              {selectedProviders.map((provider) => (
+                <div key={provider} className="flex items-center gap-3">
+                  <span className="w-24 shrink-0 text-sm font-medium capitalize">{provider}</span>
+                  <ModelPicker
+                    provider={provider}
+                    value={modelConfig[provider] ?? {}}
+                    autoSelectDefault
+                    onChange={(cfg) =>
+                      setModelConfig((prev) => ({ ...prev, [provider]: cfg }))
+                    }
+                  />
+                </div>
+              ))}
+            </div>
           </div>
 
           <div>
@@ -1294,6 +1327,7 @@ function SettingsTab({
   const [defaultProvider, setDefaultProvider] = useState<string | null>(agent.default_provider ?? null);
   const [defaultDaemonId, setDefaultDaemonId] = useState<string | null>(agent.default_daemon_id ?? null);
   const [maxConcurrentTasks, setMaxConcurrentTasks] = useState<string>(String(agent.max_concurrent_tasks ?? 6));
+  const [modelConfig, setModelConfig] = useState<Record<string, AgentModelConfig>>(agent.model_config ?? {});
   const [saving, setSaving] = useState(false);
   const { upload, uploading } = useFileUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1328,7 +1362,8 @@ function SettingsTab({
     JSON.stringify(providers) !== JSON.stringify(agent.providers ?? []) ||
     defaultProvider !== (agent.default_provider ?? null) ||
     defaultDaemonId !== (agent.default_daemon_id ?? null) ||
-    parsedMaxConcurrentTasks !== (agent.max_concurrent_tasks ?? 6);
+    parsedMaxConcurrentTasks !== (agent.max_concurrent_tasks ?? 6) ||
+    JSON.stringify(modelConfig) !== JSON.stringify(agent.model_config ?? {});
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -1341,7 +1376,7 @@ function SettingsTab({
     }
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), description, visibility, providers, github_code_access: codeAccess as Agent["github_code_access"], default_provider: defaultProvider, default_daemon_id: defaultDaemonId, max_concurrent_tasks: parsedMaxConcurrentTasks });
+      await onSave({ name: name.trim(), description, visibility, providers, github_code_access: codeAccess as Agent["github_code_access"], default_provider: defaultProvider, default_daemon_id: defaultDaemonId, max_concurrent_tasks: parsedMaxConcurrentTasks, model_config: modelConfig });
       toast.success("Settings saved");
     } catch {
       toast.error("Failed to save settings");
@@ -1502,6 +1537,35 @@ function SettingsTab({
         <p className="mt-1.5 text-xs text-muted-foreground">
           Select one or more. Tasks will be dispatched to any online environment with a matching provider.
         </p>
+      </div>
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Models</Label>
+        <p className="text-xs text-muted-foreground mt-0.5 mb-1.5">
+          Model used per provider. &ldquo;Default&rdquo; lets each CLI pick its own default model.
+        </p>
+        <div className="mt-1.5 space-y-2">
+          {providers.map((provider) => (
+            <div key={provider} className="flex items-center gap-3">
+              <span className="w-24 shrink-0 text-sm font-medium capitalize">{provider}</span>
+              <ModelPicker
+                provider={provider}
+                value={modelConfig[provider] ?? {}}
+                onChange={(cfg) =>
+                  setModelConfig((prev) => {
+                    const next = { ...prev };
+                    if (!cfg.model && !cfg.thinking_level) {
+                      delete next[provider];
+                    } else {
+                      next[provider] = cfg;
+                    }
+                    return next;
+                  })
+                }
+              />
+            </div>
+          ))}
+        </div>
       </div>
 
       <div>

--- a/apps/web/features/issues/components/pickers/agent-dispatch-confirm.test.tsx
+++ b/apps/web/features/issues/components/pickers/agent-dispatch-confirm.test.tsx
@@ -24,6 +24,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     github_code_access: "write",
     default_daemon_id: null,
     max_concurrent_tasks: 1,
+    model_config: {},
     created_at: "",
     updated_at: "",
     archived_at: null,

--- a/apps/web/features/issues/components/pickers/assignee-picker.test.tsx
+++ b/apps/web/features/issues/components/pickers/assignee-picker.test.tsx
@@ -52,6 +52,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     github_code_access: "write",
     default_daemon_id: null,
     max_concurrent_tasks: 1,
+    model_config: {},
     created_at: "",
     updated_at: "",
     archived_at: null,

--- a/apps/web/features/issues/utils/dispatch.test.ts
+++ b/apps/web/features/issues/utils/dispatch.test.ts
@@ -21,6 +21,7 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     github_code_access: "read",
     default_daemon_id: null,
     max_concurrent_tasks: 1,
+    model_config: {},
     created_at: "",
     updated_at: "",
     archived_at: null,

--- a/apps/web/features/runtimes/components/index.ts
+++ b/apps/web/features/runtimes/components/index.ts
@@ -1,1 +1,2 @@
 export { default as RuntimesPage } from "./runtimes-page";
+export { ModelPicker, useRuntimeModels } from "./model-picker";

--- a/apps/web/features/runtimes/components/model-picker.tsx
+++ b/apps/web/features/runtimes/components/model-picker.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Loader2, Sparkles } from "lucide-react";
+
+import { api } from "@/shared/api";
+import type {
+  AgentModelConfig,
+  AgentRuntime,
+  ModelListRequest,
+  RuntimeModel,
+} from "@/shared/types";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Input } from "@/components/ui/input";
+import { useRuntimeStore } from "../store";
+
+// ---------------------------------------------------------------------------
+// Discovery (initiate + poll, module-level cache)
+// ---------------------------------------------------------------------------
+
+const POLL_INTERVAL_MS = 500;
+const POLL_TIMEOUT_MS = 30_000;
+const CACHE_TTL_MS = 60_000;
+
+const discoveryCache = new Map<string, { result: ModelListRequest; at: number }>();
+const inflight = new Map<string, Promise<ModelListRequest>>();
+
+function isTerminal(status: ModelListRequest["status"]): boolean {
+  return status === "completed" || status === "failed" || status === "timeout";
+}
+
+async function discoverModels(runtimeId: string): Promise<ModelListRequest> {
+  const cached = discoveryCache.get(runtimeId);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.result;
+  }
+  const running = inflight.get(runtimeId);
+  if (running) return running;
+
+  const promise = (async () => {
+    const req = await api.initiateListModels(runtimeId);
+    let current = req;
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    while (!isTerminal(current.status) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      current = await api.getModelListResult(runtimeId, req.id);
+    }
+    if (current.status === "completed") {
+      discoveryCache.set(runtimeId, { result: current, at: Date.now() });
+    }
+    return current;
+  })();
+
+  inflight.set(runtimeId, promise);
+  try {
+    return await promise;
+  } finally {
+    inflight.delete(runtimeId);
+  }
+}
+
+/** Picks the discovery target: the most recently seen online runtime for a provider. */
+function pickRuntime(runtimes: AgentRuntime[], provider: string): AgentRuntime | null {
+  const candidates = runtimes.filter(
+    (r) => r.provider === provider && r.status === "online",
+  );
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, r) =>
+    (r.last_seen_at ?? "") > (best.last_seen_at ?? "") ? r : best,
+  );
+}
+
+interface ModelsState {
+  loading: boolean;
+  models: RuntimeModel[];
+  supported: boolean;
+  error: string | null;
+}
+
+/**
+ * useRuntimeModels discovers the model catalog for a provider by asking an
+ * online runtime of that provider (via the server's pending-request flow).
+ */
+export function useRuntimeModels(provider: string): ModelsState & { runtimeOnline: boolean } {
+  const runtimes = useRuntimeStore((s) => s.runtimes);
+  const fetching = useRuntimeStore((s) => s.fetching);
+  const fetchAll = useRuntimeStore((s) => s.fetchAll);
+
+  // Hydrate the runtimes store if nothing loaded it yet (e.g. the picker is
+  // rendered inside the create-agent dialog before visiting the runtimes page).
+  useEffect(() => {
+    if (fetching && runtimes.length === 0) {
+      void fetchAll();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const runtime = useMemo(() => pickRuntime(runtimes, provider), [runtimes, provider]);
+  const runtimeId = runtime?.id ?? null;
+
+  const [state, setState] = useState<ModelsState>({
+    loading: false,
+    models: [],
+    supported: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!runtimeId) {
+      setState({ loading: false, models: [], supported: true, error: null });
+      return;
+    }
+    let alive = true;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    discoverModels(runtimeId)
+      .then((result) => {
+        if (!alive) return;
+        if (result.status === "completed") {
+          setState({
+            loading: false,
+            models: result.models ?? [],
+            supported: result.supported,
+            error: null,
+          });
+        } else {
+          setState({
+            loading: false,
+            models: [],
+            supported: true,
+            error: result.error || "model discovery failed",
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        if (!alive) return;
+        setState({
+          loading: false,
+          models: [],
+          supported: true,
+          error: err instanceof Error ? err.message : "model discovery failed",
+        });
+      });
+    return () => {
+      alive = false;
+    };
+  }, [runtimeId]);
+
+  return { ...state, runtimeOnline: runtimeId != null };
+}
+
+// ---------------------------------------------------------------------------
+// ModelPicker
+// ---------------------------------------------------------------------------
+
+export function ModelPicker({
+  provider,
+  value,
+  onChange,
+  autoSelectDefault = false,
+}: {
+  provider: string;
+  /** Current selection for this provider; empty object = runtime defaults. */
+  value: AgentModelConfig;
+  onChange: (next: AgentModelConfig) => void;
+  /**
+   * When true and no model is set yet, the catalog's default (latest) model
+   * is auto-selected once discovery completes. Used on agent creation so new
+   * agents pick up the latest model out of the box.
+   */
+  autoSelectDefault?: boolean;
+}) {
+  const { loading, models, supported, error, runtimeOnline } = useRuntimeModels(provider);
+  const autoSelected = useRef(false);
+
+  const selectedModel = value.model ?? "";
+  const selectedEntry = models.find((m) => m.id === selectedModel);
+  const defaultEntry = models.find((m) => m.default);
+
+  // Auto-select the catalog default (latest flagship) on creation flows.
+  useEffect(() => {
+    if (!autoSelectDefault || autoSelected.current) return;
+    if (selectedModel !== "" || !defaultEntry) return;
+    autoSelected.current = true;
+    onChange({ ...value, model: defaultEntry.id });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoSelectDefault, defaultEntry?.id, selectedModel]);
+
+  const selectModel = (modelId: string) => {
+    const next: AgentModelConfig = { ...value, model: modelId || undefined };
+    // Keep thinking_level only when the new model still supports it.
+    if (next.thinking_level) {
+      const entry = models.find((m) => m.id === modelId);
+      const levels = entry?.thinking?.supported_levels ?? [];
+      if (modelId !== "" && entry && !levels.some((l) => l.value === next.thinking_level)) {
+        next.thinking_level = undefined;
+      }
+    }
+    onChange(next);
+  };
+
+  if (!supported) {
+    return (
+      <div className="text-xs italic text-muted-foreground py-1.5">
+        Model is managed by the runtime
+      </div>
+    );
+  }
+
+  // No discovered catalog (offline runtime or failed discovery): fall back
+  // to manual entry so power users can still pin a model ID.
+  const manualEntry = !loading && models.length === 0;
+
+  const thinkingLevels = selectedEntry?.thinking?.supported_levels
+    ?? (selectedModel === "" ? defaultEntry?.thinking?.supported_levels : undefined)
+    ?? [];
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-sm text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <span>Discovering models…</span>
+        </div>
+      ) : manualEntry ? (
+        <div className="flex flex-col gap-1">
+          <Input
+            value={selectedModel}
+            onChange={(e) => selectModel(e.target.value.trim())}
+            placeholder="Model ID (optional — empty = default)"
+            className="h-8 w-64 text-sm"
+          />
+          <span className="text-xs text-muted-foreground">
+            {runtimeOnline
+              ? error
+                ? `Model discovery failed: ${error}`
+                : "No models discovered — enter a model ID manually"
+              : "No online runtime for this provider — enter a model ID manually"}
+          </span>
+        </div>
+      ) : (
+        <Popover>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                className="flex items-center gap-2 rounded-lg border px-3 py-2 text-sm hover:bg-muted transition-colors"
+              >
+                <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="font-medium">
+                  {selectedEntry?.label ?? (selectedModel || "Default")}
+                </span>
+                {selectedModel === "" && defaultEntry && (
+                  <span className="text-xs text-muted-foreground">({defaultEntry.label})</span>
+                )}
+                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+            }
+          />
+          <PopoverContent align="start" className="max-h-72 w-72 overflow-y-auto p-1">
+            <button
+              type="button"
+              onClick={() => selectModel("")}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+            >
+              <span className="flex-1 text-left">Default</span>
+              {selectedModel === "" && <Check className="h-3.5 w-3.5 text-muted-foreground" />}
+            </button>
+            {models.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => selectModel(m.id)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+              >
+                <span className="flex-1 truncate text-left">{m.label}</span>
+                {m.default && (
+                  <span className="rounded bg-primary/10 px-1 py-0.5 text-[10px] text-primary">
+                    latest
+                  </span>
+                )}
+                {m.id === selectedModel && <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {thinkingLevels.length > 0 && (
+        <Popover>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
+              >
+                <span>
+                  Thinking:{" "}
+                  <span className="font-medium text-foreground">
+                    {thinkingLevels.find((l) => l.value === value.thinking_level)?.label ?? "Default"}
+                  </span>
+                </span>
+                <ChevronDown className="h-3.5 w-3.5" />
+              </button>
+            }
+          />
+          <PopoverContent align="start" className="w-56 p-1">
+            <button
+              type="button"
+              onClick={() => onChange({ ...value, thinking_level: undefined })}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+            >
+              <span className="flex-1 text-left">Default</span>
+              {!value.thinking_level && <Check className="h-3.5 w-3.5 text-muted-foreground" />}
+            </button>
+            {thinkingLevels.map((l) => (
+              <button
+                key={l.value}
+                type="button"
+                onClick={() => onChange({ ...value, thinking_level: l.value })}
+                className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+              >
+                <span className="flex-1 text-left">
+                  <span className="block">{l.label}</span>
+                  {l.description && (
+                    <span className="block text-xs text-muted-foreground">{l.description}</span>
+                  )}
+                </span>
+                {l.value === value.thinking_level && (
+                  <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                )}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/apps/web/features/runtimes/index.ts
+++ b/apps/web/features/runtimes/index.ts
@@ -1,2 +1,2 @@
-export { RuntimesPage } from "./components";
+export { RuntimesPage, ModelPicker, useRuntimeModels } from "./components";
 export { useRuntimeStore } from "./store";

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -41,6 +41,7 @@ import type {
   RuntimeHourlyActivity,
   RuntimePing,
   RuntimeUpdate,
+  ModelListRequest,
   TimelineEntry,
   TaskMessagePayload,
   Attachment,
@@ -596,6 +597,17 @@ export class ApiClient {
     updateId: string,
   ): Promise<RuntimeUpdate> {
     return this.fetch(`/api/runtimes/${runtimeId}/update/${updateId}`);
+  }
+
+  async initiateListModels(runtimeId: string): Promise<ModelListRequest> {
+    return this.fetch(`/api/runtimes/${runtimeId}/models`, { method: "POST" });
+  }
+
+  async getModelListResult(
+    runtimeId: string,
+    requestId: string,
+  ): Promise<ModelListRequest> {
+    return this.fetch(`/api/runtimes/${runtimeId}/models/${requestId}`);
   }
 
   async listAgentTasks(agentId: string): Promise<AgentTask[]> {

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -95,6 +95,16 @@ export interface AgentTask {
   result_comment_id?: string | null;
 }
 
+/**
+ * Per-provider model selection. Empty/missing model means "use the provider
+ * CLI's own default"; empty/missing thinking_level means "use the
+ * runtime/model default".
+ */
+export interface AgentModelConfig {
+  model?: string;
+  thinking_level?: string;
+}
+
 export interface Agent {
   id: string;
   workspace_id: string;
@@ -113,6 +123,7 @@ export interface Agent {
   github_code_access: GitHubCodeAccess;
   default_daemon_id: string | null;
   max_concurrent_tasks: number;
+  model_config: Record<string, AgentModelConfig>;
   created_at: string;
   updated_at: string;
   archived_at: string | null;
@@ -132,6 +143,7 @@ export interface CreateAgentRequest {
   github_code_access?: GitHubCodeAccess;
   default_daemon_id?: string | null;
   max_concurrent_tasks?: number;
+  model_config?: Record<string, AgentModelConfig>;
 }
 
 export interface UpdateAgentRequest {
@@ -148,6 +160,7 @@ export interface UpdateAgentRequest {
   github_code_access?: GitHubCodeAccess;
   default_daemon_id?: string | null;
   max_concurrent_tasks?: number;
+  model_config?: Record<string, AgentModelConfig>;
 }
 
 // Skills
@@ -236,6 +249,43 @@ export interface RuntimeUpdate {
   status: RuntimeUpdateStatus;
   target_version: string;
   output?: string;
+  error?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// Runtime model discovery
+
+export type ModelListStatus = "pending" | "running" | "completed" | "failed" | "timeout";
+
+export interface RuntimeModelThinkingLevel {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface RuntimeModelThinking {
+  supported_levels: RuntimeModelThinkingLevel[];
+  default_level?: string;
+}
+
+export interface RuntimeModel {
+  id: string;
+  label: string;
+  provider?: string;
+  /** The runtime's advertised preferred pick (display hint). */
+  default?: boolean;
+  /** Per-model reasoning/effort catalog; absent = no thinking picker. */
+  thinking?: RuntimeModelThinking;
+}
+
+export interface ModelListRequest {
+  id: string;
+  runtime_id: string;
+  status: ModelListStatus;
+  models?: RuntimeModel[];
+  /** False when the provider ignores per-agent model selection. */
+  supported: boolean;
   error?: string;
   created_at: string;
   updated_at: string;

--- a/apps/web/shared/types/index.ts
+++ b/apps/web/shared/types/index.ts
@@ -1,6 +1,7 @@
 export type { Issue, IssueLink, IssueLinkDirection, IssueLinkKind, IssueStatus, IssuePriority, IssueAssigneeType, IssueCreatorType, IssueReaction, AcceptanceCriterion, CriteriaStatus, Label } from "./issue";
 export type {
   Agent,
+  AgentModelConfig,
   AgentStatus,
   AgentRuntimeMode,
   AgentVisibility,
@@ -28,6 +29,11 @@ export type {
   ProviderAuthStatus,
   DaemonStatus,
   RuntimeStatus,
+  ModelListStatus,
+  ModelListRequest,
+  RuntimeModel,
+  RuntimeModelThinking,
+  RuntimeModelThinkingLevel,
 } from "./agent";
 export type { Workspace, WorkspaceRepo, ProviderConfig, WorkspaceProviderSettings, ProviderValidationResult, ProviderValidationStatus, Member, MemberRole, User, MemberWithUser, UserKind } from "./workspace";
 export type { InboxItem, InboxSeverity, InboxItemType } from "./inbox";

--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -63,6 +63,7 @@ export const mockAgents: Agent[] = [
     github_code_access: "write",
     default_daemon_id: null,
     max_concurrent_tasks: 6,
+    model_config: {},
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     archived_at: null,

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -94,6 +94,8 @@ func init() {
 	f.Duration("heartbeat-interval", 0, "Heartbeat interval (env: MULTICA_DAEMON_HEARTBEAT_INTERVAL)")
 	f.Duration("agent-timeout", 0, "Per-task timeout (env: MULTICA_AGENT_TIMEOUT)")
 	f.Int("max-concurrent-tasks", 0, "Max tasks running in parallel (env: MULTICA_DAEMON_MAX_CONCURRENT_TASKS)")
+	f.Bool("no-auto-update", false, "Disable periodic CLI self-update (env: MULTICA_DAEMON_AUTO_UPDATE=false)")
+	f.Duration("auto-update-interval", 0, "How often to check GitHub for a newer CLI release (env: MULTICA_DAEMON_AUTO_UPDATE_INTERVAL)")
 
 	daemonLogsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	daemonLogsCmd.Flags().IntP("lines", "n", 50, "Number of lines to show")
@@ -310,6 +312,12 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	if n, _ := cmd.Flags().GetInt("max-concurrent-tasks"); n > 0 {
 		args = append(args, "--max-concurrent-tasks", strconv.Itoa(n))
 	}
+	if v, _ := cmd.Flags().GetBool("no-auto-update"); v {
+		args = append(args, "--no-auto-update")
+	}
+	if d, _ := cmd.Flags().GetDuration("auto-update-interval"); d > 0 {
+		args = append(args, "--auto-update-interval", d.String())
+	}
 
 	// Forward global persistent flags.
 	if v, _ := cmd.Flags().GetString("server-url"); v != "" {
@@ -350,6 +358,12 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	}
 	if n, _ := cmd.Flags().GetInt("max-concurrent-tasks"); n > 0 {
 		overrides.MaxConcurrentTasks = n
+	}
+	if v, _ := cmd.Flags().GetBool("no-auto-update"); v {
+		overrides.NoAutoUpdate = true
+	}
+	if d, _ := cmd.Flags().GetDuration("auto-update-interval"); d > 0 {
+		overrides.AutoUpdateInterval = d
 	}
 
 	cfg, err := daemon.LoadConfig(overrides)

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -108,6 +108,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		r.Post("/runtimes/{runtimeId}/usage", h.ReportRuntimeUsage)
 		r.Post("/runtimes/{runtimeId}/ping/{pingId}/result", h.ReportPingResult)
 		r.Post("/runtimes/{runtimeId}/update/{updateId}/result", h.ReportUpdateResult)
+		r.Post("/runtimes/{runtimeId}/models/{requestId}/result", h.ReportModelListResult)
 
 		r.Get("/tasks/{taskId}/status", h.GetTaskStatus)
 		r.Post("/tasks/{taskId}/start", h.StartTask)
@@ -301,6 +302,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 				r.Get("/{runtimeId}/ping/{pingId}", h.GetPing)
 				r.Post("/{runtimeId}/update", h.InitiateUpdate)
 				r.Get("/{runtimeId}/update/{updateId}", h.GetUpdate)
+				r.Post("/{runtimeId}/models", h.InitiateListModels)
+				r.Get("/{runtimeId}/models/{requestId}", h.GetModelListRequest)
 			})
 
 			// Routines

--- a/server/internal/cli/update.go
+++ b/server/internal/cli/update.go
@@ -47,6 +47,67 @@ func FetchLatestRelease() (*GitHubRelease, error) {
 	return &release, nil
 }
 
+// IsReleaseVersion reports whether v looks like a tagged release version
+// (e.g. "0.1.13", "v0.1.13") rather than a dev build (e.g. an empty version
+// or a `git describe`–style "v0.2.15-235-gdaf0e935"). The auto-update poller
+// uses this to skip self-update for source builds, where downgrading to a
+// public release would clobber unreleased changes.
+func IsReleaseVersion(v string) bool {
+	_, ok := parseReleaseVersion(v)
+	return ok
+}
+
+// IsNewerVersion reports whether latest is strictly newer than current. Both
+// arguments may carry an optional "v" prefix. Returns false if either side
+// cannot be parsed — the caller treats that as "stay on current".
+func IsNewerVersion(latest, current string) bool {
+	l, ok := parseReleaseVersion(latest)
+	if !ok {
+		return false
+	}
+	c, ok := parseReleaseVersion(current)
+	if !ok {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if l[i] != c[i] {
+			return l[i] > c[i]
+		}
+	}
+	return false
+}
+
+// parseReleaseVersion extracts the three numeric components of v. Returns
+// (parts, true) on success; (_, false) when v is missing, malformed, or
+// carries any non-numeric component. Strict on purpose: the auto-update loop
+// must never silently downgrade a developer build to a public release just
+// because a dev-describe suffix happened to look numeric after trimming.
+func parseReleaseVersion(v string) ([3]int, bool) {
+	s := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(v), "v"))
+	if s == "" {
+		return [3]int{}, false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, p := range parts {
+		if p == "" {
+			return [3]int{}, false
+		}
+		n := 0
+		for _, r := range p {
+			if r < '0' || r > '9' {
+				return [3]int{}, false
+			}
+			n = n*10 + int(r-'0')
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
 // IsBrewInstall checks whether the running multica binary was installed via Homebrew.
 func IsBrewInstall() bool {
 	exePath, err := os.Executable()
@@ -193,4 +254,3 @@ func extractBinaryFromTarGz(r io.Reader, name string) ([]byte, error) {
 		}
 	}
 }
-

--- a/server/internal/cli/update_test.go
+++ b/server/internal/cli/update_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import "testing"
+
+func TestIsReleaseVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"0.1.13", true},
+		{"v0.1.13", true},
+		{" v0.1.13 ", true},
+		{"", false},
+		{"dev", false},
+		{"v0.2.15-235-gdaf0e935", false},
+		{"v0.2.15-dirty", false},
+		{"0.1", false},
+		{"0.1.13.4", false},
+		{"a.b.c", false},
+	}
+	for _, tt := range tests {
+		if got := IsReleaseVersion(tt.input); got != tt.want {
+			t.Errorf("IsReleaseVersion(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		latest  string
+		current string
+		want    bool
+	}{
+		{"v0.1.14", "v0.1.13", true},
+		{"0.1.14", "v0.1.13", true},
+		{"v0.2.0", "v0.1.99", true},
+		{"v1.0.0", "v0.9.9", true},
+		{"v0.1.13", "v0.1.13", false},
+		{"v0.1.12", "v0.1.13", false},
+		// Unparsable sides fail closed — never upgrade off a dev build.
+		{"v0.1.14", "v0.1.13-235-gdaf0e935", false},
+		{"not-a-version", "v0.1.13", false},
+		{"v0.1.14", "", false},
+	}
+	for _, tt := range tests {
+		if got := IsNewerVersion(tt.latest, tt.current); got != tt.want {
+			t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", tt.latest, tt.current, got, tt.want)
+		}
+	}
+}

--- a/server/internal/daemon/auto_update.go
+++ b/server/internal/daemon/auto_update.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	"github.com/nullne/multica/server/internal/cli"
+)
+
+// Indirections over the real release / version helpers so tests can run the
+// auto-update loop deterministically without reaching out to GitHub or
+// shelling out to brew/curl.
+var (
+	fetchLatestRelease = cli.FetchLatestRelease
+	isReleaseVersion   = cli.IsReleaseVersion
+	isNewerVersion     = cli.IsNewerVersion
+)
+
+// autoUpdateInitialDelay is how long the loop waits after Run() returns before
+// performing its first version check. The daemon has plenty to do at startup
+// (auth, register, sync workspaces, kick off heartbeats); we don't want to add
+// an outbound HTTPS call to GitHub on top of that. The delay is also short
+// enough that a brand-new install with an available update still self-updates
+// within a couple of minutes rather than after the full check interval.
+var autoUpdateInitialDelay = 2 * time.Minute
+
+// autoUpdateLoop periodically polls GitHub for a newer CLI release and, when
+// one is available and the daemon is idle, runs the same brew-or-download
+// upgrade path as the server-triggered update. On success it triggers a
+// graceful restart into the new binary.
+//
+// Disabled when:
+//   - the operator opted out via --no-auto-update / MULTICA_DAEMON_AUTO_UPDATE=false;
+//   - the running version doesn't look like a tagged release (dev builds).
+//
+// Each tick is silent on the happy path of "already on latest" so the log
+// stays uncluttered for users who run the daemon for weeks at a time.
+func (d *Daemon) autoUpdateLoop(ctx context.Context) {
+	if !d.cfg.AutoUpdateEnabled {
+		d.logger.Info("auto-update: disabled")
+		return
+	}
+	if !isReleaseVersion(d.cfg.CLIVersion) {
+		// Source builds (`make daemon`) and ad-hoc builds report a
+		// `git describe`-style version; auto-upgrading them to a public
+		// release would silently downgrade the dev work checked out on the
+		// machine. Skip and let the developer drive their own version.
+		d.logger.Info("auto-update: skipped (not a release build)", "version", d.cfg.CLIVersion)
+		return
+	}
+
+	interval := d.cfg.AutoUpdateCheckInterval
+	if interval <= 0 {
+		interval = DefaultAutoUpdateCheckInterval
+	}
+	d.logger.Info("auto-update: started", "interval", interval, "current", d.cfg.CLIVersion)
+
+	if err := sleepWithContext(ctx, autoUpdateInitialDelay); err != nil {
+		return
+	}
+	d.tryAutoUpdate(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.tryAutoUpdate(ctx)
+		}
+	}
+}
+
+// tryAutoUpdate runs one check-and-maybe-upgrade cycle. Bails early on any of:
+// already updating (server-triggered upgrade in flight), active tasks (defer
+// to next tick — we never interrupt running agents), version fetch failure,
+// or no newer release. The function never returns an error: a check that
+// fails today will be retried at the next tick, and we don't want a transient
+// network blip to escalate to a process-level shutdown.
+func (d *Daemon) tryAutoUpdate(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	// Don't race the server-triggered update path. If a manual update from
+	// the Runtimes page is already in flight, let it finish and re-check next
+	// tick (by which time we'll either be on the new binary or it failed and
+	// we can retry).
+	if d.updating.Load() {
+		d.logger.Debug("auto-update: skip — update already in progress")
+		return
+	}
+	// Cheap pre-fetch idle check: the release-metadata fetch below makes an
+	// HTTPS call to GitHub, and there is no point paying that cost (or the
+	// rate-limit budget) when we already know we are going to defer. A task
+	// that starts between this load and the barrier check below is caught
+	// by the strict re-check under claimMu inside trySetClaimBarrier.
+	if running := d.activeTasks.Load(); running > 0 {
+		d.logger.Debug("auto-update: skip — tasks running", "active", running)
+		return
+	}
+
+	release, err := fetchLatestRelease()
+	if err != nil {
+		d.logger.Warn("auto-update: fetch latest release failed — will retry", "error", err)
+		return
+	}
+	if release == nil || release.TagName == "" {
+		return
+	}
+	if !isNewerVersion(release.TagName, d.cfg.CLIVersion) {
+		return
+	}
+
+	// CAS the updating flag so a concurrent server-triggered handleUpdate
+	// dropped onto a heartbeat tick can't double-fire. Release on every exit
+	// path before triggerRestart — once that lands, the daemon ctx is
+	// cancelled and the flag dies with the process.
+	if !d.updating.CompareAndSwap(false, true) {
+		d.logger.Debug("auto-update: skip — update already in progress (raced)")
+		return
+	}
+	released := false
+	defer func() {
+		if !released {
+			d.updating.Store(false)
+		}
+	}()
+
+	// Strict barrier: between the cheap pre-fetch idle check and now the
+	// release fetch took anywhere from tens of milliseconds (typical) to
+	// seconds (slow link, GitHub hiccup), plenty of time for a poller to
+	// claim a fresh task. trySetClaimBarrier checks claimsInFlight +
+	// activeTasks under claimMu and only flips pauseClaims to true if both
+	// are zero, so once it returns true we can run the upgrade knowing that
+	// no in-flight task will be cancelled by triggerRestart.
+	if !d.trySetClaimBarrier() {
+		d.logger.Info("auto-update: deferring — task or claim in flight at barrier check")
+		return
+	}
+	barrierReleased := false
+	defer func() {
+		if !barrierReleased {
+			d.releaseClaimBarrier()
+		}
+	}()
+
+	d.logger.Info("auto-update: newer release available, upgrading",
+		"current", d.cfg.CLIVersion, "target", release.TagName)
+
+	output, err := d.runUpdateFn(release.TagName)
+	if err != nil {
+		d.logger.Warn("auto-update: upgrade failed — will retry", "error", err, "output", output)
+		return
+	}
+
+	d.logger.Info("auto-update: upgrade completed, restarting", "target", release.TagName, "output", output)
+	// triggerRestart cancels the root context, which causes Run() to return
+	// and the parent (cmd_daemon.go) to re-exec the new binary. Leave both
+	// the updating flag and the claim barrier held — process exit is
+	// imminent and clearing either would open a window for new claims / a
+	// second auto-update tick to fire mid-shutdown.
+	released = true
+	barrierReleased = true
+	d.triggerRestart()
+}

--- a/server/internal/daemon/auto_update_test.go
+++ b/server/internal/daemon/auto_update_test.go
@@ -1,0 +1,258 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nullne/multica/server/internal/cli"
+)
+
+// newAutoUpdateTestDaemon returns a Daemon stripped to just the pieces
+// tryAutoUpdate touches, plus a sentinel cancelFunc the test can assert on to
+// detect that triggerRestart fired. The caller is expected to install its own
+// runUpdateFn before calling tryAutoUpdate when it wants to exercise the
+// upgrade-success path.
+func newAutoUpdateTestDaemon(t *testing.T, currentVersion string) (*Daemon, *atomic.Int32) {
+	t.Helper()
+	var restartCalls atomic.Int32
+	d := &Daemon{
+		cfg:    Config{CLIVersion: currentVersion, AutoUpdateEnabled: true},
+		logger: slog.Default(),
+		cancelFunc: func() {
+			restartCalls.Add(1)
+		},
+	}
+	d.runUpdateFn = func(string) (string, error) {
+		t.Fatalf("runUpdateFn called unexpectedly")
+		return "", nil
+	}
+	return d, &restartCalls
+}
+
+func withStubRelease(t *testing.T, release *cli.GitHubRelease, err error) {
+	t.Helper()
+	prev := fetchLatestRelease
+	fetchLatestRelease = func() (*cli.GitHubRelease, error) { return release, err }
+	t.Cleanup(func() { fetchLatestRelease = prev })
+}
+
+func TestTryAutoUpdate_SkipsWhenUpdating(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	d.updating.Store(true)
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart called while another update was in progress")
+	}
+}
+
+func TestTryAutoUpdate_SkipsWhenTasksRunning(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	d.activeTasks.Store(1)
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart fired with active tasks; auto-update must defer")
+	}
+	if d.updating.Load() {
+		t.Fatalf("updating flag should not have been claimed while tasks were running")
+	}
+}
+
+// TestTryAutoUpdate_DefersWhenClaimInFlightAtBarrier covers the race where
+// the cheap pre-fetch idle check passes (activeTasks == 0), then during the
+// release fetch a poller decides to claim and bumps claimsInFlight.
+// trySetClaimBarrier must observe that and defer rather than proceed into
+// runUpdate (which would lead to a triggerRestart cancelling the
+// just-claimed task mid-run).
+func TestTryAutoUpdate_DefersWhenClaimInFlightAtBarrier(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+
+	d.claimsInFlight = 1 // poller is mid-ClaimTask while activeTasks is still 0
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart fired despite a claim being in flight at the barrier")
+	}
+	if d.updating.Load() {
+		t.Fatalf("updating flag must be released after a deferred upgrade so the next tick can retry")
+	}
+	if d.pauseClaims {
+		t.Fatalf("pauseClaims must be cleared after a deferred upgrade")
+	}
+}
+
+// TestTryAutoUpdate_HoldsBarrierAcrossRestart asserts the success path leaves
+// pauseClaims set: process exit is imminent and clearing the barrier would
+// open a window for a poller to claim a task that the imminent restart is
+// about to cancel.
+func TestTryAutoUpdate_HoldsBarrierAcrossRestart(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+	d.runUpdateFn = func(string) (string, error) { return "upgraded", nil }
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 1 {
+		t.Fatalf("triggerRestart fired %d times, want 1", restartCalls.Load())
+	}
+	if !d.pauseClaims {
+		t.Fatalf("pauseClaims must remain set across the restart kick; got cleared")
+	}
+}
+
+// TestTryAutoUpdate_ReleasesBarrierOnUpgradeFailure asserts the failure path
+// clears pauseClaims so the daemon can keep claiming tasks normally and
+// retry the upgrade on the next tick.
+func TestTryAutoUpdate_ReleasesBarrierOnUpgradeFailure(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+	d.runUpdateFn = func(string) (string, error) {
+		return "brew network error", errors.New("brew upgrade failed")
+	}
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart fired despite upgrade failure")
+	}
+	if d.pauseClaims {
+		t.Fatalf("pauseClaims must be cleared after a failed upgrade so pollers resume claiming")
+	}
+}
+
+// TestTryEnterClaim_RespectsBarrier asserts the poller-side helper returns
+// false while pauseClaims is held and that pairs of enter/exit balance the
+// counter so a later barrier set sees idle.
+func TestTryEnterClaim_RespectsBarrier(t *testing.T) {
+	d := &Daemon{}
+
+	if !d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim should succeed when barrier is unset")
+	}
+	d.exitClaim()
+	if d.claimsInFlight != 0 {
+		t.Fatalf("claimsInFlight not balanced: %d", d.claimsInFlight)
+	}
+
+	if !d.trySetClaimBarrier() {
+		t.Fatal("trySetClaimBarrier should succeed when idle")
+	}
+	if d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must refuse while barrier is held")
+	}
+	d.releaseClaimBarrier()
+	if !d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim should succeed after barrier release")
+	}
+	d.exitClaim()
+}
+
+func TestTryAutoUpdate_SkipsWhenFetchFails(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, nil, errors.New("network down"))
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart fired despite fetch failure")
+	}
+}
+
+func TestTryAutoUpdate_SkipsWhenNotNewer(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.13"}, nil)
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart fired even though latest == current")
+	}
+}
+
+func TestTryAutoUpdate_RunsUpgradeAndRestartsOnNewer(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+
+	var upgradedTo string
+	d.runUpdateFn = func(target string) (string, error) {
+		upgradedTo = target
+		return "upgraded", nil
+	}
+
+	d.tryAutoUpdate(context.Background())
+
+	if upgradedTo != "v0.1.14" {
+		t.Fatalf("runUpdateFn called with %q, want v0.1.14", upgradedTo)
+	}
+	if restartCalls.Load() != 1 {
+		t.Fatalf("triggerRestart fired %d times, want 1", restartCalls.Load())
+	}
+	if !d.updating.Load() {
+		t.Fatalf("updating flag should remain set across the restart kick; got cleared")
+	}
+}
+
+func TestTryAutoUpdate_DoesNotRestartOnUpgradeFailure(t *testing.T) {
+	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
+	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+
+	d.runUpdateFn = func(string) (string, error) {
+		return "brew: network error", errors.New("brew upgrade failed")
+	}
+
+	d.tryAutoUpdate(context.Background())
+
+	if restartCalls.Load() != 0 {
+		t.Fatalf("triggerRestart fired despite upgrade failure")
+	}
+	if d.updating.Load() {
+		t.Fatalf("updating flag must be released after a failed upgrade so the next tick can retry")
+	}
+}
+
+func TestAutoUpdateLoop_EarlyExits(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "disabled by config",
+			cfg:  Config{AutoUpdateEnabled: false, CLIVersion: "v0.1.13"},
+		},
+		{
+			name: "dev build",
+			cfg:  Config{AutoUpdateEnabled: true, CLIVersion: "v0.1.13-235-gabcdef0"},
+		},
+		{
+			name: "empty version",
+			cfg:  Config{AutoUpdateEnabled: true, CLIVersion: ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Daemon{cfg: tt.cfg, logger: slog.Default()}
+			d.runUpdateFn = func(string) (string, error) {
+				t.Fatalf("runUpdateFn called from an early-exit code path")
+				return "", nil
+			}
+			withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
+
+			done := make(chan struct{})
+			go func() {
+				d.autoUpdateLoop(context.Background())
+				close(done)
+			}()
+			<-done
+		})
+	}
+}

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -129,10 +129,11 @@ func (c *Client) ReportUsage(ctx context.Context, runtimeID string, entries []ma
 
 // HeartbeatResponse contains the server's response to a heartbeat, including any pending actions.
 type HeartbeatResponse struct {
-	Status         string                    `json:"status"`
-	PendingPing    *PendingPing              `json:"pending_ping,omitempty"`
-	PendingUpdates []PendingUpdate           `json:"pending_updates,omitempty"`
-	ProviderConfig map[string]ProviderConfig `json:"provider_config,omitempty"`
+	Status            string                    `json:"status"`
+	PendingPing       *PendingPing              `json:"pending_ping,omitempty"`
+	PendingUpdates    []PendingUpdate           `json:"pending_updates,omitempty"`
+	PendingModelLists []PendingModelList        `json:"pending_model_lists,omitempty"`
+	ProviderConfig    map[string]ProviderConfig `json:"provider_config,omitempty"`
 }
 
 // PendingPing represents a ping test request from the server.
@@ -143,8 +144,15 @@ type PendingPing struct {
 // PendingUpdate represents a CLI update request from the server.
 type PendingUpdate struct {
 	ID            string `json:"id"`
-	Target        string `json:"target"`         // "multica", "claude", "codex", etc.
+	Target        string `json:"target"` // "multica", "claude", "codex", etc.
 	TargetVersion string `json:"target_version"`
+}
+
+// PendingModelList represents a model discovery request from the server.
+type PendingModelList struct {
+	ID        string `json:"id"`
+	RuntimeID string `json:"runtime_id"`
+	Provider  string `json:"provider"`
 }
 
 // SendDaemonHeartbeat sends a single heartbeat for the daemon (covers all runtimes).
@@ -167,6 +175,11 @@ func (c *Client) ReportPingResult(ctx context.Context, runtimeID, pingID string,
 // ReportUpdateResult sends the CLI update result back to the server.
 func (c *Client) ReportUpdateResult(ctx context.Context, runtimeID, updateID string, result map[string]any) error {
 	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/runtimes/%s/update/%s/result", runtimeID, updateID), result, nil)
+}
+
+// ReportModelListResult sends a model discovery result back to the server.
+func (c *Client) ReportModelListResult(ctx context.Context, runtimeID, requestID string, result map[string]any) error {
+	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/runtimes/%s/models/%s/result", runtimeID, requestID), result, nil)
 }
 
 // WorkspaceInfo holds minimal workspace metadata returned by the API.

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -21,6 +21,12 @@ const (
 	DefaultWorkspaceSyncInterval = 30 * time.Second
 	DefaultHealthPort            = 19514
 	DefaultMaxConcurrentTasks    = 20
+	// DefaultCodexSemanticInactivityTimeout matches the codex backend's own
+	// default; surfaced here so it can be tuned via env without a rebuild.
+	DefaultCodexSemanticInactivityTimeout = 10 * time.Minute
+	// DefaultAutoUpdateCheckInterval is how often the daemon polls GitHub
+	// Releases for a newer CLI version when auto-update is enabled.
+	DefaultAutoUpdateCheckInterval = 6 * time.Hour
 )
 
 // Config holds all daemon configuration.
@@ -39,6 +45,17 @@ type Config struct {
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
+	// CodexSemanticInactivityTimeout bounds how long a codex task may run
+	// without semantic progress (tool use, items, status changes) before
+	// the daemon gives up on it. Zero falls back to the backend default.
+	CodexSemanticInactivityTimeout time.Duration
+
+	// AutoUpdateEnabled controls the periodic self-update loop. Defaults to
+	// true for release builds; disable with --no-auto-update or
+	// MULTICA_DAEMON_AUTO_UPDATE=false. Dev builds are skipped regardless.
+	AutoUpdateEnabled bool
+	// AutoUpdateCheckInterval is how often the loop checks GitHub Releases.
+	AutoUpdateCheckInterval time.Duration
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -55,6 +72,8 @@ type Overrides struct {
 	RuntimeName        string
 	Profile            string // profile name (empty = default)
 	HealthPort         int    // health check port (0 = use default)
+	NoAutoUpdate       bool   // disable the periodic self-update loop
+	AutoUpdateInterval time.Duration
 }
 
 // LoadConfig builds the daemon configuration from environment variables
@@ -98,7 +117,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCODE_MODEL")),
 		}
 	}
-	cursorPath := envOrDefault("MULTICA_CURSOR_PATH", "agent")
+	// Cursor renamed its CLI binary from `agent` to `cursor-agent`; probe the
+	// current name first and fall back to the legacy one.
+	cursorPath := strings.TrimSpace(os.Getenv("MULTICA_CURSOR_PATH"))
+	if cursorPath == "" {
+		cursorPath = "cursor-agent"
+		if _, err := exec.LookPath(cursorPath); err != nil {
+			cursorPath = "agent"
+		}
+	}
 	if _, err := exec.LookPath(cursorPath); err == nil {
 		agents["cursor"] = AgentEntry{
 			Path:  cursorPath,
@@ -148,6 +175,28 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	if overrides.MaxConcurrentTasks > 0 {
 		maxConcurrentTasks = overrides.MaxConcurrentTasks
+	}
+
+	codexSemanticInactivityTimeout, err := durationFromEnv("MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT", DefaultCodexSemanticInactivityTimeout)
+	if err != nil {
+		return Config{}, err
+	}
+
+	// Auto-update: enabled by default, opt out via flag or env.
+	autoUpdateEnabled := true
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MULTICA_DAEMON_AUTO_UPDATE"))) {
+	case "false", "0", "no", "off":
+		autoUpdateEnabled = false
+	}
+	if overrides.NoAutoUpdate {
+		autoUpdateEnabled = false
+	}
+	autoUpdateInterval, err := durationFromEnv("MULTICA_DAEMON_AUTO_UPDATE_INTERVAL", DefaultAutoUpdateCheckInterval)
+	if err != nil {
+		return Config{}, err
+	}
+	if overrides.AutoUpdateInterval > 0 {
+		autoUpdateInterval = overrides.AutoUpdateInterval
 	}
 
 	// Profile
@@ -218,6 +267,11 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		PollInterval:       pollInterval,
 		HeartbeatInterval:  heartbeatInterval,
 		AgentTimeout:       agentTimeout,
+
+		CodexSemanticInactivityTimeout: codexSemanticInactivityTimeout,
+
+		AutoUpdateEnabled:       autoUpdateEnabled,
+		AutoUpdateCheckInterval: autoUpdateInterval,
 	}, nil
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -47,12 +47,29 @@ type Daemon struct {
 	restartBinary string             // non-empty after a successful update; path to the new binary
 	updating      atomic.Bool        // prevents concurrent update attempts
 	reconciling   atomic.Bool        // prevents concurrent reconcileProviders
+
+	activeTasks atomic.Int64 // number of tasks currently in handleTask
+
+	// claimMu guards pauseClaims and claimsInFlight. It is held only for the
+	// flag/counter mutations, never across network calls. pollLoop refuses to
+	// call ClaimTask while pauseClaims is set, and tryAutoUpdate refuses to
+	// flip pauseClaims while any poller is mid-claim — together these close
+	// the window where an auto-update restart could cancel a task that was
+	// claimed after the idle check.
+	claimMu        sync.Mutex
+	pauseClaims    bool // when true, pollLoop skips ClaimTask
+	claimsInFlight int  // pollers that have decided to claim but haven't handed the task to handleTask yet
+
+	// runUpdateFn executes the brew-or-download upgrade. Set to d.runUpdate
+	// by New; tests inject a stub so the auto-update loop can be exercised
+	// without shelling out to brew or hitting GitHub.
+	runUpdateFn func(targetVersion string) (string, error)
 }
 
 // New creates a new Daemon instance.
 func New(cfg Config, logger *slog.Logger) *Daemon {
 	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
-	return &Daemon{
+	d := &Daemon{
 		cfg:             cfg,
 		client:          NewClient(cfg.ServerBaseURL),
 		repoCache:       repocache.New(cacheRoot, logger),
@@ -63,6 +80,8 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		taskTokens:      make(map[string]string),
 		providerConfigs: make(map[string]ProviderConfig),
 	}
+	d.runUpdateFn = d.runUpdate
+	return d
 }
 
 // Run starts the daemon: resolves auth, registers runtimes, then polls for tasks.
@@ -108,6 +127,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	go d.heartbeatLoop(ctx)
 	go d.assignmentSyncLoop(ctx)
 	go d.usageScanLoop(ctx)
+	go d.autoUpdateLoop(ctx)
 	go d.serveHealth(ctx, healthLn, time.Now())
 	return d.pollLoop(ctx)
 }
@@ -312,6 +332,10 @@ func (d *Daemon) detectLocalRuntimes(ctx context.Context) []map[string]string {
 		version, err := agent.DetectVersion(ctx, entry.Path)
 		if err != nil {
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
+			continue
+		}
+		if err := agent.CheckMinVersion(name, version); err != nil {
+			d.logger.Warn("skip registering runtime: CLI version below minimum", "name", name, "version", version, "error", err)
 			continue
 		}
 		authStatus := agent.CheckAuth(ctx, name, entry.Path)
@@ -624,6 +648,11 @@ func (d *Daemon) heartbeatLoop(ctx context.Context) {
 				go d.handleUpdate(ctx, daemonUUID, &u)
 			}
 
+			for _, pending := range resp.PendingModelLists {
+				p := pending
+				go d.handleModelList(ctx, p)
+			}
+
 			// Auto-install newly enabled providers (same cadence as auth check).
 			if refreshAuth && len(resp.ProviderConfig) > 0 && d.reconciling.CompareAndSwap(false, true) {
 				go func() {
@@ -632,6 +661,76 @@ func (d *Daemon) heartbeatLoop(ctx context.Context) {
 				}()
 			}
 		}
+	}
+}
+
+// handleModelList resolves the provider's supported models (via static
+// catalog or local CLI discovery) and reports the result back to the
+// server. Discovery failures are reported as failed so the UI polling
+// loop terminates with a real error instead of timing out.
+func (d *Daemon) handleModelList(ctx context.Context, pending PendingModelList) {
+	d.logger.Info("model list requested", "runtime_id", pending.RuntimeID, "request_id", pending.ID, "provider", pending.Provider)
+
+	entry, ok := d.cfg.Agents[pending.Provider]
+	if !ok {
+		d.reportModelListResult(ctx, pending, map[string]any{
+			"status": "failed",
+			"error":  fmt.Sprintf("provider %s is not available on this daemon", pending.Provider),
+		})
+		return
+	}
+
+	models, err := agent.ListModels(ctx, pending.Provider, entry.Path)
+	if err != nil {
+		d.reportModelListResult(ctx, pending, map[string]any{
+			"status": "failed",
+			"error":  err.Error(),
+		})
+		return
+	}
+
+	// Wire format matches handler.ModelEntry. Use structs (not
+	// map[string]string) so the Default bool and the per-model thinking
+	// catalog survive marshalling.
+	type thinkingLevelWire struct {
+		Value       string `json:"value"`
+		Label       string `json:"label"`
+		Description string `json:"description,omitempty"`
+	}
+	type modelThinkingWire struct {
+		SupportedLevels []thinkingLevelWire `json:"supported_levels"`
+		DefaultLevel    string              `json:"default_level,omitempty"`
+	}
+	type modelWire struct {
+		ID       string             `json:"id"`
+		Label    string             `json:"label"`
+		Provider string             `json:"provider,omitempty"`
+		Default  bool               `json:"default,omitempty"`
+		Thinking *modelThinkingWire `json:"thinking,omitempty"`
+	}
+	wire := make([]modelWire, 0, len(models))
+	for _, m := range models {
+		entry := modelWire{ID: m.ID, Label: m.Label, Provider: m.Provider, Default: m.Default}
+		if m.Thinking != nil {
+			levels := make([]thinkingLevelWire, 0, len(m.Thinking.SupportedLevels))
+			for _, lvl := range m.Thinking.SupportedLevels {
+				levels = append(levels, thinkingLevelWire{Value: lvl.Value, Label: lvl.Label, Description: lvl.Description})
+			}
+			entry.Thinking = &modelThinkingWire{SupportedLevels: levels, DefaultLevel: m.Thinking.DefaultLevel}
+		}
+		wire = append(wire, entry)
+	}
+
+	d.reportModelListResult(ctx, pending, map[string]any{
+		"status":    "completed",
+		"models":    wire,
+		"supported": agent.ModelSelectionSupported(pending.Provider),
+	})
+}
+
+func (d *Daemon) reportModelListResult(ctx context.Context, pending PendingModelList, payload map[string]any) {
+	if err := d.client.ReportModelListResult(ctx, pending.RuntimeID, pending.ID, payload); err != nil {
+		d.logger.Warn("report model list result failed", "runtime_id", pending.RuntimeID, "request_id", pending.ID, "error", err)
 	}
 }
 
@@ -743,34 +842,36 @@ func (d *Daemon) handleUpdate(ctx context.Context, id string, update *PendingUpd
 	}
 }
 
-// handleMulticaUpdate handles updates to the multica CLI itself.
-func (d *Daemon) handleMulticaUpdate(ctx context.Context, runtimeID string, update *PendingUpdate) {
-	// Try Homebrew first, fall back to direct download.
-	var output string
+// runUpdate executes the multica CLI upgrade via Homebrew when the binary is
+// brew-managed, otherwise via direct download of the release tarball. Shared
+// by the server-triggered update path and the auto-update loop.
+func (d *Daemon) runUpdate(targetVersion string) (string, error) {
 	if cli.IsBrewInstall() {
 		d.logger.Info("updating CLI via Homebrew...")
-		var err error
-		output, err = cli.UpdateViaBrew()
+		output, err := cli.UpdateViaBrew()
 		if err != nil {
-			d.logger.Error("CLI update failed", "error", err, "output", output)
-			d.client.ReportUpdateResult(ctx, runtimeID, update.ID, map[string]any{
-				"status": "failed",
-				"error":  fmt.Sprintf("brew upgrade failed: %v", err),
-			})
-			return
+			return output, fmt.Errorf("brew upgrade failed: %w", err)
 		}
-	} else {
-		d.logger.Info("updating CLI via direct download...", "target_version", update.TargetVersion)
-		var err error
-		output, err = cli.UpdateViaDownload(update.TargetVersion)
-		if err != nil {
-			d.logger.Error("CLI update failed", "error", err)
-			d.client.ReportUpdateResult(ctx, runtimeID, update.ID, map[string]any{
-				"status": "failed",
-				"error":  fmt.Sprintf("download update failed: %v", err),
-			})
-			return
-		}
+		return output, nil
+	}
+	d.logger.Info("updating CLI via direct download...", "target_version", targetVersion)
+	output, err := cli.UpdateViaDownload(targetVersion)
+	if err != nil {
+		return output, fmt.Errorf("download update failed: %w", err)
+	}
+	return output, nil
+}
+
+// handleMulticaUpdate handles updates to the multica CLI itself.
+func (d *Daemon) handleMulticaUpdate(ctx context.Context, runtimeID string, update *PendingUpdate) {
+	output, err := d.runUpdateFn(update.TargetVersion)
+	if err != nil {
+		d.logger.Error("CLI update failed", "error", err, "output", output)
+		d.client.ReportUpdateResult(ctx, runtimeID, update.ID, map[string]any{
+			"status": "failed",
+			"error":  err.Error(),
+		})
+		return
 	}
 
 	d.logger.Info("CLI update completed successfully", "output", output)
@@ -808,6 +909,55 @@ func (d *Daemon) handleProviderUpdate(ctx context.Context, runtimeID string, upd
 
 	// No daemon restart needed — just re-register to update version info.
 	// The next heartbeat cycle will pick up the new version.
+}
+
+// tryEnterClaim records the intent to call ClaimTask. Returns true if the
+// caller may proceed, false if the auto-update barrier is in effect. Every
+// successful call MUST be paired with an exitClaim() on every exit path —
+// either right after a failed/empty claim, or via the handleTask goroutine
+// once the task is handed off (after activeTasks has been incremented).
+func (d *Daemon) tryEnterClaim() bool {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	if d.pauseClaims {
+		return false
+	}
+	d.claimsInFlight++
+	return true
+}
+
+// exitClaim releases the in-flight claim recorded by tryEnterClaim.
+func (d *Daemon) exitClaim() {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	d.claimsInFlight--
+}
+
+// trySetClaimBarrier atomically pauses new ClaimTask calls if the daemon is
+// fully idle (no claims in flight, no tasks running). Returns true if the
+// caller now holds the barrier and must release it with releaseClaimBarrier
+// on every non-restart exit path; false if the daemon is busy and the caller
+// should defer to the next tick. Used by tryAutoUpdate to close the race
+// where a task slips in between the cheap pre-fetch idle check and the
+// actual upgrade kick-off.
+func (d *Daemon) trySetClaimBarrier() bool {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	if d.claimsInFlight > 0 || d.activeTasks.Load() > 0 {
+		return false
+	}
+	d.pauseClaims = true
+	return true
+}
+
+// releaseClaimBarrier clears the auto-update claim barrier so pollers may
+// resume claiming. Called on failure paths only — a successful upgrade leaves
+// the barrier set because triggerRestart is about to take the process down
+// and clearing it would open a window for new claims during shutdown.
+func (d *Daemon) releaseClaimBarrier() {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	d.pauseClaims = false
 }
 
 // triggerRestart initiates a graceful daemon restart after a successful CLI update.
@@ -946,9 +1096,18 @@ func (d *Daemon) pollLoop(ctx context.Context) error {
 				goto sleep
 			}
 
+			// Record claim intent so the auto-update barrier can't fire a
+			// restart between the claim and the task being handed off.
+			if !d.tryEnterClaim() {
+				<-sem // Release the slot.
+				d.logger.Debug("poll: claims paused for auto-update")
+				goto sleep
+			}
+
 			rid := runtimeIDs[(pollOffset+i)%n]
 			task, err := d.client.ClaimTask(ctx, rid)
 			if err != nil {
+				d.exitClaim()
 				<-sem // Release the slot.
 				d.logger.Warn("claim task failed", "runtime_id", rid, "error", err)
 				continue
@@ -959,6 +1118,12 @@ func (d *Daemon) pollLoop(ctx context.Context) error {
 				go func(t Task) {
 					defer wg.Done()
 					defer func() { <-sem }()
+					// Bump activeTasks before releasing the claim slot so the
+					// auto-update barrier can never observe "no claims, no
+					// tasks" while this task is alive.
+					d.activeTasks.Add(1)
+					defer d.activeTasks.Add(-1)
+					d.exitClaim()
 					d.handleTask(ctx, t)
 				}(*task)
 				claimed = true
@@ -966,6 +1131,7 @@ func (d *Daemon) pollLoop(ctx context.Context) error {
 				break
 			}
 			// No task for this runtime, release the slot and try next.
+			d.exitClaim()
 			<-sem
 		}
 
@@ -1217,11 +1383,43 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)
 	}
 
+	// Two-tier model resolution: an explicit agent-level model (from the
+	// agent's model_config for this provider) wins, then the daemon-wide
+	// MULTICA_<PROVIDER>_MODEL env var. If both are empty we deliberately
+	// pass "" through — each backend omits `--model` from the CLI
+	// invocation, so the provider picks its own default. Baking a Go-side
+	// "recommended default" here is how static guesses drift from whatever
+	// the upstream CLI actually accepts.
+	model := ""
+	thinkingLevel := ""
+	if task.Agent != nil {
+		model = task.Agent.Model
+		thinkingLevel = task.Agent.ThinkingLevel
+	}
+	if model == "" {
+		model = entry.Model
+	}
+	// Per-model guard: the server validates the literal token against the
+	// provider's enum, but per-model gaps (Claude's `xhigh` on a non-Opus
+	// model, Codex's per-model `supported_reasoning_levels`) only resolve
+	// here, against the daemon's local CLI catalog. Invalid combinations
+	// log a warning and drop the level rather than failing the task, so a
+	// stale persisted value never blocks execution. Discovery errors fail
+	// open: if we can't list models, we pass the level through unchanged.
+	if thinkingLevel != "" {
+		if valid, err := agent.ValidateThinkingLevel(ctx, provider, entry.Path, model, thinkingLevel); err == nil && !valid {
+			taskLog.Warn("thinking level not supported by model; dropping",
+				"provider", provider, "model", model, "thinking_level", thinkingLevel)
+			thinkingLevel = ""
+		}
+	}
+
 	reused := task.PriorWorkDir != "" && env.WorkDir == task.PriorWorkDir
 	taskLog.Info("starting agent",
 		"provider", provider,
 		"workdir", env.WorkDir,
-		"model", entry.Model,
+		"model", model,
+		"thinking_level", thinkingLevel,
 		"reused", reused,
 	)
 	if task.PriorSessionID != "" {
@@ -1231,10 +1429,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	taskStart := time.Now()
 
 	session, err := backend.Execute(ctx, prompt, agent.ExecOptions{
-		Cwd:             env.WorkDir,
-		Model:           entry.Model,
-		Timeout:         d.cfg.AgentTimeout,
-		ResumeSessionID: task.PriorSessionID,
+		Cwd:                       env.WorkDir,
+		Model:                     model,
+		ThinkingLevel:             thinkingLevel,
+		Timeout:                   d.cfg.AgentTimeout,
+		SemanticInactivityTimeout: d.cfg.CodexSemanticInactivityTimeout,
+		ResumeSessionID:           task.PriorSessionID,
 	})
 	if err != nil {
 		return TaskResult{}, err

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -34,9 +34,9 @@ type Task struct {
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // Claude session ID from a previous task on this issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
 	TriggerCommentID string         `json:"trigger_comment_id,omitempty"` // comment that triggered this task
-	GitHubToken      string `json:"github_token,omitempty"`
-	GitHubCodeAccess string `json:"github_code_access,omitempty"`
-	ProviderAPIKey   string `json:"provider_api_key,omitempty"` // workspace-level API key
+	GitHubToken      string         `json:"github_token,omitempty"`
+	GitHubCodeAccess string         `json:"github_code_access,omitempty"`
+	ProviderAPIKey   string         `json:"provider_api_key,omitempty"` // workspace-level API key
 }
 
 // AgentData holds agent details returned by the claim endpoint.
@@ -45,6 +45,11 @@ type AgentData struct {
 	Name         string      `json:"name"`
 	Instructions string      `json:"instructions"`
 	Skills       []SkillData `json:"skills"`
+	// Model / ThinkingLevel are resolved server-side from the agent's
+	// per-provider model_config for this task's provider. Empty means
+	// "use the daemon/CLI default".
+	Model         string `json:"model,omitempty"`
+	ThinkingLevel string `json:"thinking_level,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -11,32 +11,67 @@ import (
 	gh "github.com/nullne/multica/server/internal/github"
 	"github.com/nullne/multica/server/internal/logger"
 	"github.com/nullne/multica/server/internal/service"
+	agentpkg "github.com/nullne/multica/server/pkg/agent"
 	db "github.com/nullne/multica/server/pkg/db/generated"
 	"github.com/nullne/multica/server/pkg/protocol"
 )
 
+// AgentModelConfig is the per-provider model selection persisted on an agent.
+// Empty Model means "use the provider CLI's own default"; empty ThinkingLevel
+// means "use the runtime/model default".
+type AgentModelConfig struct {
+	Model         string `json:"model,omitempty"`
+	ThinkingLevel string `json:"thinking_level,omitempty"`
+}
+
+// validateModelConfig checks the thinking_level tokens against each
+// provider's known vocabulary. Model IDs are deliberately not validated
+// against a catalog: the UI offers discovered models but allows manual
+// entry, and the daemon passes unknown IDs through to the CLI which
+// rejects them with a real error message.
+func validateModelConfig(mc map[string]AgentModelConfig) string {
+	for provider, cfg := range mc {
+		if !agentpkg.IsKnownThinkingValue(provider, cfg.ThinkingLevel) {
+			return "invalid thinking_level " + cfg.ThinkingLevel + " for provider " + provider
+		}
+	}
+	return ""
+}
+
+func parseModelConfig(raw []byte) map[string]AgentModelConfig {
+	if len(raw) == 0 {
+		return map[string]AgentModelConfig{}
+	}
+	var mc map[string]AgentModelConfig
+	if err := json.Unmarshal(raw, &mc); err != nil || mc == nil {
+		return map[string]AgentModelConfig{}
+	}
+	return mc
+}
+
 type AgentResponse struct {
-	ID                 string          `json:"id"`
-	WorkspaceID        string          `json:"workspace_id"`
-	Providers          []string        `json:"providers"`
-	DefaultProvider    *string         `json:"default_provider"`
-	Name               string          `json:"name"`
-	Description        string          `json:"description"`
-	Instructions       string          `json:"instructions"`
-	AvatarURL          *string         `json:"avatar_url"`
-	Visibility         string          `json:"visibility"`
-	Status             string          `json:"status"`
-	OwnerID            *string         `json:"owner_id"`
-	Skills             []SkillResponse `json:"skills"`
-	Tools              any             `json:"tools"`
-	Triggers           any             `json:"triggers"`
-	GitHubCodeAccess   string          `json:"github_code_access"`
-	DefaultDaemonID    *string         `json:"default_daemon_id"`
-	MaxConcurrentTasks int32           `json:"max_concurrent_tasks"`
-	CreatedAt          string          `json:"created_at"`
-	UpdatedAt          string          `json:"updated_at"`
-	ArchivedAt         *string         `json:"archived_at"`
-	ArchivedBy         *string         `json:"archived_by"`
+	ID                 string                      `json:"id"`
+	WorkspaceID        string                      `json:"workspace_id"`
+	Providers          []string                    `json:"providers"`
+	DefaultProvider    *string                     `json:"default_provider"`
+	Name               string                      `json:"name"`
+	Description        string                      `json:"description"`
+	Instructions       string                      `json:"instructions"`
+	AvatarURL          *string                     `json:"avatar_url"`
+	Visibility         string                      `json:"visibility"`
+	Status             string                      `json:"status"`
+	OwnerID            *string                     `json:"owner_id"`
+	Skills             []SkillResponse             `json:"skills"`
+	Tools              any                         `json:"tools"`
+	Triggers           any                         `json:"triggers"`
+	GitHubCodeAccess   string                      `json:"github_code_access"`
+	DefaultDaemonID    *string                     `json:"default_daemon_id"`
+	MaxConcurrentTasks int32                       `json:"max_concurrent_tasks"`
+	ModelConfig        map[string]AgentModelConfig `json:"model_config"`
+	CreatedAt          string                      `json:"created_at"`
+	UpdatedAt          string                      `json:"updated_at"`
+	ArchivedAt         *string                     `json:"archived_at"`
+	ArchivedBy         *string                     `json:"archived_by"`
 }
 
 func agentToResponse(a db.Agent) AgentResponse {
@@ -79,6 +114,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		GitHubCodeAccess:   a.GithubCodeAccess,
 		DefaultDaemonID:    uuidToPtr(a.DefaultDaemonID),
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
+		ModelConfig:        parseModelConfig(a.ModelConfig),
 		CreatedAt:          timestampToString(a.CreatedAt),
 		UpdatedAt:          timestampToString(a.UpdatedAt),
 		ArchivedAt:         timestampToPtr(a.ArchivedAt),
@@ -114,9 +150,9 @@ type AgentTaskResponse struct {
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 	ResultCommentID  *string        `json:"result_comment_id,omitempty"`  // comment this run produced as its final reply
-	GitHubToken      string `json:"github_token,omitempty"`
-	GitHubCodeAccess string `json:"github_code_access,omitempty"`
-	ProviderAPIKey   string `json:"provider_api_key,omitempty"` // workspace-level API key for the provider
+	GitHubToken      string         `json:"github_token,omitempty"`
+	GitHubCodeAccess string         `json:"github_code_access,omitempty"`
+	ProviderAPIKey   string         `json:"provider_api_key,omitempty"` // workspace-level API key for the provider
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon
@@ -126,6 +162,10 @@ type TaskAgentData struct {
 	Name         string                   `json:"name"`
 	Instructions string                   `json:"instructions"`
 	Skills       []service.AgentSkillData `json:"skills,omitempty"`
+	// Model / ThinkingLevel are resolved server-side from the agent's
+	// model_config for the provider of the runtime that claimed the task.
+	Model         string `json:"model,omitempty"`
+	ThinkingLevel string `json:"thinking_level,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -225,19 +265,20 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 type CreateAgentRequest struct {
-	Name               string   `json:"name"`
-	Description        string   `json:"description"`
-	Instructions       string   `json:"instructions"`
-	AvatarURL          *string  `json:"avatar_url"`
-	Providers          []string `json:"providers"`
-	Provider           string   `json:"provider"` // deprecated: single provider, use providers
-	DefaultProvider    *string  `json:"default_provider"`
-	Visibility         string   `json:"visibility"`
-	Tools              any      `json:"tools"`
-	Triggers           any      `json:"triggers"`
-	GitHubCodeAccess   string   `json:"github_code_access"`
-	DefaultDaemonID    *string  `json:"default_daemon_id"`
-	MaxConcurrentTasks *int32   `json:"max_concurrent_tasks"`
+	Name               string                      `json:"name"`
+	Description        string                      `json:"description"`
+	Instructions       string                      `json:"instructions"`
+	AvatarURL          *string                     `json:"avatar_url"`
+	Providers          []string                    `json:"providers"`
+	Provider           string                      `json:"provider"` // deprecated: single provider, use providers
+	DefaultProvider    *string                     `json:"default_provider"`
+	Visibility         string                      `json:"visibility"`
+	Tools              any                         `json:"tools"`
+	Triggers           any                         `json:"triggers"`
+	GitHubCodeAccess   string                      `json:"github_code_access"`
+	DefaultDaemonID    *string                     `json:"default_daemon_id"`
+	MaxConcurrentTasks *int32                      `json:"max_concurrent_tasks"`
+	ModelConfig        map[string]AgentModelConfig `json:"model_config"`
 }
 
 func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
@@ -298,6 +339,15 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		maxConcurrentTasks = *req.MaxConcurrentTasks
 	}
 
+	if msg := validateModelConfig(req.ModelConfig); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	modelConfig := []byte("{}")
+	if req.ModelConfig != nil {
+		modelConfig, _ = json.Marshal(req.ModelConfig)
+	}
+
 	agent, err := h.Queries.CreateAgent(r.Context(), db.CreateAgentParams{
 		WorkspaceID:        parseUUID(workspaceID),
 		Name:               req.Name,
@@ -313,6 +363,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		DefaultProvider:    ptrToText(req.DefaultProvider),
 		DefaultDaemonID:    parseOptionalUUID(req.DefaultDaemonID),
 		MaxConcurrentTasks: maxConcurrentTasks,
+		ModelConfig:        modelConfig,
 	})
 	if err != nil {
 		slog.Warn("create agent failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
@@ -331,19 +382,20 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 type UpdateAgentRequest struct {
-	Name               *string  `json:"name"`
-	Description        *string  `json:"description"`
-	Instructions       *string  `json:"instructions"`
-	AvatarURL          *string  `json:"avatar_url"`
-	Providers          []string `json:"providers"`
-	DefaultProvider    *string  `json:"default_provider"`
-	Visibility         *string  `json:"visibility"`
-	Status             *string  `json:"status"`
-	Tools              any      `json:"tools"`
-	Triggers           any      `json:"triggers"`
-	GitHubCodeAccess   *string  `json:"github_code_access"`
-	DefaultDaemonID    *string  `json:"default_daemon_id"`
-	MaxConcurrentTasks *int32   `json:"max_concurrent_tasks"`
+	Name               *string                     `json:"name"`
+	Description        *string                     `json:"description"`
+	Instructions       *string                     `json:"instructions"`
+	AvatarURL          *string                     `json:"avatar_url"`
+	Providers          []string                    `json:"providers"`
+	DefaultProvider    *string                     `json:"default_provider"`
+	Visibility         *string                     `json:"visibility"`
+	Status             *string                     `json:"status"`
+	Tools              any                         `json:"tools"`
+	Triggers           any                         `json:"triggers"`
+	GitHubCodeAccess   *string                     `json:"github_code_access"`
+	DefaultDaemonID    *string                     `json:"default_daemon_id"`
+	MaxConcurrentTasks *int32                      `json:"max_concurrent_tasks"`
+	ModelConfig        map[string]AgentModelConfig `json:"model_config"`
 }
 
 // canManageAgent checks whether the current user can update or archive an agent.
@@ -461,6 +513,18 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		params.MaxConcurrentTasks = pgtype.Int4{Int32: *req.MaxConcurrentTasks, Valid: true}
+	}
+	if _, ok := rawFields["model_config"]; ok {
+		if msg := validateModelConfig(req.ModelConfig); msg != "" {
+			writeError(w, http.StatusBadRequest, msg)
+			return
+		}
+		mc := req.ModelConfig
+		if mc == nil {
+			mc = map[string]AgentModelConfig{}
+		}
+		modelConfig, _ := json.Marshal(mc)
+		params.ModelConfig = modelConfig
 	}
 
 	agent, err = h.Queries.UpdateAgent(r.Context(), params)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -368,6 +368,30 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp["pending_updates"] = out
 	}
 
+	// Pop pending model-list requests for any of this daemon's runtimes.
+	// Requests are runtime-scoped (the UI asks one runtime for its catalog)
+	// while the heartbeat is daemon-scoped, so project across all runtimes.
+	if runtimes, err := h.Queries.ListRuntimesByDaemon(r.Context(), daemon.ID); err == nil && len(runtimes) > 0 {
+		runtimeIDs := make([]string, 0, len(runtimes))
+		providerByRuntime := make(map[string]string, len(runtimes))
+		for _, rt := range runtimes {
+			id := uuidToString(rt.ID)
+			runtimeIDs = append(runtimeIDs, id)
+			providerByRuntime[id] = rt.Provider
+		}
+		if pendingModels := h.ModelListStore.PopPendingForRuntimes(runtimeIDs); len(pendingModels) > 0 {
+			out := make([]map[string]string, len(pendingModels))
+			for i, m := range pendingModels {
+				out[i] = map[string]string{
+					"id":         m.ID,
+					"runtime_id": m.RuntimeID,
+					"provider":   providerByRuntime[m.RuntimeID],
+				}
+			}
+			resp["pending_model_lists"] = out
+		}
+	}
+
 	// Project the union of provider configs across enabled workspaces so the
 	// daemon can auto-install any provider any of its workspaces wants.
 	merged := make(map[string]map[string]any)
@@ -423,6 +447,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	// Build response with fresh agent data (name + skills).
 	resp := taskToResponse(*task)
 	var agentCodeAccess string
+	var agentModelConfig map[string]AgentModelConfig
 	if agent, err := h.Queries.GetAgent(r.Context(), task.AgentID); err == nil {
 		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
 		resp.Agent = &TaskAgentData{
@@ -432,12 +457,23 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			Skills:       skills,
 		}
 		agentCodeAccess = agent.GithubCodeAccess
+		agentModelConfig = parseModelConfig(agent.ModelConfig)
 	}
 
 	// Look up the runtime to get the provider for API key injection.
 	var runtimeProvider string
 	if rt, err := h.Queries.GetAgentRuntime(r.Context(), task.RuntimeID); err == nil {
 		runtimeProvider = rt.Provider
+	}
+
+	// Resolve the agent's model selection for this task's provider. The
+	// daemon receives a single (model, thinking_level) pair so it never
+	// has to understand the per-provider model_config shape.
+	if resp.Agent != nil && runtimeProvider != "" {
+		if cfg, ok := agentModelConfig[runtimeProvider]; ok {
+			resp.Agent.Model = cfg.Model
+			resp.Agent.ThinkingLevel = cfg.ThinkingLevel
+		}
 	}
 
 	// Include workspace ID and repos so the daemon can set up worktrees.

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -42,6 +42,7 @@ type Handler struct {
 	TaskService      *service.TaskService
 	PingStore        *PingStore
 	UpdateStore      *UpdateStore
+	ModelListStore   *ModelListStore
 	Storage          *storage.S3Storage
 	CFSigner         *auth.CloudFrontSigner
 	FirebaseVerifier auth.FirebaseVerifier
@@ -64,6 +65,7 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 		TaskService:      service.NewTaskService(queries, hub, bus),
 		PingStore:        NewPingStore(),
 		UpdateStore:      NewUpdateStore(),
+		ModelListStore:   NewModelListStore(),
 		Storage:          s3,
 		CFSigner:         cfSigner,
 		FirebaseVerifier: auth.NewFirebaseVerifierFromEnv(),

--- a/server/internal/handler/runtime_models.go
+++ b/server/internal/handler/runtime_models.go
@@ -1,0 +1,310 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ---------------------------------------------------------------------------
+// Model list request store
+// ---------------------------------------------------------------------------
+//
+// The server cannot call the daemon directly (the daemon is behind the user's
+// NAT and only polls the server). So "list models for this runtime" uses a
+// pending-request pattern: a frontend POST creates a pending request, the
+// daemon pops it on the next heartbeat, executes locally, and reports the
+// result back. Same shape as PingStore / UpdateStore.
+
+// ModelListStatus represents the lifecycle of a model list request.
+type ModelListStatus string
+
+const (
+	ModelListPending   ModelListStatus = "pending"
+	ModelListRunning   ModelListStatus = "running"
+	ModelListCompleted ModelListStatus = "completed"
+	ModelListFailed    ModelListStatus = "failed"
+	ModelListTimeout   ModelListStatus = "timeout"
+)
+
+// ModelListRequest represents a pending or completed model list request.
+// Supported is false when the provider ignores per-agent model selection
+// entirely; the UI uses this to disable its dropdown rather than silently
+// accepting a value the backend will drop.
+//
+// runStartedAt is server-side bookkeeping for the running timeout; the UI
+// only needs Status / UpdatedAt to drive the polling loop.
+type ModelListRequest struct {
+	ID           string          `json:"id"`
+	RuntimeID    string          `json:"runtime_id"`
+	Status       ModelListStatus `json:"status"`
+	Models       []ModelEntry    `json:"models,omitempty"`
+	Supported    bool            `json:"supported"`
+	Error        string          `json:"error,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+	runStartedAt *time.Time
+}
+
+// ModelEntry mirrors agent.Model for the wire. `Default` tags the model the
+// runtime advertises as its preferred pick so the UI can badge it.
+//
+// `Thinking` carries the per-model reasoning-effort catalog discovered by
+// the daemon for runtimes that support it (claude, codex, opencode). nil
+// means "no picker for this model"; the UI hides the thinking_level selector.
+type ModelEntry struct {
+	ID       string         `json:"id"`
+	Label    string         `json:"label"`
+	Provider string         `json:"provider,omitempty"`
+	Default  bool           `json:"default,omitempty"`
+	Thinking *ModelThinking `json:"thinking,omitempty"`
+}
+
+// ModelThinking is the wire shape for the per-model thinking catalog.
+// Mirrors agent.ModelThinking so the daemon's report passes through
+// without remapping.
+type ModelThinking struct {
+	SupportedLevels []ThinkingLevelEntry `json:"supported_levels"`
+	DefaultLevel    string               `json:"default_level,omitempty"`
+}
+
+// ThinkingLevelEntry is the wire shape for a single entry in a model's
+// reasoning-effort catalog. `Value` is the literal token the daemon passes
+// to the CLI; `Label` is the display string; `Description` is optional
+// helper copy (Codex's debug-models output includes one per level).
+type ThinkingLevelEntry struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+const (
+	// modelListPendingTimeout bounds how long a pending request can sit in
+	// the store before the UI is told "daemon didn't pick this up".
+	modelListPendingTimeout = 30 * time.Second
+	// modelListRunningTimeout bounds how long a claimed (running) request
+	// can stay claimed before the UI is told "daemon picked this up but
+	// never reported a result" (e.g. the heartbeat response carrying the
+	// pending entry was lost in transit after PopPending mutated state).
+	modelListRunningTimeout = 60 * time.Second
+	// modelListStoreRetention bounds how long any stored request lives.
+	// Wider than the running/pending timeouts so terminal records are
+	// still readable when the UI's last poll arrives.
+	modelListStoreRetention = 2 * time.Minute
+)
+
+// applyModelListTimeout transitions a request to ModelListTimeout when it has
+// been stuck in a non-terminal state past its threshold. Returns true when
+// the record was modified.
+func applyModelListTimeout(req *ModelListRequest, now time.Time) bool {
+	switch req.Status {
+	case ModelListPending:
+		if now.Sub(req.CreatedAt) > modelListPendingTimeout {
+			req.Status = ModelListTimeout
+			req.Error = "daemon did not respond within 30 seconds"
+			req.UpdatedAt = now
+			return true
+		}
+	case ModelListRunning:
+		if req.runStartedAt != nil && now.Sub(*req.runStartedAt) > modelListRunningTimeout {
+			req.Status = ModelListTimeout
+			req.Error = "daemon did not finish within 60 seconds"
+			req.UpdatedAt = now
+			return true
+		}
+	}
+	return false
+}
+
+// ModelListStore is a thread-safe in-memory store for model list requests.
+type ModelListStore struct {
+	mu       sync.Mutex
+	requests map[string]*ModelListRequest // keyed by request ID
+}
+
+func NewModelListStore() *ModelListStore {
+	return &ModelListStore{requests: make(map[string]*ModelListRequest)}
+}
+
+func (s *ModelListStore) Create(runtimeID string) *ModelListRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Garbage-collect stale entries so the map can't grow unbounded.
+	for id, req := range s.requests {
+		if time.Since(req.CreatedAt) > modelListStoreRetention {
+			delete(s.requests, id)
+		}
+	}
+
+	now := time.Now()
+	req := &ModelListRequest{
+		ID:        randomID(),
+		RuntimeID: runtimeID,
+		Status:    ModelListPending,
+		// Default to true; the daemon overrides this in the report for
+		// providers that don't support per-agent model selection.
+		Supported: true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.requests[req.ID] = req
+	return req
+}
+
+func (s *ModelListStore) Get(id string) *ModelListRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	req, ok := s.requests[id]
+	if !ok {
+		return nil
+	}
+	applyModelListTimeout(req, time.Now())
+	return req
+}
+
+// PopPending claims the oldest pending request for a runtime (moving it to
+// running) or returns nil when there is none.
+func (s *ModelListStore) PopPending(runtimeID string) *ModelListRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var oldest *ModelListRequest
+	now := time.Now()
+	for _, req := range s.requests {
+		applyModelListTimeout(req, now)
+		if req.RuntimeID == runtimeID && req.Status == ModelListPending {
+			if oldest == nil || req.CreatedAt.Before(oldest.CreatedAt) {
+				oldest = req
+			}
+		}
+	}
+	if oldest != nil {
+		oldest.Status = ModelListRunning
+		startedAt := now
+		oldest.runStartedAt = &startedAt
+		oldest.UpdatedAt = now
+	}
+	return oldest
+}
+
+// PopPendingForRuntimes pops at most one pending request per runtime ID.
+// Used by the daemon heartbeat, which is daemon-scoped while requests are
+// runtime-scoped.
+func (s *ModelListStore) PopPendingForRuntimes(runtimeIDs []string) []*ModelListRequest {
+	var out []*ModelListRequest
+	for _, id := range runtimeIDs {
+		if req := s.PopPending(id); req != nil {
+			out = append(out, req)
+		}
+	}
+	return out
+}
+
+func (s *ModelListStore) Complete(id string, models []ModelEntry, supported bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req, ok := s.requests[id]; ok {
+		req.Status = ModelListCompleted
+		req.Models = models
+		req.Supported = supported
+		req.UpdatedAt = time.Now()
+	}
+}
+
+func (s *ModelListStore) Fail(id string, errMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req, ok := s.requests[id]; ok {
+		req.Status = ModelListFailed
+		req.Error = errMsg
+		req.UpdatedAt = time.Now()
+	}
+}
+
+func modelListRequestTerminal(status ModelListStatus) bool {
+	return status == ModelListCompleted || status == ModelListFailed || status == ModelListTimeout
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+// InitiateListModels creates a pending model list request for a runtime.
+// Called by the frontend; the daemon picks it up on its next heartbeat.
+func (h *Handler) InitiateListModels(w http.ResponseWriter, r *http.Request) {
+	rt, ok := h.requireRuntimeAccess(w, r)
+	if !ok {
+		return
+	}
+	if rt.Status != "online" {
+		writeError(w, http.StatusServiceUnavailable, "runtime is offline")
+		return
+	}
+
+	req := h.ModelListStore.Create(uuidToString(rt.ID))
+	writeJSON(w, http.StatusOK, req)
+}
+
+// GetModelListRequest returns the status of a model list request.
+func (h *Handler) GetModelListRequest(w http.ResponseWriter, r *http.Request) {
+	requestID := chi.URLParam(r, "requestId")
+
+	req := h.ModelListStore.Get(requestID)
+	if req == nil {
+		writeError(w, http.StatusNotFound, "request not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, req)
+}
+
+// ReportModelListResult receives the list result from the daemon.
+func (h *Handler) ReportModelListResult(w http.ResponseWriter, r *http.Request) {
+	runtimeID := chi.URLParam(r, "runtimeId")
+	requestID := chi.URLParam(r, "requestId")
+
+	// Fetch first so we can ignore stale reports for already-terminal
+	// requests (e.g. the heartbeat response that triggered the daemon
+	// run was a retry, and the original report already landed).
+	existing := h.ModelListStore.Get(requestID)
+	if existing == nil || existing.RuntimeID != runtimeID {
+		writeError(w, http.StatusNotFound, "request not found")
+		return
+	}
+	if modelListRequestTerminal(existing.Status) {
+		slog.Debug("ignoring stale model list report", "runtime_id", runtimeID, "request_id", requestID, "status", existing.Status)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	var body struct {
+		Status    string       `json:"status"` // "completed" or "failed"
+		Models    []ModelEntry `json:"models"`
+		Supported *bool        `json:"supported"`
+		Error     string       `json:"error"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if body.Status == "completed" {
+		supported := true
+		if body.Supported != nil {
+			supported = *body.Supported
+		}
+		h.ModelListStore.Complete(requestID, body.Models, supported)
+	} else {
+		h.ModelListStore.Fail(requestID, body.Error)
+	}
+
+	slog.Debug("model list report", "runtime_id", runtimeID, "request_id", requestID, "status", body.Status, "count", len(body.Models))
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/server/internal/handler/runtime_models_test.go
+++ b/server/internal/handler/runtime_models_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestModelListStoreLifecycle(t *testing.T) {
+	s := NewModelListStore()
+
+	req := s.Create("rt-1")
+	if req.ID == "" || req.RuntimeID != "rt-1" || req.Status != ModelListPending {
+		t.Fatalf("unexpected created request: %+v", req)
+	}
+	if !req.Supported {
+		t.Fatalf("supported should default to true")
+	}
+
+	// Pop claims the request and moves it to running.
+	popped := s.PopPending("rt-1")
+	if popped == nil || popped.ID != req.ID || popped.Status != ModelListRunning {
+		t.Fatalf("unexpected popped request: %+v", popped)
+	}
+	// A second pop finds nothing.
+	if again := s.PopPending("rt-1"); again != nil {
+		t.Fatalf("expected nil on second pop, got %+v", again)
+	}
+
+	// Complete stores the models and supported flag.
+	s.Complete(req.ID, []ModelEntry{{ID: "m1", Label: "M1", Default: true}}, true)
+	got := s.Get(req.ID)
+	if got == nil || got.Status != ModelListCompleted || len(got.Models) != 1 || !got.Models[0].Default {
+		t.Fatalf("unexpected completed request: %+v", got)
+	}
+}
+
+func TestModelListStorePopPendingForRuntimes(t *testing.T) {
+	s := NewModelListStore()
+	a := s.Create("rt-a")
+	s.Create("rt-b")
+
+	popped := s.PopPendingForRuntimes([]string{"rt-a", "rt-b", "rt-c"})
+	if len(popped) != 2 {
+		t.Fatalf("expected 2 popped requests, got %d", len(popped))
+	}
+	if popped[0].ID != a.ID {
+		t.Fatalf("expected rt-a request first, got %+v", popped[0])
+	}
+}
+
+func TestModelListStoreFail(t *testing.T) {
+	s := NewModelListStore()
+	req := s.Create("rt-1")
+	s.Fail(req.ID, "boom")
+	got := s.Get(req.ID)
+	if got.Status != ModelListFailed || got.Error != "boom" {
+		t.Fatalf("unexpected failed request: %+v", got)
+	}
+	if !modelListRequestTerminal(got.Status) {
+		t.Fatalf("failed should be terminal")
+	}
+}
+
+func TestApplyModelListTimeout(t *testing.T) {
+	now := time.Now()
+
+	pending := &ModelListRequest{Status: ModelListPending, CreatedAt: now.Add(-time.Minute)}
+	if !applyModelListTimeout(pending, now) || pending.Status != ModelListTimeout {
+		t.Fatalf("stale pending should time out: %+v", pending)
+	}
+
+	fresh := &ModelListRequest{Status: ModelListPending, CreatedAt: now}
+	if applyModelListTimeout(fresh, now) {
+		t.Fatalf("fresh pending should not time out")
+	}
+
+	started := now.Add(-2 * time.Minute)
+	running := &ModelListRequest{Status: ModelListRunning, CreatedAt: started, runStartedAt: &started}
+	if !applyModelListTimeout(running, now) || running.Status != ModelListTimeout {
+		t.Fatalf("stuck running should time out: %+v", running)
+	}
+
+	done := &ModelListRequest{Status: ModelListCompleted, CreatedAt: now.Add(-time.Hour)}
+	if applyModelListTimeout(done, now) {
+		t.Fatalf("terminal request should never transition")
+	}
+}
+
+func TestValidateModelConfig(t *testing.T) {
+	cases := []struct {
+		name   string
+		mc     map[string]AgentModelConfig
+		wantOK bool
+	}{
+		{"nil config", nil, true},
+		{"empty config", map[string]AgentModelConfig{}, true},
+		{"model only", map[string]AgentModelConfig{"claude": {Model: "claude-fable-5"}}, true},
+		{"valid claude thinking", map[string]AgentModelConfig{"claude": {Model: "claude-opus-4-8", ThinkingLevel: "xhigh"}}, true},
+		{"valid codex thinking", map[string]AgentModelConfig{"codex": {ThinkingLevel: "minimal"}}, true},
+		{"invalid claude thinking", map[string]AgentModelConfig{"claude": {ThinkingLevel: "warp9"}}, false},
+		{"thinking on unknown provider", map[string]AgentModelConfig{"gemini": {ThinkingLevel: "high"}}, false},
+		{"opencode variant name", map[string]AgentModelConfig{"opencode": {ThinkingLevel: "fast-mode"}}, true},
+		{"opencode invalid variant", map[string]AgentModelConfig{"opencode": {ThinkingLevel: "no spaces allowed"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validateModelConfig(tc.mc)
+			if (msg == "") != tc.wantOK {
+				t.Fatalf("validateModelConfig(%+v) = %q, wantOK=%v", tc.mc, msg, tc.wantOK)
+			}
+		})
+	}
+}

--- a/server/migrations/070_agent_model_config.down.sql
+++ b/server/migrations/070_agent_model_config.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN model_config;

--- a/server/migrations/070_agent_model_config.up.sql
+++ b/server/migrations/070_agent_model_config.up.sql
@@ -1,0 +1,4 @@
+-- Per-provider model configuration for agents. Keyed by provider, e.g.
+-- {"claude": {"model": "claude-fable-5", "thinking_level": "high"}}.
+-- Empty object means "no overrides" — each provider CLI picks its own default.
+ALTER TABLE agent ADD COLUMN model_config JSONB NOT NULL DEFAULT '{}';

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,10 +1,11 @@
 // Package agent provides a unified interface for executing prompts via
-// coding agents (Claude Code, Codex, OpenCode). It mirrors the happy-cli AgentBackend
-// pattern, translated to idiomatic Go.
+// coding agents (Claude Code, Codex, OpenCode, Cursor). It mirrors the
+// happy-cli AgentBackend pattern, translated to idiomatic Go.
 package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -20,12 +21,38 @@ type Backend interface {
 
 // ExecOptions configures a single execution.
 type ExecOptions struct {
-	Cwd             string
-	Model           string
-	SystemPrompt    string
-	MaxTurns        int
-	Timeout         time.Duration
-	ResumeSessionID string // if non-empty, resume a previous agent session
+	Cwd                       string
+	Model                     string
+	SystemPrompt              string
+	ThreadName                string
+	MaxTurns                  int
+	Timeout                   time.Duration
+	SemanticInactivityTimeout time.Duration
+	ResumeSessionID           string          // if non-empty, resume a previous agent session
+	ExtraArgs                 []string        // daemon-wide default CLI arguments appended before CustomArgs
+	CustomArgs                []string        // per-agent CLI arguments appended after ExtraArgs
+	McpConfig                 json.RawMessage // if non-nil, MCP server config to pass via --mcp-config
+	// ThinkingLevel is the runtime-native reasoning/effort value (e.g.
+	// Claude's "low|medium|high|xhigh|max", Codex's "none|minimal|low|
+	// medium|high|xhigh", OpenCode's model variant names). Empty means
+	// "use the runtime/model default" — every backend that consumes this
+	// skips its --effort / reasoning_effort injection so the upstream
+	// CLI's own default applies. Backends that don't support the concept
+	// ignore the field rather than fail.
+	ThinkingLevel string
+}
+
+// runContext derives the execution context for an agent subprocess from the
+// configured per-run timeout. A positive timeout imposes a hard wall-clock
+// deadline; a zero (or negative) timeout imposes NO deadline, leaving
+// liveness to the caller's own watchdog so a session that keeps emitting
+// events is never killed merely for running long. The caller owns the
+// returned CancelFunc and must call it to release resources.
+func runContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return context.WithCancel(ctx)
 }
 
 // Session represents a running agent execution.
@@ -52,14 +79,23 @@ const (
 
 // Message is a unified event emitted by an agent during execution.
 type Message struct {
-	Type    MessageType
-	Content string         // text content (Text, Error, Log)
-	Tool    string         // tool name (ToolUse, ToolResult)
-	CallID  string         // tool call ID (ToolUse, ToolResult)
-	Input   map[string]any // tool input (ToolUse)
-	Output  string         // tool output (ToolResult)
-	Status  string         // agent status string (Status)
-	Level   string         // log level (Log)
+	Type      MessageType
+	Content   string         // text content (Text, Error, Log)
+	Tool      string         // tool name (ToolUse, ToolResult)
+	CallID    string         // tool call ID (ToolUse, ToolResult)
+	Input     map[string]any // tool input (ToolUse)
+	Output    string         // tool output (ToolResult)
+	Status    string         // agent status string (Status)
+	Level     string         // log level (Log)
+	SessionID string         // backend session id (Status), for early resume-pointer pinning
+}
+
+// TokenUsage tracks token consumption for a single model.
+type TokenUsage struct {
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
 }
 
 // Result is the final outcome after an agent session completes.
@@ -69,11 +105,12 @@ type Result struct {
 	Error      string // error message if failed
 	DurationMs int64
 	SessionID  string
+	Usage      map[string]TokenUsage // keyed by model name
 }
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, or opencode)
+	ExecutablePath string            // path to CLI binary (claude, codex, opencode, or cursor-agent)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -28,31 +30,36 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}
 
 	timeout := opts.Timeout
-	if timeout == 0 {
-		timeout = 20 * time.Minute
-	}
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	runCtx, cancel := runContext(ctx, timeout)
 
-	args := []string{
-		"--output-format", "stream-json",
-		"--verbose",
-		"--permission-mode", "bypassPermissions",
+	args := buildClaudeArgs(opts, b.cfg.Logger)
+
+	// If the caller provided an MCP config, write it to a temp file and pass
+	// --mcp-config <path> so the agent uses a controlled set of MCP servers
+	// instead of inheriting from the outer Claude Code session.
+	var mcpConfigPath string
+	var mcpFileCleanup func() // non-nil while this function owns the temp file
+	if len(opts.McpConfig) > 0 {
+		path, err := writeMcpConfigToTemp(opts.McpConfig)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		mcpConfigPath = path
+		mcpFileCleanup = func() { os.Remove(mcpConfigPath) }
+		args = append(args, "--mcp-config", mcpConfigPath)
 	}
-	if opts.Model != "" {
-		args = append(args, "--model", opts.Model)
-	}
-	if opts.MaxTurns > 0 {
-		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
-	}
-	if opts.SystemPrompt != "" {
-		args = append(args, "--append-system-prompt", opts.SystemPrompt)
-	}
-	if opts.ResumeSessionID != "" {
-		args = append(args, "--resume", opts.ResumeSessionID)
-	}
-	args = append(args, "-p", prompt)
+	// Clean up the temp file if we return before the goroutine takes ownership.
+	defer func() {
+		if mcpFileCleanup != nil {
+			mcpFileCleanup()
+		}
+	}()
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
+	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
@@ -68,29 +75,74 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("claude stdin pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[claude:stderr] ")
+	var closeStdinOnce sync.Once
+	closeStdin := func() { closeStdinOnce.Do(func() { _ = stdin.Close() }) }
+	// Capture stderr into both the daemon log (as before) and a bounded tail
+	// buffer so we can include the last few KB in Result.Error when claude
+	// exits unexpectedly. Without the tail, an exit-code-only failure looks
+	// like "claude exited with error: exit status 3" — which is useless for
+	// root-causing V8 aborts, Bun panics, or any other CLI-side crash.
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[claude:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
+		closeStdin()
 		cancel()
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
 
 	b.cfg.Logger.Info("claude started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
+	// cmd.Start() succeeded — transfer temp file ownership to the goroutine.
+	mcpFileCleanup = nil
+
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
+
+	// writeClaudeInput runs in its own goroutine so it cannot deadlock
+	// against the stdout reader. With --verbose --output-format stream-json
+	// the CLI emits a startup banner before reading its first stdin frame;
+	// if nothing is draining stdout while we write the prompt, claude blocks
+	// writing stdout, never reads stdin, and our Write blocks until runCtx
+	// fires. The field symptom is "write |1: The pipe has been ended."
+	// surfacing exactly at the per-task timeout when the kill invalidates
+	// the still-blocked pipe.
+	//
+	// Keep stdin open after the initial user message. Claude's stream-json
+	// protocol can emit control_request events mid-run and expects matching
+	// control_response frames on the same input stream; closing stdin here
+	// leaves the child stuck waiting for a response until its own fallback
+	// timeout.
+	writeDone := make(chan error, 1)
+	go func() {
+		err := writeClaudeInput(stdin, prompt)
+		if err != nil {
+			closeStdin()
+		}
+		writeDone <- err
+	}()
 
 	go func() {
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
-		defer stdin.Close()
+		if mcpConfigPath != "" {
+			defer os.Remove(mcpConfigPath)
+		}
 
 		startTime := time.Now()
 		var output strings.Builder
 		var sessionID string
 		finalStatus := "completed"
 		var finalError string
+		usage := make(map[string]TokenUsage)
+
+		// Close stdout when the context is cancelled so scanner.Scan() unblocks.
+		go func() {
+			<-runCtx.Done()
+			closeStdin()
+			_ = stdout.Close()
+		}()
 
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -108,24 +160,28 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 			switch msg.Type {
 			case "assistant":
-				b.handleAssistant(msg, msgCh, &output)
+				b.handleAssistant(msg, msgCh, &output, usage)
 			case "user":
 				b.handleUser(msg, msgCh)
 			case "system":
 				if msg.SessionID != "" {
 					sessionID = msg.SessionID
 				}
-				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
+				trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 			case "result":
 				sessionID = msg.SessionID
 				if msg.ResultText != "" {
 					output.Reset()
 					output.WriteString(msg.ResultText)
 				}
+				if resultUsage := claudeResultUsage(msg, opts.Model); len(resultUsage) > 0 {
+					usage = resultUsage
+				}
 				if msg.IsError {
 					finalStatus = "failed"
 					finalError = msg.ResultText
 				}
+				closeStdin()
 			case "log":
 				if msg.Log != nil {
 					trySend(msgCh, Message{
@@ -139,39 +195,80 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			}
 		}
 
+		closeStdin()
+
 		// Wait for process exit
 		exitErr := cmd.Wait()
 		duration := time.Since(startTime)
+		// writeDone is buffered (cap 1) and the writer always sends — by the
+		// time cmd has exited, the prompt write has either succeeded, hit a
+		// broken pipe, or been unblocked by the kill that ended cmd.
+		writeErr := <-writeDone
 
-		if runCtx.Err() == context.DeadlineExceeded {
+		switch {
+		case runCtx.Err() == context.DeadlineExceeded:
 			finalStatus = "timeout"
 			finalError = fmt.Sprintf("claude timed out after %s", timeout)
-		} else if runCtx.Err() == context.Canceled {
+		case runCtx.Err() == context.Canceled:
 			finalStatus = "aborted"
 			finalError = "execution cancelled"
-		} else if exitErr != nil && finalStatus == "completed" {
+		case writeErr != nil && finalStatus == "completed" && sessionID == "":
+			// No result event landed and the prompt write failed — claude
+			// died before reading the prompt. Surface the write error; the
+			// stderr tail attached below carries the real reason.
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("write claude input: %v", writeErr)
+		case exitErr != nil && finalStatus == "completed":
 			finalStatus = "failed"
 			finalError = fmt.Sprintf("claude exited with error: %v", exitErr)
 		}
 
+		// cmd.Wait() has returned — os/exec's stderr copy goroutine has
+		// observed every byte claude wrote to stderr before exiting, so
+		// stderrBuf.Tail() is safe to sample now. Attach the tail to any
+		// non-empty failure message; callers upstream surface this as the
+		// task's error field, which is the only place users see it.
+		if finalError != "" {
+			finalError = withAgentStderr(finalError, "claude", stderrBuf.Tail())
+		}
+
 		b.cfg.Logger.Info("claude finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		reportedSessionID := resolveSessionID(opts.ResumeSessionID, sessionID, finalStatus == "failed")
+		if reportedSessionID != sessionID {
+			b.cfg.Logger.Info("claude resume did not land; clearing fresh session id for daemon fallback",
+				"requested_resume", opts.ResumeSessionID,
+				"emitted_session", sessionID,
+			)
+		}
 
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     output.String(),
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
-			SessionID:  sessionID,
+			SessionID:  reportedSessionID,
+			Usage:      usage,
 		}
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message, output *strings.Builder) {
+func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message, output *strings.Builder, usage map[string]TokenUsage) {
 	var content claudeMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
 		return
+	}
+
+	// Accumulate token usage per model.
+	if content.Usage != nil && content.Model != "" {
+		u := usage[content.Model]
+		u.InputTokens += content.Usage.InputTokens
+		u.OutputTokens += content.Usage.OutputTokens
+		u.CacheReadTokens += content.Usage.CacheReadInputTokens
+		u.CacheWriteTokens += content.Usage.CacheCreationInputTokens
+		usage[content.Model] = u
 	}
 
 	for _, block := range content.Content {
@@ -266,12 +363,15 @@ type claudeSDKMessage struct {
 	Message   json.RawMessage `json:"message,omitempty"`
 	Subtype   string          `json:"subtype,omitempty"`
 	SessionID string          `json:"session_id,omitempty"`
+	Model     string          `json:"model,omitempty"`
 
 	// result fields
-	ResultText string  `json:"result,omitempty"`
-	IsError    bool    `json:"is_error,omitempty"`
-	DurationMs float64 `json:"duration_ms,omitempty"`
-	NumTurns   int     `json:"num_turns,omitempty"`
+	ResultText string                            `json:"result,omitempty"`
+	IsError    bool                              `json:"is_error,omitempty"`
+	DurationMs float64                           `json:"duration_ms,omitempty"`
+	NumTurns   int                               `json:"num_turns,omitempty"`
+	Usage      *claudeUsage                      `json:"usage,omitempty"`
+	ModelUsage map[string]claudeResultModelUsage `json:"modelUsage,omitempty"`
 
 	// log fields
 	Log *claudeLogEntry `json:"log,omitempty"`
@@ -288,7 +388,68 @@ type claudeLogEntry struct {
 
 type claudeMessageContent struct {
 	Role    string               `json:"role"`
+	Model   string               `json:"model"`
 	Content []claudeContentBlock `json:"content"`
+	Usage   *claudeUsage         `json:"usage,omitempty"`
+}
+
+type claudeUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+}
+
+type claudeResultModelUsage struct {
+	InputTokens              int64 `json:"inputTokens"`
+	OutputTokens             int64 `json:"outputTokens"`
+	CacheReadInputTokens     int64 `json:"cacheReadInputTokens"`
+	CacheCreationInputTokens int64 `json:"cacheCreationInputTokens"`
+}
+
+func claudeResultUsage(msg claudeSDKMessage, fallbackModel string) map[string]TokenUsage {
+	if len(msg.ModelUsage) > 0 {
+		usage := make(map[string]TokenUsage, len(msg.ModelUsage))
+		for model, u := range msg.ModelUsage {
+			if model == "" || !claudeUsageHasTokens(u.InputTokens, u.OutputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens) {
+				continue
+			}
+			usage[model] = TokenUsage{
+				InputTokens:      u.InputTokens,
+				OutputTokens:     u.OutputTokens,
+				CacheReadTokens:  u.CacheReadInputTokens,
+				CacheWriteTokens: u.CacheCreationInputTokens,
+			}
+		}
+		if len(usage) > 0 {
+			return usage
+		}
+	}
+
+	model := msg.Model
+	if model == "" {
+		model = fallbackModel
+	}
+	if msg.Usage == nil || model == "" || !claudeUsageHasTokens(
+		msg.Usage.InputTokens,
+		msg.Usage.OutputTokens,
+		msg.Usage.CacheReadInputTokens,
+		msg.Usage.CacheCreationInputTokens,
+	) {
+		return nil
+	}
+	return map[string]TokenUsage{
+		model: {
+			InputTokens:      msg.Usage.InputTokens,
+			OutputTokens:     msg.Usage.OutputTokens,
+			CacheReadTokens:  msg.Usage.CacheReadInputTokens,
+			CacheWriteTokens: msg.Usage.CacheCreationInputTokens,
+		},
+	}
+}
+
+func claudeUsageHasTokens(input, output, cacheRead, cacheWrite int64) bool {
+	return input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0
 }
 
 type claudeContentBlock struct {
@@ -318,23 +479,139 @@ func trySend(ch chan<- Message, msg Message) {
 	}
 }
 
-func buildEnv(extra map[string]string) []string {
-	return buildEnvOmitting(extra)
+// claudeBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. Overriding these would break
+// the daemon↔Claude communication protocol.
+var claudeBlockedArgs = map[string]blockedArgMode{
+	"-p":                blockedStandalone, // non-interactive mode
+	"--output-format":   blockedWithValue,  // stream-json protocol
+	"--input-format":    blockedWithValue,  // stream-json protocol
+	"--permission-mode": blockedWithValue,  // bypassPermissions for autonomous operation
+	"--mcp-config":      blockedWithValue,  // set by daemon from agent.mcp_config
+	// `--effort` is owned by the per-agent thinking_level picker so a
+	// user-supplied custom_arg cannot silently outvote it. The daemon
+	// injects --effort only when opts.ThinkingLevel is set; if a user
+	// nevertheless writes it in custom_args we drop the duplicate and
+	// log a warning rather than letting the CLI receive two conflicting
+	// --effort values.
+	"--effort": blockedWithValue,
 }
 
+func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		"--verbose",
+		"--strict-mcp-config",
+		"--permission-mode", "bypassPermissions",
+		// AskUserQuestion is Claude Code's built-in interactive question tool.
+		// The daemon runs Claude in non-interactive stream-json mode and has
+		// no UI for the prompt to render in, so a call returns an empty
+		// answer and the agent ends up "inferring" silently — the user
+		// never sees the question. User-facing clarification belongs in an
+		// issue comment instead.
+		"--disallowedTools", "AskUserQuestion",
+	}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	if opts.ThinkingLevel != "" {
+		// Slotted right after --model so the per-session effort runs
+		// against the same model selection the args advertise; the CLI
+		// itself accepts the flag in any order but this ordering makes
+		// the launch line readable in `agent command` logs.
+		args = append(args, "--effort", opts.ThinkingLevel)
+	}
+	if opts.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
+	}
+	if opts.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", opts.SystemPrompt)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	args = append(args, filterCustomArgs(opts.ExtraArgs, claudeBlockedArgs, logger)...)
+	args = append(args, filterCustomArgs(opts.CustomArgs, claudeBlockedArgs, logger)...)
+	return args
+}
+
+func writeClaudeInput(w io.Writer, prompt string) error {
+	data, err := buildClaudeInput(prompt)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildClaudeInput(prompt string) ([]byte, error) {
+	payload := map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"role": "user",
+			"content": []map[string]string{
+				{
+					"type": "text",
+					"text": prompt,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claude input: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// resolveSessionID decides which session id to report on the Result. When the
+// caller requested --resume but claude emitted a fresh, different session id
+// AND the run failed, the resume did not land (claude prints
+// "No conversation found with session ID: ..." to stderr, generates a fresh
+// session, and exits). Returning "" in that case keeps the daemon's
+// retry-with-fresh-session fallback able to trigger, instead of silently
+// persisting a brand-new id as if resume had succeeded.
+func resolveSessionID(requestedResume, emitted string, failed bool) string {
+	if failed && requestedResume != "" && emitted != "" && emitted != requestedResume {
+		return ""
+	}
+	return emitted
+}
+
+func buildEnv(extra map[string]string) []string {
+	return mergeEnv(os.Environ(), extra)
+}
+
+// buildEnvOmitting builds the child env like buildEnv but additionally drops
+// the named inherited keys (the caller can still set them via extra).
 func buildEnvOmitting(extra map[string]string, omittedKeys ...string) []string {
 	omit := make(map[string]bool, len(omittedKeys))
 	for _, key := range omittedKeys {
 		omit[key] = true
 	}
-
-	env := make([]string, 0, len(os.Environ())+len(extra))
+	base := make([]string, 0, len(os.Environ()))
 	for _, item := range os.Environ() {
 		key, _, ok := strings.Cut(item, "=")
 		if ok && omit[key] {
 			continue
 		}
-		env = append(env, item)
+		base = append(base, item)
+	}
+	return mergeEnv(base, extra)
+}
+
+func mergeEnv(base []string, extra map[string]string) []string {
+	env := make([]string, 0, len(base)+len(extra))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if isFilteredChildEnvKey(key) {
+			continue
+		}
+		env = append(env, entry)
 	}
 	for k, v := range extra {
 		env = append(env, k+"="+v)
@@ -342,13 +619,173 @@ func buildEnvOmitting(extra map[string]string, omittedKeys ...string) []string {
 	return env
 }
 
+// isFilteredChildEnvKey reports whether an inherited env var is an internal
+// Claude Code runtime/session marker that must NOT leak into the spawned child
+// (otherwise the child mistakes itself for a nested or resumed session, or
+// inherits the parent's exec path / transport).
+//
+// It must NOT strip the user-facing CLAUDE_CODE_* configuration namespace
+// (CLAUDE_CODE_GIT_BASH_PATH, CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_VERTEX,
+// CLAUDE_CODE_MAX_OUTPUT_TOKENS, CLAUDE_CODE_TMPDIR, ...): users set those
+// deliberately and the child needs them. Blanket-stripping the whole prefix
+// breaks Windows — CLAUDE_CODE_GIT_BASH_PATH would be silently removed, so
+// Claude Code could not find bash.exe and exited immediately. Strip internal
+// markers by exact name and let every other CLAUDE_CODE_* var through.
+func isFilteredChildEnvKey(key string) bool {
+	switch key {
+	case "CLAUDECODE", // "1" when running inside Claude Code
+		"CLAUDE_CODE_ENTRYPOINT", // entrypoint marker (cli/sdk-cli/...)
+		"CLAUDE_CODE_EXECPATH",   // path to the running CLI binary
+		"CLAUDE_CODE_SESSION_ID", // per-session identifier
+		"CLAUDE_CODE_SSE_PORT":   // IDE-extension transport port
+		return true
+	}
+	// CLAUDECODE_* (no underscore between CLAUDE and CODE) is wholly internal;
+	// keep stripping it. The user-facing config namespace is CLAUDE_CODE_*.
+	return strings.HasPrefix(key, "CLAUDECODE_")
+}
+
+// blockedArgMode specifies whether a blocked arg takes a value or is standalone.
+type blockedArgMode int
+
+const (
+	blockedWithValue  blockedArgMode = iota // flag takes a value (next arg or =value)
+	blockedStandalone                       // flag is boolean, no value
+)
+
+// filterCustomArgs removes protocol-critical flags from user-configured custom
+// args to prevent breaking daemon↔agent communication. Each backend defines its
+// own blocked set (the flags it hardcodes). This is intentionally narrow — we
+// only block args that would break the communication protocol, not every
+// possible dangerous flag. Workspace members are trusted to configure agents
+// sensibly, same as with custom env vars.
+//
+// Shell quoting is stripped from each arg before processing: users commonly
+// type custom_args in config fields using shell syntax (e.g.
+// --deny-tool='write'). Since the daemon spawns processes directly without a
+// shell, those quotes would otherwise be passed literally to the child process,
+// which typically rejects them as unrecognised flag values.
+func filterCustomArgs(args []string, blocked map[string]blockedArgMode, logger *slog.Logger) []string {
+	if len(args) == 0 {
+		return args
+	}
+	filtered := make([]string, 0, len(args))
+	skip := false
+	for _, raw := range args {
+		if skip {
+			skip = false
+			continue
+		}
+		arg := unshellQuoteArg(raw)
+		flag := arg
+		hasInlineValue := false
+		if idx := strings.Index(arg, "="); idx > 0 {
+			flag = arg[:idx]
+			hasInlineValue = true
+		}
+		mode, isBlocked := blocked[flag]
+		if isBlocked {
+			logger.Warn("custom_args: blocked protocol-critical flag, skipping", "flag", flag)
+			if mode == blockedWithValue && !hasInlineValue {
+				// The next arg is the value for this flag — skip it too.
+				skip = true
+			}
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+// unshellQuoteArg strips a single layer of shell-style single or double quotes
+// from an argument. It handles two forms:
+//
+//   - --flag='value' or --flag="value" → --flag=value
+//   - 'standalone' or "standalone"     → standalone
+//
+// Only flag-style args (`-x=…`, `--flag=…`) get inline value unquoting. Plain
+// assignment syntax like `model="o3"` is left alone because the quotes may be
+// semantic for the child process (for example Codex `-c model="o3"`). Only
+// matching outer quotes are stripped; no escape processing is done.
+func unshellQuoteArg(arg string) string {
+	if strings.HasPrefix(arg, "-") {
+		if idx := strings.Index(arg, "="); idx > 0 {
+			value := arg[idx+1:]
+			if unquoted, ok := stripSurroundingQuotes(value); ok {
+				return arg[:idx+1] + unquoted
+			}
+			return arg
+		}
+	}
+	if unquoted, ok := stripSurroundingQuotes(arg); ok {
+		return unquoted
+	}
+	return arg
+}
+
+// stripSurroundingQuotes removes a matching outer pair of single or double
+// quotes from s and returns (unquoted, true). Returns (s, false) if s does not
+// start and end with the same quote character.
+func stripSurroundingQuotes(s string) (string, bool) {
+	if len(s) >= 2 {
+		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+			return s[1 : len(s)-1], true
+		}
+	}
+	return s, false
+}
+
+// writeMcpConfigToTemp writes raw MCP config JSON to a temporary file and returns
+// its path. The caller is responsible for removing the file when done.
+func writeMcpConfigToTemp(raw json.RawMessage) (string, error) {
+	f, err := os.CreateTemp("", "multica-mcp-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create mcp config temp file: %w", err)
+	}
+	if _, err := f.Write(raw); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("write mcp config temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("close mcp config temp file: %w", err)
+	}
+	return f.Name(), nil
+}
+
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
 	cmd := exec.CommandContext(ctx, execPath, "--version")
+	hideAgentWindow(cmd)
 	data, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("detect version for %s: %w", execPath, err)
 	}
-	return strings.TrimSpace(string(data)), nil
+	return extractVersionLine(string(data)), nil
+}
+
+// extractVersionLine pulls the version line out of a `<cli> --version` capture,
+// discarding leading shell noise. On Windows, npm-installed CLI shims emit
+// `chcp` output like `Active code page: 65001` before the real version reaches
+// stdout, and the raw concatenation would otherwise be persisted as the
+// runtime version.
+//
+// The heuristic: return the first non-empty line that contains a semver-shaped
+// token (matches versionRe). Full version strings like "2.1.5 (Claude Code)"
+// or "codex-cli 0.118.0" survive unchanged because the whole matching line is
+// returned. If no line carries a semver token, fall back to the trimmed raw
+// output so unusual version formats aren't silently dropped to empty.
+func extractVersionLine(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if versionRe.MatchString(line) {
+			return line
+		}
+	}
+	return strings.TrimSpace(raw)
 }
 
 // logWriter adapts a *slog.Logger to an io.Writer for capturing stderr.

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -1,0 +1,196 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMain intercepts when the test binary is re-executed as a fake
+// child process by the agent backend. The fake's behavior is selected via
+// CLAUDE_FAKE_MODE; absent that env var, this is a normal `go test` run.
+func TestMain(m *testing.M) {
+	switch mode := os.Getenv("CLAUDE_FAKE_MODE"); mode {
+	case "":
+		os.Exit(m.Run())
+	case "startup_stdout_burst":
+		runFakeClaudeStartupStdoutBurst()
+		os.Exit(0)
+	case "control_request":
+		runFakeClaudeControlRequest()
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown CLAUDE_FAKE_MODE: %q\n", mode)
+		os.Exit(2)
+	}
+}
+
+// runFakeClaudeStartupStdoutBurst writes ~256 KiB to stdout BEFORE
+// reading any byte from stdin, then reads the first stdin frame and emits a
+// stream-json result. Reproduces the stdio deadlock: if the daemon writes
+// the prompt to stdin before a stdout reader is running, the child blocks
+// writing stdout and the daemon blocks writing stdin — neither side can
+// progress until the per-task context times out and the child is killed.
+func runFakeClaudeStartupStdoutBurst() {
+	line := strings.Repeat("x", 1020)
+	bw := bufio.NewWriter(os.Stdout)
+	for i := 0; i < 256; i++ {
+		if _, err := fmt.Fprintf(bw, `{"type":"log","log":{"level":"info","message":"%s"}}`+"\n", line); err != nil {
+			os.Exit(11)
+		}
+	}
+	if err := bw.Flush(); err != nil {
+		os.Exit(12)
+	}
+	if _, err := bufio.NewReader(os.Stdin).ReadString('\n'); err != nil {
+		os.Exit(13)
+	}
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-deadlock","result":"done"}`)
+}
+
+func runFakeClaudeControlRequest() {
+	reader := bufio.NewReader(os.Stdin)
+	if _, err := reader.ReadString('\n'); err != nil {
+		fmt.Fprintf(os.Stderr, "read prompt: %v\n", err)
+		os.Exit(21)
+	}
+	fmt.Println(`{"type":"system","session_id":"sess-control"}`)
+	fmt.Println(`{"type":"control_request","request_id":"req-42","request":{"subtype":"tool_use","tool_name":"Bash","input":{"command":"pwd"}}}`)
+
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read control response: %v\n", err)
+		os.Exit(22)
+	}
+	var resp struct {
+		Type     string `json:"type"`
+		Response struct {
+			RequestID string `json:"request_id"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &resp); err != nil {
+		fmt.Fprintf(os.Stderr, "decode control response: %v\n", err)
+		os.Exit(23)
+	}
+	if resp.Type != "control_response" || resp.Response.RequestID != "req-42" {
+		fmt.Fprintf(os.Stderr, "unexpected control response: %s\n", line)
+		os.Exit(24)
+	}
+	fmt.Println(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"approved"}]}}`)
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-control","result":"done after control"}`)
+}
+
+// TestClaudeExecuteDoesNotDeadlockOnStartupStdoutBurst verifies that the
+// claude backend drains stdout concurrently with writing the prompt to
+// stdin. The buggy path serialises the two: writeClaudeInput runs before
+// the reader goroutine starts, so a child that emits startup output
+// before its first stdin read deadlocks both directions. Field evidence
+// in the daemon log shows tasks failing exactly at the 2 h per-task
+// timeout with "write |1: The pipe has been ended.", produced when
+// runCtx fires, the child is killed, and the blocked stdin Write
+// finally unwinds.
+//
+// The fake child writes 256 KiB to stdout then 128 KiB of prompt is
+// pushed at stdin — both well past any plausible OS pipe buffer
+// (Linux ~64 KiB, Windows 4-64 KiB) — so a regression here hangs until
+// the test deadline rather than passing slowly.
+func TestClaudeExecuteDoesNotDeadlockOnStartupStdoutBurst(t *testing.T) {
+	t.Parallel()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	backend, err := New("claude", Config{
+		ExecutablePath: self,
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "startup_stdout_burst"},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	// 128 KiB prompt forces writeClaudeInput to block until the child
+	// drains stdin, which the buggy code cannot reach because the reader
+	// goroutine hasn't started yet.
+	prompt := strings.Repeat("p", 128*1024)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, prompt, ExecOptions{Timeout: 20 * time.Second})
+	if err != nil {
+		t.Fatalf("execute returned error: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("timeout waiting for result — claude backend is deadlocked on writeClaudeInput because stdout is not being drained concurrently")
+	}
+}
+
+func TestClaudeExecuteRespondsToControlRequest(t *testing.T) {
+	t.Parallel()
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	backend, err := New("claude", Config{
+		ExecutablePath: self,
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "control_request"},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "run a command", ExecOptions{Timeout: 8 * time.Second})
+	if err != nil {
+		t.Fatalf("execute returned error: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "done after control" {
+			t.Fatalf("expected result output from fake claude, got %q", result.Output)
+		}
+		if result.SessionID != "sess-control" {
+			t.Fatalf("expected session id sess-control, got %q", result.SessionID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for result — claude backend did not answer control_request")
+	}
+}

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -2,10 +2,15 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClaudeHandleAssistantText(t *testing.T) {
@@ -25,7 +30,7 @@ func TestClaudeHandleAssistantText(t *testing.T) {
 		}),
 	}
 
-	b.handleAssistant(msg, ch, &output)
+	b.handleAssistant(msg, ch, &output, make(map[string]TokenUsage))
 
 	if output.String() != "Hello world" {
 		t.Fatalf("expected output 'Hello world', got %q", output.String())
@@ -62,7 +67,7 @@ func TestClaudeHandleAssistantToolUse(t *testing.T) {
 		}),
 	}
 
-	b.handleAssistant(msg, ch, &output)
+	b.handleAssistant(msg, ch, &output, make(map[string]TokenUsage))
 
 	if output.String() != "" {
 		t.Fatalf("tool_use should not add to output, got %q", output.String())
@@ -162,7 +167,7 @@ func TestClaudeHandleAssistantInvalidJSON(t *testing.T) {
 	}
 
 	// Should not panic
-	b.handleAssistant(msg, ch, &output)
+	b.handleAssistant(msg, ch, &output, make(map[string]TokenUsage))
 
 	if output.String() != "" {
 		t.Fatalf("expected empty output for invalid JSON, got %q", output.String())
@@ -194,6 +199,279 @@ func TestTrySendDropsWhenFull(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{}, slog.Default())
+	expected := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		"--verbose",
+		"--strict-mcp-config",
+		"--permission-mode", "bypassPermissions",
+		"--disallowedTools", "AskUserQuestion",
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("expected args[%d] = %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestFilterCustomArgsBlocksProtocolFlags(t *testing.T) {
+	t.Parallel()
+
+	blocked := map[string]blockedArgMode{
+		"--output-format":   blockedWithValue,
+		"--permission-mode": blockedWithValue,
+		"-p":                blockedStandalone,
+	}
+	logger := slog.Default()
+
+	// Blocks flag with separate value
+	result := filterCustomArgs([]string{"--output-format", "text", "--model", "o3"}, blocked, logger)
+	if len(result) != 2 || result[0] != "--model" || result[1] != "o3" {
+		t.Fatalf("expected [--model o3], got %v", result)
+	}
+
+	// Blocks flag=value form
+	result = filterCustomArgs([]string{"--permission-mode=plan", "--verbose"}, blocked, logger)
+	if len(result) != 1 || result[0] != "--verbose" {
+		t.Fatalf("expected [--verbose], got %v", result)
+	}
+
+	// Blocks standalone short flags without consuming next arg
+	result = filterCustomArgs([]string{"-p", "--max-turns", "10"}, blocked, logger)
+	if len(result) != 2 || result[0] != "--max-turns" || result[1] != "10" {
+		t.Fatalf("expected [--max-turns 10], got %v", result)
+	}
+
+	// Passes through non-blocked args
+	result = filterCustomArgs([]string{"--model", "o3", "--max-turns", "50"}, blocked, logger)
+	if len(result) != 4 {
+		t.Fatalf("expected all 4 args to pass through, got %v", result)
+	}
+
+	// Handles nil blocked map
+	result = filterCustomArgs([]string{"--anything"}, nil, logger)
+	if len(result) != 1 {
+		t.Fatalf("expected args to pass through with nil blocked map, got %v", result)
+	}
+
+	// Handles empty args
+	result = filterCustomArgs(nil, blocked, logger)
+	if result != nil {
+		t.Fatalf("expected nil for nil input, got %v", result)
+	}
+}
+
+func TestFilterCustomArgsStripsShellQuotes(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.Default()
+
+	// Single-quoted inline value: --deny-tool='write' → --deny-tool=write
+	result := filterCustomArgs([]string{"--deny-tool='write'"}, nil, logger)
+	if len(result) != 1 || result[0] != "--deny-tool=write" {
+		t.Fatalf("expected [--deny-tool=write], got %v", result)
+	}
+
+	// Double-quoted inline value: --deny-tool="write" → --deny-tool=write
+	result = filterCustomArgs([]string{`--deny-tool="write"`}, nil, logger)
+	if len(result) != 1 || result[0] != "--deny-tool=write" {
+		t.Fatalf("expected [--deny-tool=write], got %v", result)
+	}
+
+	// Standalone quoted value: 'write' → write
+	result = filterCustomArgs([]string{"'write'"}, nil, logger)
+	if len(result) != 1 || result[0] != "write" {
+		t.Fatalf("expected [write], got %v", result)
+	}
+
+	// Non-flag assignments may use quotes semantically (for example Codex
+	// `-c model="o3"`), so they must survive unchanged.
+	result = filterCustomArgs([]string{`model="o3"`}, nil, logger)
+	if len(result) != 1 || result[0] != `model="o3"` {
+		t.Fatalf("expected [model=\"o3\"], got %v", result)
+	}
+
+	// Unquoted arg passes through unchanged
+	result = filterCustomArgs([]string{"--deny-tool=write"}, nil, logger)
+	if len(result) != 1 || result[0] != "--deny-tool=write" {
+		t.Fatalf("expected [--deny-tool=write], got %v", result)
+	}
+
+	// Mismatched quotes are not stripped
+	result = filterCustomArgs([]string{"--flag='val\""}, nil, logger)
+	if len(result) != 1 || result[0] != "--flag='val\"" {
+		t.Fatalf("mismatched quotes should not be stripped, got %v", result)
+	}
+
+	// Blocked flag with quoted value: the blocking still fires, the unquoted
+	// form passes the flag-match, and the arg is dropped.
+	blocked := map[string]blockedArgMode{"--output-format": blockedWithValue}
+	result = filterCustomArgs([]string{"--output-format='json'", "--verbose"}, blocked, logger)
+	if len(result) != 1 || result[0] != "--verbose" {
+		t.Fatalf("quoted blocked flag should still be dropped, got %v", result)
+	}
+}
+
+func TestBuildClaudeArgsPassesThroughCustomArgs(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{
+		CustomArgs: []string{"--max-turns", "50", "--verbose"},
+	}, slog.Default())
+
+	// Custom args should appear at the end
+	found := 0
+	for i, a := range args {
+		if a == "--max-turns" && i+1 < len(args) && args[i+1] == "50" {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Fatalf("expected --max-turns 50 in args: %v", args)
+	}
+}
+
+func TestBuildClaudeArgsFiltersBlockedCustomArgs(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{
+		CustomArgs: []string{"--output-format", "text", "--model", "o3"},
+	}, slog.Default())
+
+	// --output-format text should be stripped
+	for _, a := range args[len(args)-2:] {
+		if a == "text" {
+			// "text" should not be in the last args since --output-format was blocked
+			// The actual --output-format stream-json is earlier in the list
+		}
+	}
+	// --model o3 should pass through
+	foundModel := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "o3" {
+			foundModel = true
+		}
+		// Verify no duplicate --output-format with value "text"
+		if a == "--output-format" && i+1 < len(args) && args[i+1] == "text" {
+			t.Fatalf("blocked --output-format text should have been filtered: %v", args)
+		}
+	}
+	if !foundModel {
+		t.Fatalf("expected --model o3 in args but it was missing: %v", args)
+	}
+}
+
+func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
+	t.Parallel()
+
+	data, err := buildClaudeInput("say pong")
+	if err != nil {
+		t.Fatalf("buildClaudeInput: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("expected newline-terminated payload, got %q", data)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["type"] != "user" {
+		t.Fatalf("expected type user, got %v", payload["type"])
+	}
+
+	message, ok := payload["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected message object, got %T", payload["message"])
+	}
+	if message["role"] != "user" {
+		t.Fatalf("expected role user, got %v", message["role"])
+	}
+
+	content, ok := message["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("expected one content block, got %v", message["content"])
+	}
+	block, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected content block object, got %T", content[0])
+	}
+	if block["type"] != "text" || block["text"] != "say pong" {
+		t.Fatalf("unexpected content block: %v", block)
+	}
+}
+
+func TestMergeEnvFiltersClaudeCodeVars(t *testing.T) {
+	t.Parallel()
+
+	env := mergeEnv([]string{
+		"PATH=/usr/bin",
+		"CLAUDECODE=1",
+		"CLAUDE_CODE_ENTRYPOINT=cli",
+		"CLAUDE_CODE_EXECPATH=/opt/claude",
+		"CLAUDE_CODE_SESSION_ID=abc123",
+		"CLAUDE_CODE_SSE_PORT=9999",
+		"CLAUDECODEX=keep-me",
+		"CLAUDE_CODE_GIT_BASH_PATH=C:\\Program Files\\Git\\bin\\bash.exe",
+		"CLAUDE_CODE_USE_BEDROCK=1",
+		"CLAUDE_CODE_TMPDIR=/custom/tmp",
+	}, map[string]string{"FOO": "bar"})
+
+	// Internal runtime/session markers must be stripped so the child does not
+	// inherit the parent's identity or transport.
+	filteredOut := []string{
+		"CLAUDECODE=1",
+		"CLAUDE_CODE_ENTRYPOINT=cli",
+		"CLAUDE_CODE_EXECPATH=/opt/claude",
+		"CLAUDE_CODE_SESSION_ID=abc123",
+		"CLAUDE_CODE_SSE_PORT=9999",
+	}
+	for _, entry := range env {
+		for _, banned := range filteredOut {
+			if entry == banned {
+				t.Fatalf("expected internal Claude Code marker %q to be filtered, got %v", banned, env)
+			}
+		}
+	}
+
+	found := map[string]bool{}
+	for _, entry := range env {
+		found[entry] = true
+	}
+
+	if !found["PATH=/usr/bin"] {
+		t.Fatalf("expected PATH to be preserved, got %v", env)
+	}
+	if !found["CLAUDECODEX=keep-me"] {
+		t.Fatalf("expected unrelated env vars to be preserved, got %v", env)
+	}
+	// User-facing CLAUDE_CODE_* config must reach the child — stripping
+	// CLAUDE_CODE_GIT_BASH_PATH is what broke Claude Code on Windows (#3671).
+	if !found["CLAUDE_CODE_GIT_BASH_PATH=C:\\Program Files\\Git\\bin\\bash.exe"] {
+		t.Fatalf("expected CLAUDE_CODE_GIT_BASH_PATH to be preserved, got %v", env)
+	}
+	if !found["CLAUDE_CODE_USE_BEDROCK=1"] {
+		t.Fatalf("expected CLAUDE_CODE_USE_BEDROCK to be preserved, got %v", env)
+	}
+	// CLAUDE_CODE_TMPDIR is a documented user-configurable temp-dir override, not
+	// an internal per-session marker, so it must reach the child.
+	if !found["CLAUDE_CODE_TMPDIR=/custom/tmp"] {
+		t.Fatalf("expected CLAUDE_CODE_TMPDIR to be preserved, got %v", env)
+	}
+	if !found["FOO=bar"] {
+		t.Fatalf("expected extra env var to be appended, got %v", env)
+	}
+}
+
 func TestBuildEnvAppendsExtras(t *testing.T) {
 	t.Parallel()
 
@@ -218,27 +496,231 @@ func TestBuildEnvNilExtras(t *testing.T) {
 	}
 }
 
-func TestBuildEnvOmittingSkipsSystemEnv(t *testing.T) {
-	t.Setenv("OMIT_ME", "system")
+func TestBuildClaudeArgsBlocksMcpConfig(t *testing.T) {
+	t.Parallel()
 
-	env := buildEnvOmitting(map[string]string{"KEEP_ME": "extra"}, "OMIT_ME")
-	for _, item := range env {
-		if item == "OMIT_ME=system" {
-			t.Fatal("expected OMIT_ME to be omitted")
+	// --mcp-config is hardcoded by the daemon — it must not be overridable via custom_args.
+	args := buildClaudeArgs(ExecOptions{
+		CustomArgs: []string{"--mcp-config", "/tmp/evil.json", "--model", "o3"},
+	}, slog.Default())
+
+	for i, a := range args {
+		if a == "--mcp-config" {
+			t.Fatalf("--mcp-config should be blocked from custom_args, found at index %d: %v", i, args)
+		}
+		if a == "/tmp/evil.json" {
+			t.Fatalf("--mcp-config value should be consumed when blocking, but found it at index %d: %v", i, args)
 		}
 	}
-	if !containsEnv(env, "KEEP_ME=extra") {
-		t.Fatal("expected KEEP_ME extra env var")
+
+	// Non-blocked args should still pass through.
+	foundModel := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "o3" {
+			foundModel = true
+		}
+	}
+	if !foundModel {
+		t.Fatalf("expected --model o3 in args after blocking --mcp-config: %v", args)
 	}
 }
 
-func containsEnv(env []string, want string) bool {
-	for _, item := range env {
-		if item == want {
-			return true
-		}
+func TestWriteMcpConfigToTemp(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"mcpServers":{"test":{"command":"echo","args":["hello"]}}}`)
+	path, err := writeMcpConfigToTemp(raw)
+	if err != nil {
+		t.Fatalf("writeMcpConfigToTemp: %v", err)
 	}
-	return false
+
+	// File should exist and contain exactly the raw JSON.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temp file %s: %v", path, err)
+	}
+	if !bytes.Equal(data, []byte(raw)) {
+		t.Fatalf("expected %s, got %s", raw, data)
+	}
+
+	// Cleanup should remove the file.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove temp file: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected temp file to be removed, but it still exists")
+	}
+}
+
+func TestResolveSessionID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		requested string
+		emitted   string
+		failed    bool
+		want      string
+	}{
+		{
+			name:      "no resume requested propagates emitted",
+			requested: "",
+			emitted:   "fresh-abc",
+			failed:    false,
+			want:      "fresh-abc",
+		},
+		{
+			name:      "resume succeeded keeps matching id",
+			requested: "sess-old",
+			emitted:   "sess-old",
+			failed:    false,
+			want:      "sess-old",
+		},
+		{
+			name:      "resume succeeded but run failed mid-turn keeps id for later retry",
+			requested: "sess-old",
+			emitted:   "sess-old",
+			failed:    true,
+			want:      "sess-old",
+		},
+		{
+			name:      "resume did not land and run failed clears id so daemon fallback fires",
+			requested: "sess-dead",
+			emitted:   "fresh-new",
+			failed:    true,
+			want:      "",
+		},
+		{
+			name:      "resume did not land but run succeeded keeps fresh id (defensive)",
+			requested: "sess-dead",
+			emitted:   "fresh-new",
+			failed:    false,
+			want:      "fresh-new",
+		},
+		{
+			name:      "no emitted id leaves result empty",
+			requested: "sess-old",
+			emitted:   "",
+			failed:    true,
+			want:      "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveSessionID(tc.requested, tc.emitted, tc.failed)
+			if got != tc.want {
+				t.Fatalf("resolveSessionID(%q, %q, %v) = %q, want %q",
+					tc.requested, tc.emitted, tc.failed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeExecuteSurfacesStderrWhenChildExitsEarly(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Fake claude binary: reads the initial stdin frame so writeClaudeInput
+	// succeeds, writes a canonical V8-abort line to stderr, then exits
+	// non-zero before emitting any stream-json to stdout. This is the exact
+	// failure mode that motivated PR #1674 — without sampling stderrBuf.Tail()
+	// after cmd.Wait() returns, Result.Error would be a useless
+	// "exit status 3".
+	fakePath := filepath.Join(t.TempDir(), "claude")
+	script := "#!/bin/sh\n" +
+		"IFS= read -r _\n" +
+		"echo \"FATAL ERROR: V8 abort: assertion failed\" >&2\n" +
+		"exit 3\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Drain message stream so the lifecycle goroutine can progress.
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "claude exited with error") {
+			t.Fatalf("expected error to mention exit, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "V8 abort: assertion failed") {
+			t.Fatalf("expected error to include stderr hint, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "claude stderr:") {
+			t.Fatalf("expected stderr label in error, got %q", result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestClaudeExecuteRecordsResultModelUsage(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "claude")
+	script := "#!/bin/sh\n" +
+		"IFS= read -r _\n" +
+		"printf '%s\\n' '{\"type\":\"system\",\"session_id\":\"sess-result-usage\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"session_id\":\"sess-result-usage\",\"result\":\"done\",\"modelUsage\":{\"zhipu/coding-plan\":{\"inputTokens\":123,\"outputTokens\":45,\"cacheReadInputTokens\":7,\"cacheCreationInputTokens\":11,\"costUSD\":0.01}}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		usage, ok := result.Usage["zhipu/coding-plan"]
+		if !ok {
+			t.Fatalf("expected usage for zhipu/coding-plan, got %#v", result.Usage)
+		}
+		if usage.InputTokens != 123 || usage.OutputTokens != 45 || usage.CacheReadTokens != 7 || usage.CacheWriteTokens != 11 {
+			t.Fatalf("unexpected usage: %+v", usage)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
 }
 
 func mustMarshal(t *testing.T, v any) json.RawMessage {
@@ -248,4 +730,27 @@ func mustMarshal(t *testing.T, v any) json.RawMessage {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 	return data
+}
+
+func TestBuildClaudeArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
+	args := buildClaudeArgs(ExecOptions{
+		ExtraArgs:  []string{"--output-format", "text", "--max-budget-usd", "1.00"},
+		CustomArgs: []string{"--max-budget-usd", "2.00", "--permission-mode", "plan"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--output-format text") || strings.Contains(joined, "--permission-mode plan") {
+		t.Fatalf("blocked args should be filtered from both layers: %v", args)
+	}
+	extraIdx, customIdx := -1, -1
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--max-budget-usd" && args[i+1] == "1.00" {
+			extraIdx = i
+		}
+		if args[i] == "--max-budget-usd" && args[i+1] == "2.00" {
+			customIdx = i
+		}
+	}
+	if extraIdx == -1 || customIdx == -1 || extraIdx > customIdx {
+		t.Fatalf("expected extra args before custom args, got %v", args)
+	}
 }

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -2,19 +2,491 @@ package agent
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
+// codexBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. The mcp_servers config keys
+// live in the per-task `$CODEX_HOME/config.toml` (written by
+// ensureCodexMcpConfig); user-supplied `-c mcp_servers.…` overrides are
+// stripped separately by filterCodexCustomConfigOverrides because they
+// share the `-c` flag with legitimate non-MCP overrides like `-c model=…`.
+var codexBlockedArgs = map[string]blockedArgMode{
+	"--listen": blockedWithValue, // stdio:// transport for daemon communication
+}
+
+// codexStderrTailBytes bounds the stderr tail captured for inclusion in
+// error messages when codex exits before the JSON-RPC handshake (e.g. the
+// user supplied a custom_args flag that the `app-server` subcommand
+// rejects). Kept as its own constant so bumping codex independently of
+// other agents stays easy if codex starts shipping longer failure traces.
+const (
+	codexStderrTailBytes                   = 2048
+	defaultCodexSemanticInactivityTimeout  = 10 * time.Minute
+	defaultCodexFirstTurnNoProgressTimeout = 30 * time.Second
+	codexVersionDiagnosticTimeout          = 2 * time.Second
+	// codexGracefulShutdownTimeout bounds how long the lifecycle goroutine
+	// waits for codex to exit on its own after stdin is closed, before forcing
+	// a context-cancel kill. A clean exit lets codex run its shutdown path and
+	// flush buffered telemetry — OTEL batch exporters only force-flush on
+	// graceful shutdown, so killing it immediately drops the task's
+	// spans/metrics/logs.
+	codexGracefulShutdownTimeout = 10 * time.Second
+)
+
+// CodexSemanticInactivityMarker prefixes timeout errors emitted when Codex
+// stops making semantic progress while the process is still alive.
+const CodexSemanticInactivityMarker = "codex semantic inactivity timeout"
+
+// CodexFirstTurnNoProgressMarker identifies the app-server failure mode where
+// Codex accepts a turn and then never emits any item, completion, or error.
+const CodexFirstTurnNoProgressMarker = "codex app-server no progress timeout"
+
+const codexModelCatalogRefreshTimeoutSignal = "failed to refresh available models: timeout waiting for child process to exit"
+
+type codexTimeoutKind int
+
+const (
+	codexTimeoutNone codexTimeoutKind = iota
+	codexTimeoutSemanticInactivity
+	codexTimeoutFirstTurnNoProgress
+)
+
+type codexTimeoutDiagnostic struct {
+	Kind         codexTimeoutKind
+	Timeout      time.Duration
+	LastActivity string
+	ThreadID     string
+	TurnID       string
+	Model        string
+	CodexVersion string
+}
+
 // codexBackend implements Backend by spawning `codex app-server --listen stdio://`
 // and communicating via JSON-RPC 2.0 over stdin/stdout.
 type codexBackend struct {
 	cfg Config
+}
+
+func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{"app-server", "--listen", "stdio://"}
+	extra := filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)
+	custom := filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)
+	// Only claim ownership of the `mcp_servers` namespace when the agent
+	// actually has a managed mcp_config. Otherwise users who configure MCP
+	// via `custom_args: ["-c", "mcp_servers.…"]` would silently lose those
+	// entries. With managed mcp_config present, daemon-written
+	// `$CODEX_HOME/config.toml` is the authoritative source and stray
+	// `-c mcp_servers.*` overrides are dropped to keep last-wins from
+	// re-shadowing it.
+	if hasManagedCodexMcpConfig(opts.McpConfig) {
+		extra = filterCodexCustomConfigOverrides(extra, logger)
+		custom = filterCodexCustomConfigOverrides(custom, logger)
+	}
+	args = append(args, extra...)
+	args = append(args, custom...)
+	return args
+}
+
+// hasManagedCodexMcpConfig reports whether the agent's mcp_config field is
+// "present" in the API three-state sense: a non-null JSON value. Both
+// `{}` and `{"mcpServers":{}}` count as present (the admin saved an empty
+// managed set — strict mode, no global fallback); only SQL NULL or the
+// literal JSON `null` count as absent (CLI default).
+func hasManagedCodexMcpConfig(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return false
+	}
+	return true
+}
+
+// codexManagedMcpConfigKeyRe matches the daemon-managed config namespace
+// (`mcp_servers.…`) when it appears as the value of a Codex `-c` /
+// `--config` flag. Used by filterCodexCustomConfigOverrides to drop user
+// overrides that would otherwise shadow what the daemon writes into
+// `$CODEX_HOME/config.toml`.
+var codexManagedMcpConfigKeyRe = regexp.MustCompile(`^\s*mcp_servers(?:\s*\.|\s*=|\s*$)`)
+
+// filterCodexCustomConfigOverrides drops `-c mcp_servers.…=` and
+// `--config mcp_servers.…=` entries from custom args. Codex's `-c` is
+// last-wins, so without this filter a user-written `-c mcp_servers.fetch=…`
+// in custom_args would silently override whatever was saved into the
+// per-task config.toml. We own the `mcp_servers` namespace via the managed
+// block, so user attempts to write into it are dropped with a warning.
+// Other `-c`/`--config` keys (e.g. `-c model="o3"`) pass through unchanged.
+func filterCodexCustomConfigOverrides(args []string, logger *slog.Logger) []string {
+	if len(args) == 0 {
+		return args
+	}
+	filtered := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		flag := arg
+		inlineValue := ""
+		hasInlineValue := false
+		if idx := strings.Index(arg, "="); idx > 0 {
+			flag = arg[:idx]
+			inlineValue = arg[idx+1:]
+			hasInlineValue = true
+		}
+		if flag == "-c" || flag == "--config" {
+			value := inlineValue
+			if !hasInlineValue && i+1 < len(args) {
+				value = args[i+1]
+			}
+			if codexManagedMcpConfigKeyRe.MatchString(value) {
+				if logger != nil {
+					// Log the key only, never the value — mcp_servers.<name>.env
+					// is allowed to carry secrets and the whole point of moving
+					// this to config.toml is to keep raw values out of logs/argv.
+					key := value
+					if eqIdx := strings.Index(value, "="); eqIdx >= 0 {
+						key = value[:eqIdx]
+					}
+					logger.Warn("custom_args: blocked mcp_servers override; daemon manages this via CODEX_HOME/config.toml",
+						"flag", flag, "key", strings.TrimSpace(key))
+				}
+				if !hasInlineValue && i+1 < len(args) {
+					i++ // skip the value arg
+				}
+				continue
+			}
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+// Markers delimiting the daemon-managed `[mcp_servers.*]` block in
+// `$CODEX_HOME/config.toml`.
+const (
+	multicaCodexMcpBeginMarker = "# BEGIN multica-managed mcp_servers (do not edit; regenerated by daemon)"
+	multicaCodexMcpEndMarker   = "# END multica-managed mcp_servers"
+)
+
+var codexMcpBlockRe = regexp.MustCompile(
+	`(?ms)^` + regexp.QuoteMeta(multicaCodexMcpBeginMarker) +
+		`.*?^` + regexp.QuoteMeta(multicaCodexMcpEndMarker) + `\n*`)
+
+// userCodexMcpServersTableHeaderRe matches `[mcp_servers.<name>]` (and its
+// quoted-key form `[mcp_servers."<name>"]`) at the start of a line. Used
+// to strip user-provided mcp_servers tables from the per-task config when
+// the agent has its own mcp_config — mirrors Claude's `--strict-mcp-config`
+// model where the daemon's set is authoritative.
+var userCodexMcpServersTableHeaderRe = regexp.MustCompile(
+	`^\s*\[\s*mcp_servers\s*\.\s*(?:"[^"]*"|[^\]\s]+)\s*\]\s*(?:#.*)?$`)
+
+// ensureCodexMcpConfig writes (or clears) the daemon-managed
+// `[mcp_servers.*]` block in `$CODEX_HOME/config.toml`. The block is the
+// authoritative source of MCP servers for this run: with mcp_config set
+// the daemon also strips any inherited `[mcp_servers.*]` tables from the
+// per-task config so the user's global `~/.codex/config.toml` doesn't
+// shadow or collide with the managed set.
+//
+// The file mode is 0o600 because `mcp_servers.<id>.env` values may carry
+// secrets (API keys, bearer tokens); the per-task home is owned by the
+// daemon's user, so 0o600 keeps secrets out of any world-readable copy
+// while still letting the codex child read them.
+//
+// A malformed mcp_config is returned as an error and the caller decides
+// whether to surface or warn.
+func ensureCodexMcpConfig(configPath string, mcpConfig json.RawMessage, logger *slog.Logger) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read config.toml: %w", err)
+	}
+	existing := string(data)
+
+	// Always strip a prior managed block so reruns and clear-config flows
+	// converge on a clean state.
+	stripped := codexMcpBlockRe.ReplaceAllString(existing, "")
+
+	managed := hasManagedCodexMcpConfig(mcpConfig)
+	block, _, renderErr := renderCodexMcpServersBlock(mcpConfig)
+	if renderErr != nil {
+		return renderErr
+	}
+
+	var updated string
+	if managed {
+		// Agent has a managed MCP set (possibly empty — `{}` /
+		// `{"mcpServers":{}}` count as "saved an empty set", distinct from
+		// nil/null which means "fall back to CLI default"). Strip any
+		// user-defined `[mcp_servers.*]` tables inherited from
+		// `~/.codex/config.toml` so the managed set is strict — mirrors
+		// Claude's `--strict-mcp-config`. Two reasons we cannot mix:
+		//   1. TOML rejects redefining the same table; a user table
+		//      named `[mcp_servers.fetch]` would crash codex if the
+		//      agent also defined `fetch`.
+		//   2. An admin saving an explicit list would otherwise see
+		//      user-global servers silently joined in.
+		stripped = stripCodexUserMcpServerTables(stripped)
+		stripped = strings.TrimRight(stripped, "\n")
+		// When the managed set is empty we still write the marker
+		// block (with no tables between). This pins "managed but
+		// empty" on disk so the next run can find and strip the
+		// markers, and so the file's intent is grep-able by ops.
+		if block == "" {
+			block = multicaCodexMcpBeginMarker + "\n" + multicaCodexMcpEndMarker + "\n"
+		}
+		if stripped == "" {
+			updated = block
+		} else {
+			updated = stripped + "\n\n" + block
+		}
+	} else {
+		// No managed config: just remove any prior managed block and
+		// leave inherited user tables alone (CLI default fallback).
+		updated = stripped
+	}
+
+	if updated == existing {
+		return nil
+	}
+	if err := os.WriteFile(configPath, []byte(updated), 0o600); err != nil {
+		return fmt.Errorf("write config.toml: %w", err)
+	}
+	// os.WriteFile applies the mode only when creating a new file; if the
+	// per-task config.toml was already on disk at a wider mode, the
+	// secret-bearing values we just wrote would inherit it. Chmod
+	// unconditionally to keep the secret in the daemon owner's lane.
+	if err := os.Chmod(configPath, 0o600); err != nil {
+		return fmt.Errorf("chmod config.toml to 0600: %w", err)
+	}
+	if logger != nil {
+		logger.Debug("codex: wrote managed mcp_servers block to config.toml",
+			"config_path", configPath, "managed", managed)
+	}
+	return nil
+}
+
+// renderCodexMcpServersBlock renders the agent's mcp_config JSON
+// (Claude-style `{"mcpServers": {...}}`) as a TOML block of
+// `[mcp_servers.<name>]` tables wrapped in BEGIN/END markers. Returns
+// (block, hasServers, err); hasServers=false means the input had no
+// servers to render (empty/null mcp_config) and the caller should only
+// strip the prior managed block.
+//
+// Claude-style camelCase keys (`args`, `env`, `command`, `url`) pass
+// through verbatim — Codex's config schema happens to use the same
+// names today. If they ever diverge, rename here rather than in the UI.
+func renderCodexMcpServersBlock(raw json.RawMessage) (string, bool, error) {
+	if len(raw) == 0 {
+		return "", false, nil
+	}
+	var parsed struct {
+		McpServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", false, fmt.Errorf("parse mcp_config json: %w", err)
+	}
+	if len(parsed.McpServers) == 0 {
+		return "", false, nil
+	}
+
+	names := make([]string, 0, len(parsed.McpServers))
+	for name := range parsed.McpServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var sb strings.Builder
+	sb.WriteString(multicaCodexMcpBeginMarker)
+	sb.WriteString("\n")
+	for i, name := range names {
+		if !isCodexBareTomlKey(name) {
+			return "", false, fmt.Errorf("mcp server name %q must be ASCII alphanumeric / _ / - to fit Codex's bare-key requirement", name)
+		}
+		var serverVal map[string]any
+		if err := json.Unmarshal(parsed.McpServers[name], &serverVal); err != nil {
+			return "", false, fmt.Errorf("mcp_servers.%s: %w", name, err)
+		}
+		if serverVal == nil {
+			return "", false, fmt.Errorf("mcp_servers.%s must be a JSON object", name)
+		}
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("[mcp_servers.")
+		sb.WriteString(name)
+		sb.WriteString("]\n")
+		keys := make([]string, 0, len(serverVal))
+		for k := range serverVal {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			tomlValue, err := jsonValueToCodexTOMLInline(serverVal[k])
+			if err != nil {
+				return "", false, fmt.Errorf("mcp_servers.%s.%s: %w", name, k, err)
+			}
+			sb.WriteString(codexTOMLKey(k))
+			sb.WriteString(" = ")
+			sb.WriteString(tomlValue)
+			sb.WriteString("\n")
+		}
+	}
+	sb.WriteString(multicaCodexMcpEndMarker)
+	sb.WriteString("\n")
+	return sb.String(), true, nil
+}
+
+// stripCodexUserMcpServerTables removes every `[mcp_servers.*]` table
+// (header + body lines until the next top-level table header or EOF) from
+// a TOML config string. Sub-tables like `[mcp_servers.fetch.env]` count
+// as part of the parent table and are dropped along with it.
+func stripCodexUserMcpServerTables(content string) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	for _, line := range lines {
+		if userCodexMcpServersTableHeaderRe.MatchString(line) {
+			skipping = true
+			continue
+		}
+		if skipping {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "[") {
+				// Next table header. If it's still an `mcp_servers.*`
+				// table (including a sub-table), keep skipping; otherwise
+				// stop and emit this line.
+				if userCodexMcpServersTableHeaderRe.MatchString(line) ||
+					strings.HasPrefix(trimmed, "[mcp_servers.") ||
+					strings.HasPrefix(trimmed, "[ mcp_servers.") {
+					continue
+				}
+				skipping = false
+				out = append(out, line)
+				continue
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// jsonValueToCodexTOMLInline serialises a JSON value as a TOML inline
+// value. Only the subset Codex's `-c` accepts is supported: strings,
+// numbers, booleans, arrays, and inline tables. JSON nulls are rejected
+// because TOML has no null and silently dropping them would be confusing.
+func jsonValueToCodexTOMLInline(v any) (string, error) {
+	switch x := v.(type) {
+	case nil:
+		return "", fmt.Errorf("null is not a valid TOML value")
+	case bool:
+		if x {
+			return "true", nil
+		}
+		return "false", nil
+	case float64:
+		if x == float64(int64(x)) {
+			return strconv.FormatInt(int64(x), 10), nil
+		}
+		return strconv.FormatFloat(x, 'f', -1, 64), nil
+	case string:
+		return codexTOMLBasicString(x), nil
+	case []any:
+		parts := make([]string, len(x))
+		for i, e := range x {
+			p, err := jsonValueToCodexTOMLInline(e)
+			if err != nil {
+				return "", err
+			}
+			parts[i] = p
+		}
+		return "[" + strings.Join(parts, ", ") + "]", nil
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, len(keys))
+		for i, k := range keys {
+			p, err := jsonValueToCodexTOMLInline(x[k])
+			if err != nil {
+				return "", err
+			}
+			parts[i] = codexTOMLKey(k) + " = " + p
+		}
+		return "{ " + strings.Join(parts, ", ") + " }", nil
+	default:
+		return "", fmt.Errorf("unsupported value type %T", v)
+	}
+}
+
+func codexTOMLBasicString(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s) + 2)
+	sb.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			sb.WriteString(`\\`)
+		case '"':
+			sb.WriteString(`\"`)
+		case '\b':
+			sb.WriteString(`\b`)
+		case '\t':
+			sb.WriteString(`\t`)
+		case '\n':
+			sb.WriteString(`\n`)
+		case '\f':
+			sb.WriteString(`\f`)
+		case '\r':
+			sb.WriteString(`\r`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				sb.WriteString(fmt.Sprintf(`\u%04x`, r))
+			} else {
+				sb.WriteRune(r)
+			}
+		}
+	}
+	sb.WriteByte('"')
+	return sb.String()
+}
+
+func codexTOMLKey(s string) string {
+	if isCodexBareTomlKey(s) {
+		return s
+	}
+	return codexTOMLBasicString(s)
+}
+
+func isCodexBareTomlKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
@@ -27,15 +499,49 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}
 
 	timeout := opts.Timeout
-	if timeout == 0 {
-		timeout = 20 * time.Minute
+	semanticInactivityTimeout := opts.SemanticInactivityTimeout
+	if semanticInactivityTimeout == 0 {
+		semanticInactivityTimeout = defaultCodexSemanticInactivityTimeout
 	}
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	runCtx, cancel := runContext(ctx, timeout)
 
-	cmd := exec.CommandContext(runCtx, execPath, "app-server", "--listen", "stdio://")
+	// Materialise the agent's MCP config into the per-task
+	// `$CODEX_HOME/config.toml`. Argv would be the simpler path, but
+	// `mcp_servers.<id>.env` is allowed to carry secrets and process argv
+	// ends up in OS-level `ps` listings and the daemon's `agent command`
+	// log line below. Writing through config.toml at 0o600 keeps the
+	// secret values out of argv and logs.
+	if codexHome := strings.TrimSpace(b.cfg.Env["CODEX_HOME"]); codexHome != "" {
+		if err := ensureCodexMcpConfig(filepath.Join(codexHome, "config.toml"), opts.McpConfig, b.cfg.Logger); err != nil {
+			// Fail closed when we can't materialise the managed config.
+			// Warning-and-launching would silently fall back to the
+			// user's global `~/.codex/config.toml` MCP servers and
+			// look indistinguishable from "the saved config was applied".
+			cancel()
+			return nil, fmt.Errorf("apply codex mcp_config: %w", err)
+		}
+	} else if hasManagedCodexMcpConfig(opts.McpConfig) {
+		// Managed mcp_config saved but no CODEX_HOME to anchor it.
+		// Same reasoning as above: silently launching would inherit
+		// whatever MCP setup the host user has, which is the wrong
+		// shape of failure.
+		cancel()
+		return nil, fmt.Errorf("codex: mcp_config is set but CODEX_HOME env var is not configured; cannot apply managed MCP")
+	}
+
+	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
+	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
+	hideAgentWindow(cmd)
+	// Bound the wait after the context is cancelled so a stuck child (or an
+	// open pipe held by a grandchild) can't hang cmd.Wait() forever.
+	cmd.WaitDelay = 10 * time.Second
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", codexArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
+	// Omit the host's OPENAI_API_KEY so codex authenticates via the
+	// per-task CODEX_HOME auth.json (or an explicitly injected key in
+	// cfg.Env) instead of whatever the daemon host happens to export.
 	cmd.Env = buildEnvOmitting(b.cfg.Env, "OPENAI_API_KEY")
 
 	stdout, err := cmd.StdoutPipe()
@@ -48,7 +554,8 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		cancel()
 		return nil, fmt.Errorf("codex stdin pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[codex:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[codex:stderr] "), codexStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -59,6 +566,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
+	semanticActivityCh := make(chan string, 256)
 
 	var outputMu sync.Mutex
 	var output strings.Builder
@@ -80,6 +588,11 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				outputMu.Unlock()
 			}
 			trySend(msgCh, msg)
+			trySendString(semanticActivityCh, describeCodexSemanticActivity(msg))
+		},
+		onSemanticActivity: func(description string) {
+			b.cfg.Logger.Debug("codex semantic activity observed", "activity", description)
+			trySendString(semanticActivityCh, description)
 		},
 		onTurnDone: func(aborted bool) {
 			select {
@@ -105,18 +618,32 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		c.closeAllPending(fmt.Errorf("codex process exited"))
 	}()
 
+	// drainAndWait closes stdin so codex shuts down, then joins cmd.Wait().
+	// cmd.Wait() is the only Go-stdlib-documented synchronization point for
+	// os/exec's internal stderr/stdout copy goroutines — until it returns,
+	// stderrBuf may not have observed every byte codex wrote before it
+	// exited, and stderrBuf.Tail() can come back empty or truncated. Any
+	// code that reads stderrBuf.Tail() must call drainAndWait() first.
+	// sync.Once makes it safe to call from both error paths and the deferred
+	// cleanup.
+	var waitOnce sync.Once
+	drainAndWait := func() {
+		waitOnce.Do(func() {
+			stdin.Close()
+			_ = cmd.Wait()
+		})
+	}
+
 	// Drive the session lifecycle in a goroutine.
-	// Shutdown sequence: lifecycle goroutine closes stdin + cancels context →
-	// codex process exits → reader goroutine's scanner.Scan() returns false →
-	// readerDone closes → lifecycle goroutine collects final output and sends Result.
+	// Shutdown sequence: lifecycle goroutine closes stdin (+ cancels context
+	// if needed) → codex process exits → reader goroutine's scanner.Scan()
+	// returns false → readerDone closes → lifecycle goroutine collects final
+	// output and sends Result.
 	go func() {
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
-		defer func() {
-			stdin.Close()
-			_ = cmd.Wait()
-		}()
+		defer drainAndWait()
 
 		startTime := time.Now()
 		finalStatus := "completed"
@@ -134,137 +661,509 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			},
 		})
 		if err != nil {
+			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("codex initialize failed: %v", err)
+			finalError = withAgentStderr(fmt.Sprintf("codex initialize failed: %v", err), "codex", stderrBuf.Tail())
 			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 			return
 		}
 		c.notify("initialized")
 
-		// 2. Start thread
-		threadResult, err := c.request(runCtx, "thread/start", map[string]any{
-			"model":                  nilIfEmpty(opts.Model),
-			"modelProvider":          nil,
-			"profile":                nil,
-			"cwd":                    opts.Cwd,
-			"approvalPolicy":         nil,
-			"sandbox":                "workspace-write",
-			"config":                 nil,
-			"baseInstructions":       nil,
-			"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
-			"compactPrompt":          nil,
-			"includeApplyPatchTool":  nil,
-			"experimentalRawEvents":  true,
-			"persistExtendedHistory": true,
-		})
+		// 2. Start a new thread, or resume the prior one for this issue. When
+		// resume fails (thread GCed on the server, schema drift, etc.) we fall
+		// back to a fresh thread so the task still makes progress.
+		threadID, resumed, err := c.startOrResumeThread(runCtx, opts, b.cfg.Logger)
 		if err != nil {
+			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("codex thread/start failed: %v", err)
-			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
-			return
-		}
-
-		threadID := extractThreadID(threadResult)
-		if threadID == "" {
-			finalStatus = "failed"
-			finalError = "codex thread/start returned no thread ID"
+			finalError = withAgentStderr(err.Error(), "codex", stderrBuf.Tail())
 			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 			return
 		}
 		c.threadID = threadID
-		b.cfg.Logger.Info("codex thread started", "thread_id", threadID)
+		if resumed {
+			b.cfg.Logger.Info("codex thread resumed", "thread_id", threadID)
+		} else {
+			b.cfg.Logger.Info("codex thread started", "thread_id", threadID)
+		}
 
 		// 3. Send turn and wait for completion
-		_, err = c.request(runCtx, "turn/start", map[string]any{
+		turnParams := map[string]any{
 			"threadId": threadID,
 			"input": []map[string]any{
 				{"type": "text", "text": prompt},
 			},
-		})
+		}
+		// Per-turn reasoning override. Mirrors the per-thread injection in
+		// startOrResumeThread; the three injection points must not drift
+		// independently.
+		applyCodexReasoningEffort(turnParams, opts.ThinkingLevel)
+		_, err = c.request(runCtx, "turn/start", turnParams)
 		if err != nil {
+			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("codex turn/start failed: %v", err)
+			finalError = withAgentStderr(fmt.Sprintf("codex turn/start failed: %v", err), "codex", stderrBuf.Tail())
 			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 			return
 		}
 
-		// Wait for turn completion or context cancellation
-		select {
-		case aborted := <-turnDone:
-			c.mu.Lock()
-			turnStatus := c.lastTurnStatus
-			turnError := c.lastError
-			c.mu.Unlock()
-			if turnStatus == "failed" {
-				finalStatus = "failed"
-				finalError = turnError
-				if finalError == "" {
-					finalError = "codex turn failed"
-				}
-			} else if aborted {
-				finalStatus = "aborted"
-				finalError = "turn was aborted"
+		lastSemanticActivity := time.Now()
+		lastSemanticActivityDescription := "turn/start"
+		semanticTimer := time.NewTimer(semanticInactivityTimeout)
+		defer semanticTimer.Stop()
+
+		firstTurnNoProgressTimeout := codexFirstTurnNoProgressTimeout(semanticInactivityTimeout)
+		var firstTurnNoProgressTimer *time.Timer
+		var firstTurnNoProgressTimerC <-chan time.Time
+		firstTurnStarted := false
+		firstTurnProgressObserved := false
+		stopFirstTurnNoProgressTimer := func() {
+			if firstTurnNoProgressTimer == nil {
+				return
 			}
-		case <-runCtx.Done():
-			if runCtx.Err() == context.DeadlineExceeded {
+			stopTimer(firstTurnNoProgressTimer)
+			firstTurnNoProgressTimerC = nil
+		}
+		defer stopFirstTurnNoProgressTimer()
+
+		waitingForTurn := true
+		var timeoutDiagnostic codexTimeoutDiagnostic
+		for waitingForTurn {
+			select {
+			case aborted := <-turnDone:
+				waitingForTurn = false
+				switch {
+				case aborted:
+					finalStatus = "aborted"
+					finalError = "turn was aborted"
+				default:
+					if errMsg := c.getTurnError(); errMsg != "" {
+						finalStatus = "failed"
+						finalError = errMsg
+					}
+				}
+			case activity := <-semanticActivityCh:
+				lastSemanticActivity = time.Now()
+				lastSemanticActivityDescription = activity
+				resetTimer(semanticTimer, semanticInactivityTimeout)
+				if activity == "status:running" && !firstTurnStarted {
+					firstTurnStarted = true
+					firstTurnNoProgressTimer = time.NewTimer(firstTurnNoProgressTimeout)
+					firstTurnNoProgressTimerC = firstTurnNoProgressTimer.C
+				} else if firstTurnStarted && !firstTurnProgressObserved && isCodexFirstTurnProgressActivity(activity) {
+					firstTurnProgressObserved = true
+					stopFirstTurnNoProgressTimer()
+				}
+			case <-firstTurnNoProgressTimerC:
+				waitingForTurn = false
 				finalStatus = "timeout"
-				finalError = fmt.Sprintf("codex timed out after %s", timeout)
-			} else {
-				finalStatus = "aborted"
-				finalError = "execution cancelled"
+				timeoutDiagnostic = codexTimeoutDiagnostic{
+					Kind:         codexTimeoutFirstTurnNoProgress,
+					Timeout:      firstTurnNoProgressTimeout,
+					LastActivity: lastSemanticActivityDescription,
+					ThreadID:     threadID,
+					TurnID:       c.turnID,
+					Model:        opts.Model,
+				}
+				b.cfg.Logger.Warn(CodexFirstTurnNoProgressMarker,
+					"pid", cmd.Process.Pid,
+					"thread_id", threadID,
+					"turn_id", c.turnID,
+					"timeout", firstTurnNoProgressTimeout.String(),
+					"last_activity", lastSemanticActivityDescription,
+				)
+			case <-semanticTimer.C:
+				waitingForTurn = false
+				finalStatus = "timeout"
+				timeoutDiagnostic = codexTimeoutDiagnostic{
+					Kind:         codexTimeoutSemanticInactivity,
+					Timeout:      semanticInactivityTimeout,
+					LastActivity: lastSemanticActivityDescription,
+					ThreadID:     threadID,
+					TurnID:       c.turnID,
+					Model:        opts.Model,
+				}
+				b.cfg.Logger.Warn(CodexSemanticInactivityMarker,
+					"pid", cmd.Process.Pid,
+					"thread_id", threadID,
+					"turn_id", c.turnID,
+					"timeout", semanticInactivityTimeout.String(),
+					"last_activity", lastSemanticActivityDescription,
+					"idle_for", time.Since(lastSemanticActivity).Round(time.Millisecond).String(),
+				)
+			case <-runCtx.Done():
+				waitingForTurn = false
+				if runCtx.Err() == context.DeadlineExceeded {
+					finalStatus = "timeout"
+					finalError = fmt.Sprintf("codex timed out after %s", timeout)
+				} else {
+					finalStatus = "aborted"
+					finalError = "execution cancelled"
+				}
 			}
 		}
 
 		duration := time.Since(startTime)
 		b.cfg.Logger.Info("codex finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
-		// Close stdin and cancel context to signal the app-server to exit.
-		// Without this, the long-running codex process keeps stdout open and
-		// the reader goroutine blocks forever on scanner.Scan().
+		// Close stdin to signal the app-server to exit. Prefer letting codex
+		// shut down on its own: a clean exit runs codex's shutdown path, which
+		// force-flushes its OTEL batch exporters — killing it immediately (via
+		// cancel → SIGKILL) drops the task's buffered telemetry. Give it a
+		// bounded grace period; only force-cancel if it doesn't exit, so the
+		// reader goroutine can never block forever on scanner.Scan().
 		stdin.Close()
-		cancel()
+		select {
+		case <-readerDone:
+			// codex closed stdout on its own — clean shutdown, telemetry flushed.
+		case <-time.After(codexGracefulShutdownTimeout):
+			b.cfg.Logger.Warn("codex did not exit after stdin close; forcing shutdown",
+				"pid", cmd.Process.Pid,
+				"grace", codexGracefulShutdownTimeout.String(),
+			)
+			cancel()
+			<-readerDone
+		}
+		drainAndWait()
 
-		// Wait for the reader goroutine to finish so all output is accumulated.
-		<-readerDone
+		if timeoutDiagnostic.Kind != codexTimeoutNone {
+			timeoutDiagnostic.CodexVersion = detectCodexVersionForDiagnostics(context.Background(), execPath, cmd.Env, b.cfg.Logger)
+			finalError = buildCodexTimeoutDiagnosticError(timeoutDiagnostic, stderrBuf.Tail())
+		}
 
 		outputMu.Lock()
 		finalOutput := output.String()
 		outputMu.Unlock()
 
+		// Build usage map from accumulated codex usage.
+		// First check JSON-RPC notifications (often empty for Codex).
+		var usageMap map[string]TokenUsage
+		c.usageMu.Lock()
+		u := c.usage
+		c.usageMu.Unlock()
+
+		// Fallback: if no usage from JSON-RPC, scan Codex session JSONL logs.
+		// Codex writes token_count events to ~/.codex/sessions/YYYY/MM/DD/*.jsonl.
+		if u.InputTokens == 0 && u.OutputTokens == 0 {
+			if scanned := scanCodexSessionUsage(startTime); scanned != nil {
+				u = scanned.usage
+				if scanned.model != "" && opts.Model == "" {
+					opts.Model = scanned.model
+				}
+			}
+		}
+
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usageMap = map[string]TokenUsage{model: u}
+		}
+
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     finalOutput,
 			Error:      finalError,
+			SessionID:  threadID,
 			DurationMs: duration.Milliseconds(),
+			Usage:      usageMap,
 		}
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
+// startOrResumeThread picks between Codex's thread/resume and thread/start
+// based on opts.ResumeSessionID. When a prior thread ID is provided it first
+// tries thread/resume; any error (unknown thread, schema mismatch, transport
+// failure) is logged and the method falls back to thread/start so the task
+// still executes. The returned threadID is what subsequent turn/start calls
+// must reference, and resumed indicates whether the prior thread was picked
+// up (only useful for logging).
+func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions, logger *slog.Logger) (string, bool, error) {
+	if priorThreadID := opts.ResumeSessionID; priorThreadID != "" {
+		// thread/resume reuses the thread's persisted model and reasoning
+		// effort; only override fields the daemon actually cares about.
+		resumeParams := map[string]any{
+			"threadId":              priorThreadID,
+			"cwd":                   opts.Cwd,
+			"model":                 nilIfEmpty(opts.Model),
+			"developerInstructions": nilIfEmpty(opts.SystemPrompt),
+		}
+		// Explicit override of the persisted reasoning effort: without
+		// this, a Codex resume silently reuses whatever level the prior
+		// session was created with, even when the user has flipped the
+		// agent's thinking_level since.
+		applyCodexReasoningEffort(resumeParams, opts.ThinkingLevel)
+		resumeResult, err := c.request(ctx, "thread/resume", resumeParams)
+		if err == nil {
+			if threadID := extractThreadID(resumeResult); threadID != "" {
+				return threadID, true, nil
+			}
+			logger.Warn("codex thread/resume returned no thread ID; falling back to thread/start", "prior_thread_id", priorThreadID)
+		} else {
+			logger.Warn("codex thread/resume failed; falling back to thread/start", "prior_thread_id", priorThreadID, "error", err)
+		}
+	}
+
+	startParams := map[string]any{
+		"model":                  nilIfEmpty(opts.Model),
+		"modelProvider":          nil,
+		"profile":                nil,
+		"cwd":                    opts.Cwd,
+		"approvalPolicy":         nil,
+		"sandbox":                "workspace-write",
+		"config":                 nil,
+		"baseInstructions":       nil,
+		"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
+		"compactPrompt":          nil,
+		"includeApplyPatchTool":  nil,
+		"experimentalRawEvents":  true,
+		"persistExtendedHistory": true,
+	}
+	applyCodexReasoningEffort(startParams, opts.ThinkingLevel)
+	startResult, err := c.request(ctx, "thread/start", startParams)
+	if err != nil {
+		return "", false, fmt.Errorf("codex thread/start failed: %w", err)
+	}
+	threadID := extractThreadID(startResult)
+	if threadID == "" {
+		return "", false, fmt.Errorf("codex thread/start returned no thread ID")
+	}
+	c.trySetThreadName(ctx, threadID, opts.ThreadName, logger)
+	return threadID, false, nil
+}
+
+func (c *codexClient) trySetThreadName(ctx context.Context, threadID, name string, logger *slog.Logger) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	if err := c.setThreadName(ctx, threadID, name); err != nil {
+		logger.Warn("codex thread/name/set failed; continuing without provider-native thread title",
+			"thread_id", threadID, "error", err)
+	}
+}
+
+func (c *codexClient) setThreadName(ctx context.Context, threadID, name string) error {
+	_, err := c.request(ctx, "thread/name/set", map[string]any{
+		"threadId": threadID,
+		"name":     name,
+	})
+	return err
+}
+
+// applyCodexReasoningEffort writes the per-agent thinking_level into a
+// Codex app-server request. The three points — thread/start.config,
+// thread/resume.config, turn/start.effort — all flow through this helper
+// so any future protocol/key change touches one site rather than three.
+//
+// The shape is detected from the params keys:
+//   - turn/start always carries `input`, and the schema exposes the
+//     reasoning override as the top-level `effort` field.
+//   - thread/start and thread/resume nest it under
+//     `config.model_reasoning_effort`.
+//
+// Empty `level` is a no-op: we deliberately do NOT emit a key when the
+// caller didn't request an override, so the upstream defaults (config
+// file, account-scoped model preference) stay in charge. This also
+// guarantees `effort: ""` never reaches the CLI — Codex rejects empty
+// strings on this field.
+func applyCodexReasoningEffort(params map[string]any, level string) {
+	if params == nil || level == "" {
+		return
+	}
+	if _, isTurnStart := params["input"]; isTurnStart {
+		params["effort"] = level
+		return
+	}
+	cfg, _ := params["config"].(map[string]any)
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	cfg["model_reasoning_effort"] = level
+	params["config"] = cfg
+}
+
+func resetTimer(timer *time.Timer, d time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(d)
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func codexFirstTurnNoProgressTimeout(semanticInactivityTimeout time.Duration) time.Duration {
+	if semanticInactivityTimeout <= 0 || semanticInactivityTimeout > defaultCodexFirstTurnNoProgressTimeout {
+		return defaultCodexFirstTurnNoProgressTimeout
+	}
+	scaled := semanticInactivityTimeout * 4 / 5
+	if scaled <= 0 {
+		return semanticInactivityTimeout
+	}
+	return scaled
+}
+
+func isCodexFirstTurnProgressActivity(activity string) bool {
+	return activity != "" && activity != "status:running" && activity != "error:retry"
+}
+
+func buildCodexTimeoutDiagnosticError(diag codexTimeoutDiagnostic, stderrTail string) string {
+	var msg string
+	switch diag.Kind {
+	case codexTimeoutFirstTurnNoProgress:
+		msg = fmt.Sprintf("%s after %s: received turn start but no item, message, tool, turn/completed, or error event (%s)",
+			CodexFirstTurnNoProgressMarker,
+			diag.Timeout,
+			formatCodexDiagnosticFields(diag),
+		)
+	case codexTimeoutSemanticInactivity:
+		msg = fmt.Sprintf("%s after %s without agent progress (last activity: %s; %s)",
+			CodexSemanticInactivityMarker,
+			diag.Timeout,
+			nonEmptyCodexDiagnosticValue(diag.LastActivity),
+			formatCodexDiagnosticFields(diag),
+		)
+	default:
+		msg = "codex timed out"
+	}
+	msg = appendCodexKnownStderrHint(msg, stderrTail)
+	return withAgentStderr(msg, "codex", stderrTail)
+}
+
+func formatCodexDiagnosticFields(diag codexTimeoutDiagnostic) string {
+	return fmt.Sprintf("codex_version=%q thread_id=%q turn_id=%q model=%q",
+		nonEmptyCodexDiagnosticValue(diag.CodexVersion),
+		nonEmptyCodexDiagnosticValue(diag.ThreadID),
+		nonEmptyCodexDiagnosticValue(diag.TurnID),
+		formatCodexDiagnosticModel(diag.Model),
+	)
+}
+
+func nonEmptyCodexDiagnosticValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func formatCodexDiagnosticModel(model string) string {
+	if strings.TrimSpace(model) == "" {
+		return "default(empty)"
+	}
+	return model
+}
+
+func appendCodexKnownStderrHint(msg, stderrTail string) string {
+	if strings.Contains(stderrTail, codexModelCatalogRefreshTimeoutSignal) {
+		return msg + "; diagnosis: Codex stderr shows the model catalog refresh timed out. Try setting an explicit model, switching Codex CLI versions, or using another runtime while Codex app-server recovers"
+	}
+	return msg
+}
+
+func detectCodexVersionForDiagnostics(ctx context.Context, execPath string, env []string, logger *slog.Logger) string {
+	versionCtx, cancel := context.WithTimeout(ctx, codexVersionDiagnosticTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(versionCtx, execPath, "--version")
+	hideAgentWindow(cmd)
+	cmd.Env = env
+	data, err := cmd.Output()
+	if err != nil {
+		if logger != nil {
+			logger.Debug("codex version diagnostic failed", "error", err)
+		}
+		return "unknown"
+	}
+	version := extractVersionLine(string(data))
+	if strings.TrimSpace(version) == "" {
+		return "unknown"
+	}
+	return version
+}
+
+func trySendString(ch chan<- string, value string) {
+	select {
+	case ch <- value:
+	default:
+	}
+}
+
+func describeCodexSemanticActivity(msg Message) string {
+	switch msg.Type {
+	case MessageToolUse, MessageToolResult:
+		if msg.Tool != "" {
+			return fmt.Sprintf("%s:%s", msg.Type, msg.Tool)
+		}
+	case MessageStatus:
+		if msg.Status != "" {
+			return fmt.Sprintf("%s:%s", msg.Type, msg.Status)
+		}
+	}
+	return string(msg.Type)
+}
+
 // ── codexClient: JSON-RPC 2.0 transport ──
 
 type codexClient struct {
-	cfg        Config
-	stdin      interface{ Write([]byte) (int, error) }
-	mu         sync.Mutex
-	nextID     int
-	pending    map[int]*pendingRPC
-	threadID   string
-	turnID     string
-	onMessage  func(Message)
-	onTurnDone func(aborted bool)
+	cfg                Config
+	stdin              interface{ Write([]byte) (int, error) }
+	mu                 sync.Mutex
+	nextID             int
+	pending            map[int]*pendingRPC
+	threadID           string
+	turnID             string
+	onMessage          func(Message)
+	onSemanticActivity func(description string)
+	onTurnDone         func(aborted bool)
 
 	notificationProtocol string // "unknown", "legacy", "raw"
 	turnStarted          bool
 	completedTurnIDs     map[string]bool
 	emittedText          bool
-	lastTurnStatus       string
-	lastError            string
+
+	usageMu sync.Mutex
+	usage   TokenUsage // accumulated from turn events
+
+	turnErrorMu sync.Mutex
+	turnError   string // captured from turn/completed status=failed or terminal error notifications
+
 	// pendingCommands maps itemId → command string captured from
 	// item/commandExecution/requestApproval, which is the only place
 	// Codex includes the raw command text in the raw v2 protocol.
 	pendingCommands map[string]string
+}
+
+func (c *codexClient) setTurnError(msg string) {
+	if msg == "" {
+		return
+	}
+	c.turnErrorMu.Lock()
+	defer c.turnErrorMu.Unlock()
+	if c.turnError == "" {
+		c.turnError = msg
+	}
+}
+
+func (c *codexClient) getTurnError() string {
+	c.turnErrorMu.Lock()
+	defer c.turnErrorMu.Unlock()
+	return c.turnError
 }
 
 type pendingRPC struct {
@@ -305,6 +1204,13 @@ func (c *codexClient) request(ctx context.Context, method string, params any) (j
 		c.mu.Unlock()
 		return nil, fmt.Errorf("write %s: %w", method, err)
 	}
+	if method == "turn/start" {
+		threadID := ""
+		if paramMap, ok := params.(map[string]any); ok {
+			threadID, _ = paramMap["threadId"].(string)
+		}
+		c.cfg.Logger.Info("codex turn/start sent", "request_id", id, "thread_id", threadID)
+	}
 
 	select {
 	case res := <-pr.ch:
@@ -332,6 +1238,20 @@ func (c *codexClient) respond(id int, result any) {
 		"jsonrpc": "2.0",
 		"id":      id,
 		"result":  result,
+	}
+	data, _ := json.Marshal(msg)
+	data = append(data, '\n')
+	_, _ = c.stdin.Write(data)
+}
+
+func (c *codexClient) respondError(id int, code int, message string) {
+	msg := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
 	}
 	data, _ := json.Marshal(msg)
 	data = append(data, '\n')
@@ -434,8 +1354,11 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/fileChange/requestApproval", "applyPatchApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
+	case "mcpServer/elicitation/request":
+		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
-		c.respond(id, map[string]any{})
+		c.cfg.Logger.Warn("codex: unhandled server request", "method", method, "id", id)
+		c.respondError(id, -32601, fmt.Sprintf("unhandled server request: %s", method))
 	}
 }
 
@@ -485,7 +1408,7 @@ func (c *codexClient) handleEvent(msg map[string]any) {
 	case "task_started":
 		c.turnStarted = true
 		if c.onMessage != nil {
-			c.onMessage(Message{Type: MessageStatus, Status: "running"})
+			c.onMessage(Message{Type: MessageStatus, Status: "running", SessionID: c.threadID})
 		}
 	case "agent_message":
 		text, _ := msg["message"].(string)
@@ -531,6 +1454,8 @@ func (c *codexClient) handleEvent(msg map[string]any) {
 			})
 		}
 	case "task_complete":
+		// Extract usage from legacy task_complete if present.
+		c.extractUsageFromMap(msg)
 		if c.onTurnDone != nil {
 			c.onTurnDone(false)
 		}
@@ -542,39 +1467,46 @@ func (c *codexClient) handleEvent(msg map[string]any) {
 }
 
 func (c *codexClient) handleRawNotification(method string, params map[string]any) {
-	switch method {
-	case "error":
-		if msg := extractNestedString(params, "error", "message"); msg != "" {
-			c.mu.Lock()
-			c.lastError = msg
-			c.mu.Unlock()
-			if c.onMessage != nil {
-				c.onMessage(Message{Type: MessageError, Content: msg})
-			}
-		}
+	// Ignore notifications from threads other than the one we are tracking.
+	// Codex multiplexes subagent threads (e.g. memory consolidation) on the
+	// same stdio pipe; only our thread should drive turn lifecycle and output.
+	//
+	// The v2 app-server-protocol schema guarantees a top-level threadId on
+	// every notification, so this dispatch-level guard transparently covers
+	// every handler below. If a future codex revision introduces notifications
+	// without threadId, they fall through (ok=false) — re-audit this guard
+	// when bumping codex.
+	if threadID, ok := params["threadId"].(string); ok && c.threadID != "" && threadID != c.threadID {
+		return
+	}
 
+	switch method {
 	case "turn/started":
 		c.turnStarted = true
 		if turnID := extractNestedString(params, "turn", "id"); turnID != "" {
 			c.turnID = turnID
 		}
 		if c.onMessage != nil {
-			c.onMessage(Message{Type: MessageStatus, Status: "running"})
+			c.onMessage(Message{Type: MessageStatus, Status: "running", SessionID: c.threadID})
 		}
 
 	case "turn/completed":
 		turnID := extractNestedString(params, "turn", "id")
 		status := extractNestedString(params, "turn", "status")
+		threadID, _ := params["threadId"].(string)
+		c.cfg.Logger.Info("codex turn/completed received", "thread_id", threadID, "turn_id", turnID, "status", status)
 		aborted := status == "cancelled" || status == "canceled" ||
 			status == "aborted" || status == "interrupted"
-		errorMessage := extractNestedString(params, "turn", "error", "message")
 
-		c.mu.Lock()
-		c.lastTurnStatus = status
-		if errorMessage != "" {
-			c.lastError = errorMessage
+		// Capture the error message from failed turns so callers can surface
+		// a real reason instead of falling back to "empty output".
+		if status == "failed" {
+			errMsg := extractNestedString(params, "turn", "error", "message")
+			if errMsg == "" {
+				errMsg = "codex turn failed"
+			}
+			c.setTurnError(errMsg)
 		}
-		c.mu.Unlock()
 
 		if c.completedTurnIDs == nil {
 			c.completedTurnIDs = map[string]bool{}
@@ -586,8 +1518,39 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 			c.completedTurnIDs[turnID] = true
 		}
 
+		// Extract usage from turn/completed if present (e.g. params.turn.usage).
+		if turn, ok := params["turn"].(map[string]any); ok {
+			c.extractUsageFromMap(turn)
+		}
+
 		if c.onTurnDone != nil {
 			c.onTurnDone(aborted)
+		}
+
+	case "error":
+		// Top-level protocol error. Retrying notifications (willRetry=true) are
+		// transient reconnect attempts; only capture terminal errors so we
+		// don't stomp on a real failure later with a retry placeholder.
+		willRetry, _ := params["willRetry"].(bool)
+		errMsg := extractNestedString(params, "error", "message")
+		if errMsg == "" {
+			errMsg = extractNestedString(params, "message")
+		}
+		if errMsg != "" {
+			c.cfg.Logger.Warn("codex error notification", "message", errMsg, "will_retry", willRetry)
+			if c.onSemanticActivity != nil {
+				if willRetry {
+					c.onSemanticActivity("error:retry")
+				} else {
+					c.onSemanticActivity("error:terminal")
+				}
+			}
+			if !willRetry {
+				c.setTurnError(errMsg)
+				if c.onTurnDone != nil {
+					c.onTurnDone(false)
+				}
+			}
 		}
 
 	case "thread/status/changed":
@@ -610,13 +1573,15 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 }
 
 func (c *codexClient) handleItemNotification(method string, params map[string]any) {
-	item, ok := params["item"].(map[string]any)
-	if !ok {
-		return
-	}
-
+	item, _ := params["item"].(map[string]any)
 	itemType, _ := item["type"].(string)
 	itemID, _ := item["id"].(string)
+	if isCodexItemProgressActivity(method) && c.onSemanticActivity != nil {
+		c.onSemanticActivity(describeCodexItemProgressActivity(method, itemType, itemID))
+	}
+	if item == nil {
+		return
+	}
 
 	switch {
 	case method == "item/started" && itemType == "commandExecution":
@@ -668,6 +1633,8 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 		}
 
 	case method == "item/completed" && itemType == "agentMessage":
+		// When the stream already delivered this text via
+		// item/agentMessage/delta events, don't emit it twice.
 		text, _ := item["text"].(string)
 		if !c.emittedText {
 			c.emitText(text)
@@ -687,6 +1654,225 @@ func (c *codexClient) emitText(text string) {
 	}
 	c.emittedText = true
 	c.onMessage(Message{Type: MessageText, Content: text})
+}
+
+func isCodexItemProgressActivity(method string) bool {
+	return strings.HasPrefix(method, "item/")
+}
+
+func describeCodexItemProgressActivity(method, itemType, itemID string) string {
+	if itemType == "" {
+		itemType = "unknown"
+	}
+	if itemID == "" {
+		return fmt.Sprintf("%s:%s", method, itemType)
+	}
+	return fmt.Sprintf("%s:%s:%s", method, itemType, itemID)
+}
+
+// extractUsageFromMap extracts token usage from a map that may contain
+// "usage", "token_usage", or "tokens" fields. Handles various Codex formats.
+func (c *codexClient) extractUsageFromMap(data map[string]any) {
+	// Try common field names for usage data.
+	var usageMap map[string]any
+	for _, key := range []string{"usage", "token_usage", "tokens"} {
+		if v, ok := data[key].(map[string]any); ok {
+			usageMap = v
+			break
+		}
+	}
+	if usageMap == nil {
+		return
+	}
+
+	c.usageMu.Lock()
+	defer c.usageMu.Unlock()
+
+	// Try various key conventions.
+	c.usage.InputTokens += codexInt64(usageMap, "input_tokens", "input", "prompt_tokens")
+	c.usage.OutputTokens += codexInt64(usageMap, "output_tokens", "output", "completion_tokens")
+	c.usage.CacheReadTokens += codexInt64(usageMap, "cache_read_tokens", "cache_read_input_tokens")
+	c.usage.CacheWriteTokens += codexInt64(usageMap, "cache_write_tokens", "cache_creation_input_tokens")
+}
+
+// codexInt64 returns the first non-zero int64 value from the map for the given keys.
+func codexInt64(m map[string]any, keys ...string) int64 {
+	for _, key := range keys {
+		switch v := m[key].(type) {
+		case float64:
+			if v != 0 {
+				return int64(v)
+			}
+		case int64:
+			if v != 0 {
+				return v
+			}
+		}
+	}
+	return 0
+}
+
+// ── Codex session log scanner ──
+
+// codexSessionUsage holds usage extracted from a Codex session JSONL file.
+type codexSessionUsage struct {
+	usage TokenUsage
+	model string
+}
+
+// scanCodexSessionUsage scans Codex session JSONL files written after startTime
+// to extract token usage. Codex writes token_count events to
+// ~/.codex/sessions/YYYY/MM/DD/*.jsonl.
+func scanCodexSessionUsage(startTime time.Time) *codexSessionUsage {
+	root := codexSessionRoot()
+	if root == "" {
+		return nil
+	}
+
+	// Look in today's session directory.
+	dateDir := filepath.Join(root,
+		fmt.Sprintf("%04d", startTime.Year()),
+		fmt.Sprintf("%02d", int(startTime.Month())),
+		fmt.Sprintf("%02d", startTime.Day()),
+	)
+
+	files, err := filepath.Glob(filepath.Join(dateDir, "*.jsonl"))
+	if err != nil || len(files) == 0 {
+		return nil
+	}
+
+	// Only scan files modified after startTime (this task's session).
+	var result codexSessionUsage
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil || info.ModTime().Before(startTime) {
+			continue
+		}
+		if u := parseCodexSessionFile(f); u != nil {
+			// Take the last matching file's data (usually there's only one per task).
+			result = *u
+		}
+	}
+
+	if result.usage.InputTokens == 0 && result.usage.OutputTokens == 0 {
+		return nil
+	}
+	return &result
+}
+
+// codexSessionRoot returns the Codex sessions directory.
+func codexSessionRoot() string {
+	if codexHome := os.Getenv("CODEX_HOME"); codexHome != "" {
+		dir := filepath.Join(codexHome, "sessions")
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	dir := filepath.Join(home, ".codex", "sessions")
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		return dir
+	}
+	return ""
+}
+
+// codexSessionTokenCount represents a token_count event in Codex JSONL.
+type codexSessionTokenCount struct {
+	Type    string `json:"type"`
+	Payload *struct {
+		Type string `json:"type"`
+		Info *struct {
+			TotalTokenUsage *struct {
+				InputTokens           int64 `json:"input_tokens"`
+				OutputTokens          int64 `json:"output_tokens"`
+				CachedInputTokens     int64 `json:"cached_input_tokens"`
+				CacheReadInputTokens  int64 `json:"cache_read_input_tokens"`
+				ReasoningOutputTokens int64 `json:"reasoning_output_tokens"`
+			} `json:"total_token_usage"`
+			LastTokenUsage *struct {
+				InputTokens           int64 `json:"input_tokens"`
+				OutputTokens          int64 `json:"output_tokens"`
+				CachedInputTokens     int64 `json:"cached_input_tokens"`
+				CacheReadInputTokens  int64 `json:"cache_read_input_tokens"`
+				ReasoningOutputTokens int64 `json:"reasoning_output_tokens"`
+			} `json:"last_token_usage"`
+			Model string `json:"model"`
+		} `json:"info"`
+		Model string `json:"model"`
+	} `json:"payload"`
+}
+
+// parseCodexSessionFile extracts the final token_count from a Codex session file.
+func parseCodexSessionFile(path string) *codexSessionUsage {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var result codexSessionUsage
+	found := false
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		// Fast pre-filter.
+		if !bytesContainsStr(line, "token_count") && !bytesContainsStr(line, "turn_context") {
+			continue
+		}
+
+		var evt codexSessionTokenCount
+		if err := json.Unmarshal(line, &evt); err != nil || evt.Payload == nil {
+			continue
+		}
+
+		// Track model from turn_context events.
+		if evt.Type == "turn_context" && evt.Payload.Model != "" {
+			result.model = evt.Payload.Model
+			continue
+		}
+
+		// Extract token usage from token_count events.
+		if evt.Payload.Type == "token_count" && evt.Payload.Info != nil {
+			usage := evt.Payload.Info.TotalTokenUsage
+			if usage == nil {
+				usage = evt.Payload.Info.LastTokenUsage
+			}
+			if usage != nil {
+				cachedTokens := usage.CachedInputTokens
+				if cachedTokens == 0 {
+					cachedTokens = usage.CacheReadInputTokens
+				}
+				result.usage = TokenUsage{
+					InputTokens:     usage.InputTokens,
+					OutputTokens:    usage.OutputTokens + usage.ReasoningOutputTokens,
+					CacheReadTokens: cachedTokens,
+				}
+				if evt.Payload.Info.Model != "" {
+					result.model = evt.Payload.Info.Model
+				}
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return nil
+	}
+	return &result
+}
+
+// bytesContainsStr checks if b contains the string s.
+func bytesContainsStr(b []byte, s string) bool {
+	return strings.Contains(string(b), s)
 }
 
 // ── Helpers ──

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1,11 +1,18 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func newTestCodexClient(t *testing.T) (*codexClient, *fakeStdin, []Message) {
@@ -15,10 +22,9 @@ func newTestCodexClient(t *testing.T) (*codexClient, *fakeStdin, []Message) {
 	var messages []Message
 
 	c := &codexClient{
-		cfg:             Config{Logger: slog.Default()},
-		stdin:           fs,
-		pending:         make(map[int]*pendingRPC),
-		pendingCommands: make(map[string]string),
+		cfg:     Config{Logger: slog.Default()},
+		stdin:   fs,
+		pending: make(map[int]*pendingRPC),
 		onMessage: func(msg Message) {
 			mu.Lock()
 			messages = append(messages, msg)
@@ -161,6 +167,68 @@ func TestCodexHandleServerRequestFileChangeApproval(t *testing.T) {
 	result := resp["result"].(map[string]any)
 	if result["decision"] != "accept" {
 		t.Fatalf("expected decision=accept, got %v", result["decision"])
+	}
+}
+
+func TestCodexHandleServerRequestMCPElicitation(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":12,"method":"mcpServer/elicitation/request","params":{}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["id"] != float64(12) {
+		t.Fatalf("expected id=12, got %v", resp["id"])
+	}
+	result := resp["result"].(map[string]any)
+	if result["action"] != "accept" {
+		t.Fatalf("expected action=accept, got %v", result["action"])
+	}
+	if _, ok := result["content"]; !ok {
+		t.Fatal("expected content key in response")
+	}
+	if _, ok := result["_meta"]; !ok {
+		t.Fatal("expected _meta key in response")
+	}
+}
+
+func TestCodexHandleServerRequestUnknownReturnsError(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":13,"method":"some/unknown/method","params":{}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["id"] != float64(13) {
+		t.Fatalf("expected id=13, got %v", resp["id"])
+	}
+	if resp["result"] != nil {
+		t.Fatalf("expected no result for error response, got %v", resp["result"])
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatal("expected error object in response")
+	}
+	if errObj["code"] != float64(-32601) {
+		t.Fatalf("expected error code -32601, got %v", errObj["code"])
 	}
 }
 
@@ -356,63 +424,131 @@ func TestCodexRawTurnCompletedFailedCapturesError(t *testing.T) {
 	c, _, _ := newTestCodexClient(t)
 	c.notificationProtocol = "raw"
 
-	var done bool
+	var wasAborted bool
 	c.onTurnDone = func(aborted bool) {
-		done = true
+		wasAborted = aborted
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-f","status":"failed","error":{"message":"unexpected status 401 Unauthorized"}}}}`)
+
+	if wasAborted {
+		t.Fatal("failed is distinct from aborted")
+	}
+	if got := c.getTurnError(); got != "unexpected status 401 Unauthorized" {
+		t.Fatalf("expected error captured from turn.error.message, got %q", got)
+	}
+}
+
+func TestCodexRawTurnCompletedFailedWithoutMessageFallsBack(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.onTurnDone = func(aborted bool) {}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-f","status":"failed"}}}`)
+
+	if got := c.getTurnError(); got != "codex turn failed" {
+		t.Fatalf("expected fallback message, got %q", got)
+	}
+}
+
+func TestCodexRawErrorNotificationTerminal(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	done := false
+	var activities []string
+	c.onSemanticActivity = func(activity string) {
+		activities = append(activities, activity)
+	}
+	c.onTurnDone = func(aborted bool) {
 		if aborted {
-			t.Fatal("expected aborted=false for failed status")
+			t.Fatal("terminal error should not mark the turn aborted")
 		}
+		done = true
 	}
 
-	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-3","status":"failed","error":{"message":"bad auth"}}}}`)
+	c.handleLine(`{"jsonrpc":"2.0","method":"error","params":{"error":{"message":"boom"},"willRetry":false}}`)
 
+	if got := c.getTurnError(); got != "boom" {
+		t.Fatalf("expected terminal error captured, got %q", got)
+	}
 	if !done {
-		t.Fatal("expected onTurnDone for failed status")
+		t.Fatal("terminal error should finish the turn")
 	}
-	if c.lastTurnStatus != "failed" {
-		t.Fatalf("expected lastTurnStatus failed, got %q", c.lastTurnStatus)
+	if got, want := strings.Join(activities, ","), "error:terminal"; got != want {
+		t.Fatalf("semantic activity = %q, want %q", got, want)
 	}
-	if c.lastError != "bad auth" {
-		t.Fatalf("expected lastError bad auth, got %q", c.lastError)
+}
+
+func TestCodexRawErrorNotificationRetryingIgnored(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	var activities []string
+	c.onSemanticActivity = func(activity string) {
+		activities = append(activities, activity)
+	}
+	c.onTurnDone = func(aborted bool) {
+		t.Fatal("retrying error should not finish the turn")
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"error","params":{"error":{"message":"reconnecting"},"willRetry":true}}`)
+
+	if got := c.getTurnError(); got != "" {
+		t.Fatalf("retrying error should not be captured, got %q", got)
+	}
+	if got, want := strings.Join(activities, ","), "error:retry"; got != want {
+		t.Fatalf("semantic activity = %q, want %q", got, want)
+	}
+}
+
+func TestCodexFirstTurnProgressActivity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		activity string
+		want     bool
+	}{
+		{activity: "", want: false},
+		{activity: "status:running", want: false},
+		{activity: "error:retry", want: false},
+		{activity: "error", want: true},
+		{activity: "text", want: true},
+		{activity: "tool-use:exec_command", want: true},
+		{activity: "tool-result:exec_command", want: true},
+		{activity: "item/started:commandExecution:cmd-1", want: true},
+		{activity: "item/completed:agentMessage:msg-1", want: true},
+		{activity: "error:terminal", want: true},
+		{activity: "turn:completed", want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.activity, func(t *testing.T) {
+			if got := isCodexFirstTurnProgressActivity(tc.activity); got != tc.want {
+				t.Fatalf("isCodexFirstTurnProgressActivity(%q) = %v, want %v", tc.activity, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexSetTurnErrorFirstWins(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+
+	c.setTurnError("first")
+	c.setTurnError("second")
+
+	if got := c.getTurnError(); got != "first" {
+		t.Fatalf("expected first-wins semantics, got %q", got)
 	}
 }
 
 func TestCodexRawItemCommandExecution(t *testing.T) {
-	t.Parallel()
-
-	c, stdin, _ := newTestCodexClient(t)
-	c.notificationProtocol = "raw"
-
-	var messages []Message
-	c.onMessage = func(msg Message) {
-		messages = append(messages, msg)
-	}
-
-	// Real Codex raw protocol: approval request arrives first with the command
-	// text; item/started only carries the item id and type, not the command.
-	c.handleLine(`{"jsonrpc":"2.0","id":1,"method":"item/commandExecution/requestApproval","params":{"itemId":"item-1","command":"git status","workingDirectory":"/repo"}}`)
-	// Verify an accept response was written to stdin.
-	if lines := stdin.Lines(); len(lines) == 0 {
-		t.Fatal("expected accept response on stdin")
-	}
-
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/started","params":{"item":{"type":"commandExecution","id":"item-1"}}}`)
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"commandExecution","id":"item-1","aggregatedOutput":"on branch main"}}}`)
-
-	if len(messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(messages))
-	}
-	if messages[0].Type != MessageToolUse || messages[0].Tool != "exec_command" || messages[0].Input["command"] != "git status" {
-		t.Fatalf("unexpected start message: %+v", messages[0])
-	}
-	if messages[1].Type != MessageToolResult || messages[1].Output != "on branch main" {
-		t.Fatalf("unexpected complete message: %+v", messages[1])
-	}
-}
-
-// TestCodexRawItemCommandExecutionFallback verifies that if item/started
-// includes the command field directly (older Codex versions), it still works.
-func TestCodexRawItemCommandExecutionFallback(t *testing.T) {
 	t.Parallel()
 
 	c, _, _ := newTestCodexClient(t)
@@ -423,14 +559,17 @@ func TestCodexRawItemCommandExecutionFallback(t *testing.T) {
 		messages = append(messages, msg)
 	}
 
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/started","params":{"item":{"type":"commandExecution","id":"item-2","command":"ls -la"}}}`)
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"commandExecution","id":"item-2","aggregatedOutput":"total 0"}}}`)
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/started","params":{"item":{"type":"commandExecution","id":"item-1","command":"git status"}}}`)
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"commandExecution","id":"item-1","aggregatedOutput":"on branch main"}}}`)
 
 	if len(messages) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(messages))
 	}
-	if messages[0].Input["command"] != "ls -la" {
-		t.Fatalf("unexpected command: %+v", messages[0])
+	if messages[0].Type != MessageToolUse || messages[0].Tool != "exec_command" || messages[0].Input["command"] != "git status" {
+		t.Fatalf("unexpected start message: %+v", messages[0])
+	}
+	if messages[1].Type != MessageToolResult || messages[1].Output != "on branch main" {
+		t.Fatalf("unexpected complete message: %+v", messages[1])
 	}
 }
 
@@ -462,47 +601,6 @@ func TestCodexRawItemAgentMessageFinalAnswer(t *testing.T) {
 	}
 }
 
-func TestCodexRawAgentMessageDelta(t *testing.T) {
-	t.Parallel()
-
-	c, _, _ := newTestCodexClient(t)
-	c.notificationProtocol = "raw"
-
-	var gotText string
-	c.onMessage = func(msg Message) {
-		if msg.Type == MessageText {
-			gotText += msg.Content
-		}
-	}
-
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"msg-1","delta":"4"}}`)
-
-	if gotText != "4" {
-		t.Fatalf("expected text delta '4', got %q", gotText)
-	}
-}
-
-func TestCodexRawAgentMessageFinalDoesNotDuplicateDelta(t *testing.T) {
-	t.Parallel()
-
-	c, _, _ := newTestCodexClient(t)
-	c.notificationProtocol = "raw"
-
-	var gotText string
-	c.onMessage = func(msg Message) {
-		if msg.Type == MessageText {
-			gotText += msg.Content
-		}
-	}
-
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"msg-1","delta":"4"}}`)
-	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"agentMessage","id":"msg-1","text":"4","phase":"final_answer"}}}`)
-
-	if gotText != "4" {
-		t.Fatalf("expected text to be emitted once, got %q", gotText)
-	}
-}
-
 func TestCodexRawThreadStatusIdle(t *testing.T) {
 	t.Parallel()
 
@@ -522,6 +620,63 @@ func TestCodexRawThreadStatusIdle(t *testing.T) {
 
 	if !turnDone {
 		t.Fatal("expected onTurnDone for idle status")
+	}
+}
+
+// Regression for #1181: subagent threads (e.g. memory consolidation)
+// are multiplexed on the same stdio pipe. Their turn/completed must not
+// terminate the main turn.
+func TestCodexRawTurnCompletedFromSubagentIgnored(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.threadID = "thr_main"
+
+	var doneCount int
+	c.onTurnDone = func(aborted bool) {
+		doneCount++
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr_subagent","turn":{"id":"turn-sub","status":"completed"}}}`)
+
+	if doneCount != 0 {
+		t.Fatalf("subagent turn/completed must not trigger onTurnDone, got %d calls", doneCount)
+	}
+
+	// Sanity check: a matching threadId still drives completion.
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr_main","turn":{"id":"turn-main","status":"completed"}}}`)
+	if doneCount != 1 {
+		t.Fatalf("matching threadId should trigger onTurnDone exactly once, got %d", doneCount)
+	}
+}
+
+// Regression for #1181: subagent agentMessage/final_answer must not
+// trigger turn completion or leak text into the main output stream.
+func TestCodexRawItemAgentMessageFinalAnswerFromSubagentIgnored(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.threadID = "thr_main"
+	c.turnStarted = true
+
+	var messages []Message
+	var doneCount int
+	c.onMessage = func(msg Message) {
+		messages = append(messages, msg)
+	}
+	c.onTurnDone = func(aborted bool) {
+		doneCount++
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr_subagent","item":{"type":"agentMessage","id":"sub-1","text":"subagent leakage","phase":"final_answer"}}}`)
+
+	if len(messages) != 0 {
+		t.Fatalf("subagent text must not leak into output builder, got %+v", messages)
+	}
+	if doneCount != 0 {
+		t.Fatalf("subagent final_answer must not trigger onTurnDone, got %d calls", doneCount)
 	}
 }
 
@@ -619,6 +774,315 @@ func TestNilIfEmpty(t *testing.T) {
 	}
 }
 
+// runRPCScript feeds JSON-RPC responses back to the codexClient by matching
+// each method call written to stdin against the script, and emitting the
+// scripted response via c.handleLine. It returns once all scripted calls have
+// been served.
+type rpcResponse struct {
+	method   string          // expected request method
+	result   json.RawMessage // success result body (mutually exclusive with errMsg)
+	errMsg   string          // non-empty → respond with JSON-RPC error object
+	errCode  int             // JSON-RPC error code when errMsg is set
+	assertFn func(t *testing.T, params map[string]any)
+}
+
+// drainRPCScript spins up a goroutine that watches fs.Lines() for new outbound
+// requests and, for each one, injects the scripted response via c.handleLine.
+// It returns a stop function that blocks until the script is exhausted or the
+// test terminates.
+func drainRPCScript(t *testing.T, c *codexClient, fs *fakeStdin, script []rpcResponse) func() {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		seen := 0
+		deadline := time.Now().Add(2 * time.Second)
+		for seen < len(script) {
+			lines := fs.Lines()
+			for seen < len(lines) && seen < len(script) {
+				var req struct {
+					ID     int             `json:"id"`
+					Method string          `json:"method"`
+					Params json.RawMessage `json:"params"`
+				}
+				if err := json.Unmarshal([]byte(lines[seen]), &req); err != nil {
+					t.Errorf("drainRPCScript: unmarshal request %d: %v", seen, err)
+					return
+				}
+				expected := script[seen]
+				if req.Method != expected.method {
+					t.Errorf("drainRPCScript: call %d method = %q, want %q", seen, req.Method, expected.method)
+					return
+				}
+				if expected.assertFn != nil {
+					var params map[string]any
+					_ = json.Unmarshal(req.Params, &params)
+					expected.assertFn(t, params)
+				}
+				var resp string
+				if expected.errMsg != "" {
+					resp = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"error":{"code":%d,"message":%q}}`, req.ID, expected.errCode, expected.errMsg)
+				} else {
+					resp = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":%s}`, req.ID, string(expected.result))
+				}
+				c.handleLine(resp)
+				seen++
+			}
+			if seen < len(script) {
+				if time.Now().After(deadline) {
+					t.Errorf("drainRPCScript: timed out after %d/%d responses", seen, len(script))
+					return
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+	}()
+
+	return func() {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("drainRPCScript did not finish")
+		}
+	}
+}
+
+func TestCodexStartOrResumeThreadStartsFresh(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method: "thread/start",
+			result: json.RawMessage(`{"thread":{"id":"thr_fresh"}}`),
+			assertFn: func(t *testing.T, params map[string]any) {
+				if params["cwd"] != "/work" {
+					t.Errorf("cwd = %v, want /work", params["cwd"])
+				}
+				if params["persistExtendedHistory"] != true {
+					t.Error("expected persistExtendedHistory=true on thread/start")
+				}
+			},
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(context.Background(), ExecOptions{Cwd: "/work"}, slog.Default())
+	if err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+	if threadID != "thr_fresh" {
+		t.Errorf("threadID = %q, want thr_fresh", threadID)
+	}
+	if resumed {
+		t.Error("resumed should be false when no prior session is provided")
+	}
+}
+
+func TestCodexStartOrResumeThreadSetsNameOnFreshThread(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method: "thread/start",
+			result: json.RawMessage(`{"thread":{"id":"thr_named"}}`),
+		},
+		{
+			method: "thread/name/set",
+			result: json.RawMessage(`{}`),
+			assertFn: func(t *testing.T, params map[string]any) {
+				if params["threadId"] != "thr_named" {
+					t.Errorf("threadId = %v, want thr_named", params["threadId"])
+				}
+				if params["name"] != "Review GitHub issue #3843" {
+					t.Errorf("name = %v, want semantic title", params["name"])
+				}
+			},
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{ThreadName: "Review GitHub issue #3843"},
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+	if threadID != "thr_named" {
+		t.Errorf("threadID = %q, want thr_named", threadID)
+	}
+	if resumed {
+		t.Error("resumed should be false when no prior session is provided")
+	}
+}
+
+func TestCodexStartOrResumeThreadNameFailureDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method: "thread/start",
+			result: json.RawMessage(`{"thread":{"id":"thr_named"}}`),
+		},
+		{
+			method:  "thread/name/set",
+			errMsg:  "unsupported method",
+			errCode: -32601,
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{ThreadName: "Semantic task title"},
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("startOrResumeThread should continue after name failure: %v", err)
+	}
+	if threadID != "thr_named" {
+		t.Errorf("threadID = %q, want thr_named", threadID)
+	}
+	if resumed {
+		t.Error("resumed should be false when no prior session is provided")
+	}
+}
+
+func TestCodexStartOrResumeThreadResumesPriorThread(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method: "thread/resume",
+			result: json.RawMessage(`{"thread":{"id":"thr_prior"}}`),
+			assertFn: func(t *testing.T, params map[string]any) {
+				if params["threadId"] != "thr_prior" {
+					t.Errorf("threadId = %v, want thr_prior", params["threadId"])
+				}
+				if params["cwd"] != "/work" {
+					t.Errorf("cwd = %v, want /work", params["cwd"])
+				}
+			},
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{Cwd: "/work", ResumeSessionID: "thr_prior"},
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+	if threadID != "thr_prior" {
+		t.Errorf("threadID = %q, want thr_prior", threadID)
+	}
+	if !resumed {
+		t.Error("expected resumed=true when thread/resume succeeded")
+	}
+}
+
+func TestCodexStartOrResumeThreadFallsBackOnResumeError(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:  "thread/resume",
+			errMsg:  "unknown thread",
+			errCode: -32602,
+		},
+		{
+			method: "thread/start",
+			result: json.RawMessage(`{"thread":{"id":"thr_new"}}`),
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{Cwd: "/work", ResumeSessionID: "thr_stale"},
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+	if threadID != "thr_new" {
+		t.Errorf("threadID = %q, want thr_new (fresh thread after fallback)", threadID)
+	}
+	if resumed {
+		t.Error("expected resumed=false after falling back to thread/start")
+	}
+}
+
+func TestCodexStartOrResumeThreadFallsBackWhenResumeReturnsNoID(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method: "thread/resume",
+			result: json.RawMessage(`{"thread":{}}`),
+		},
+		{
+			method: "thread/start",
+			result: json.RawMessage(`{"thread":{"id":"thr_new"}}`),
+		},
+	})
+	defer wait()
+
+	threadID, resumed, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{ResumeSessionID: "thr_prior"},
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+	if threadID != "thr_new" {
+		t.Errorf("threadID = %q, want thr_new", threadID)
+	}
+	if resumed {
+		t.Error("expected resumed=false when resume yielded no thread ID")
+	}
+}
+
+func TestCodexStartOrResumeThreadStartFailureSurfaces(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:  "thread/start",
+			errMsg:  "boom",
+			errCode: -32000,
+		},
+	})
+	defer wait()
+
+	_, _, err := c.startOrResumeThread(context.Background(), ExecOptions{}, slog.Default())
+	if err == nil {
+		t.Fatal("expected error when thread/start fails")
+	}
+	if !strings.Contains(err.Error(), "thread/start") {
+		t.Errorf("error should mention thread/start, got %v", err)
+	}
+}
+
 func TestCodexProtocolDetectionLegacyBlocksRaw(t *testing.T) {
 	t.Parallel()
 
@@ -642,5 +1106,944 @@ func TestCodexProtocolDetectionLegacyBlocksRaw(t *testing.T) {
 
 	if len(messages) != messagesBefore {
 		t.Fatal("raw notification should be ignored in legacy mode")
+	}
+}
+
+func TestStderrTailForwardsAndCapturesTail(t *testing.T) {
+	t.Parallel()
+
+	var sink strings.Builder
+	s := newStderrTail(&sink, 16)
+
+	if _, err := s.Write([]byte("first line\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := s.Write([]byte("error: unexpected argument '-m' found\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Inner writer sees every byte verbatim.
+	want := "first line\nerror: unexpected argument '-m' found\n"
+	if sink.String() != want {
+		t.Errorf("inner sink: got %q, want %q", sink.String(), want)
+	}
+
+	// Tail is bounded by max; earlier bytes get dropped.
+	tail := s.Tail()
+	if len(tail) > 16 {
+		t.Errorf("tail exceeds bound: got %d bytes (%q)", len(tail), tail)
+	}
+	if tail == "" {
+		t.Fatal("expected non-empty tail")
+	}
+	// Tail must be a suffix of what was written (whitespace-trimmed).
+	if !strings.HasSuffix(strings.TrimSpace(want), tail) {
+		t.Errorf("tail %q is not a suffix of %q", tail, want)
+	}
+}
+
+func TestStderrTailEmptyWhenNothingWritten(t *testing.T) {
+	t.Parallel()
+
+	var sink strings.Builder
+	s := newStderrTail(&sink, 16)
+	if tail := s.Tail(); tail != "" {
+		t.Errorf("expected empty tail, got %q", tail)
+	}
+}
+
+func TestCodexExecuteSurfacesStderrWhenChildExitsEarly(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Fake codex binary: writes a canonical CLI rejection line to stderr and
+	// exits before ever responding to `initialize`, mimicking what real codex
+	// does when `app-server` gets a flag it doesn't accept. This exercises the
+	// real os/exec stderr pipe-copy goroutine — without drainAndWait joining
+	// cmd.Wait() before sampling stderrBuf.Tail(), Result.Error would come
+	// back empty or truncated here.
+	fakePath := filepath.Join(t.TempDir(), "codex")
+	script := "#!/bin/sh\n" +
+		"echo \"error: unexpected argument '-m' found\" >&2\n" +
+		"exit 2\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Drain message stream so the lifecycle goroutine can progress.
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "codex initialize failed") {
+			t.Fatalf("expected error to mention initialize failure, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "unexpected argument '-m' found") {
+			t.Fatalf("expected error to include stderr hint, got %q", result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-stale"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-stale","turn":{"id":"turn-stale"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thr-stale","item":{"type":"commandExecution","id":"cmd-1","command":"git status"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-stale","item":{"type":"commandExecution","id":"cmd-1","aggregatedOutput":"clean"}}}'`+"\n"+
+		`sleep 5`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "semantic inactivity") {
+		t.Fatalf("expected semantic inactivity error, got %q", result.Error)
+	}
+	if result.SessionID != "thr-stale" {
+		t.Fatalf("expected session id to be preserved, got %q", result.SessionID)
+	}
+}
+
+func TestCodexExecuteFirstTurnNoProgressSurfacesDiagnostics(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-stuck"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-stuck","turn":{"id":"turn-stuck"}}}'`+"\n"+
+		`echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
+		`sleep 5`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	for _, want := range []string{
+		CodexFirstTurnNoProgressMarker,
+		"thr-stuck",
+		"turn-stuck",
+		`model="default(empty)"`,
+		`codex_version="codex-cli 0.0.0-test"`,
+		"model catalog refresh timed out",
+		"codex stderr:",
+		codexModelCatalogRefreshTimeoutSignal,
+	} {
+		if !strings.Contains(result.Error, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, result.Error)
+		}
+	}
+}
+
+func TestCodexExecuteFirstTurnRetryErrorDoesNotSatisfyProgress(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-retry"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-retry","turn":{"id":"turn-retry"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"error","params":{"threadId":"thr-retry","error":{"message":"temporary reconnect"},"willRetry":true}}'`+"\n"+
+		`sleep 5`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 200 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, CodexFirstTurnNoProgressMarker) {
+		t.Fatalf("expected first-turn no-progress error, got %q", result.Error)
+	}
+	if strings.Contains(result.Error, CodexSemanticInactivityMarker) {
+		t.Fatalf("retrying error should not demote first-turn timeout to semantic inactivity, got %q", result.Error)
+	}
+}
+
+func TestCodexExecuteLegacyFirstTurnMessageSatisfiesProgress(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-legacy"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"task_started"}}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"agent_message","message":"legacy alive"}}}'`+"\n"+
+		`sleep 0.07`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"task_complete"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Output != "legacy alive" {
+		t.Fatalf("expected legacy output, got %q", result.Output)
+	}
+}
+
+func TestCodexExecuteSemanticInactivityAllowsContinuousMessages(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-progress"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-progress","turn":{"id":"turn-progress"}}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-progress","item":{"type":"agentMessage","id":"msg-1","text":"still working"}}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-progress","item":{"type":"commandExecution","id":"cmd-1","aggregatedOutput":"ok"}}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-progress","turn":{"id":"turn-progress","status":"completed"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 90 * time.Millisecond,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "still working") {
+		t.Fatalf("expected streamed text in output, got %q", result.Output)
+	}
+}
+
+func TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-delta"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-delta","turn":{"id":"turn-delta"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/commandExecution/outputDelta","params":{"threadId":"thr-delta","item":{"type":"commandExecution","id":"cmd-1"},"delta":"line 1\n"}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thr-delta","item":{"type":"agentMessage","id":"msg-1"},"delta":"thinking"}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/fileChange/outputDelta","params":{"threadId":"thr-delta","item":{"type":"fileChange","id":"patch-1"},"delta":"patched"}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/mcpToolCall/progress","params":{"threadId":"thr-delta","item":{"type":"mcpToolCall","id":"mcp-1"},"progress":{"message":"still running"}}}'`+"\n"+
+		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-delta","turn":{"id":"turn-delta","status":"completed"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 150 * time.Millisecond,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+}
+
+func TestCodexExecuteSemanticInactivityDoesNotAffectNormalTurnCompletion(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-normal"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-normal","turn":{"id":"turn-normal"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-normal","item":{"type":"agentMessage","id":"msg-1","text":"Done"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-normal","turn":{"id":"turn-normal","status":"completed"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Output != "Done" {
+		t.Fatalf("expected output Done, got %q", result.Output)
+	}
+}
+
+func writeFakeCodexAppServer(t *testing.T, body string) string {
+	t.Helper()
+	fakePath := filepath.Join(t.TempDir(), "codex")
+	script := "#!/bin/sh\n" +
+		`if [ "$1" = "--version" ]; then echo "codex-cli 0.0.0-test"; exit 0; fi` + "\n" +
+		body
+	writeTestExecutable(t, fakePath, []byte(script))
+	return fakePath
+}
+
+func executeFakeCodex(t *testing.T, fakePath string, opts ExecOptions) Result {
+	t.Helper()
+	backend, err := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt", opts)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		return result
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+		return Result{}
+	}
+}
+
+func TestWithAgentStderrAppendsHint(t *testing.T) {
+	t.Parallel()
+
+	if got := withAgentStderr("codex initialize failed: process exited", "codex", ""); got != "codex initialize failed: process exited" {
+		t.Errorf("empty tail should not modify msg, got %q", got)
+	}
+	msg := withAgentStderr("codex initialize failed: process exited", "codex", "unexpected argument '-m' found")
+	want := "codex initialize failed: process exited; codex stderr: unexpected argument '-m' found"
+	if msg != want {
+		t.Errorf("got %q, want %q", msg, want)
+	}
+}
+
+func TestBuildCodexArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
+	args := buildCodexArgs(ExecOptions{
+		ExtraArgs:  []string{"--listen", "tcp://evil", "--sandbox", "read-only"},
+		CustomArgs: []string{"--sandbox", "workspace-write", "--listen=bad"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "tcp://evil") || strings.Contains(joined, "--listen=bad") {
+		t.Fatalf("blocked args should be filtered from both layers: %v", args)
+	}
+	extraIdx, customIdx := -1, -1
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--sandbox" && args[i+1] == "read-only" {
+			extraIdx = i
+		}
+		if args[i] == "--sandbox" && args[i+1] == "workspace-write" {
+			customIdx = i
+		}
+	}
+	if extraIdx == -1 || customIdx == -1 || extraIdx > customIdx {
+		t.Fatalf("expected extra args before custom args, got %v", args)
+	}
+}
+
+func TestBuildCodexArgsDoesNotLeakMcpToArgv(t *testing.T) {
+	t.Parallel()
+
+	// MCP config is materialised into $CODEX_HOME/config.toml, never into
+	// argv — otherwise `mcp_servers.<id>.env` secrets would land in
+	// `ps aux` output and in the daemon's `agent command` log line. This
+	// test pins the contract: even with a non-empty mcp_config, no -c /
+	// --config / mcp_servers.* entry shows up in buildCodexArgs output.
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","env":{"SECRET":"hunter2"}}}}`)
+	args := buildCodexArgs(ExecOptions{
+		McpConfig:  raw,
+		CustomArgs: []string{"-c", `model="o3"`},
+	}, slog.Default())
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "mcp_servers") {
+		t.Fatalf("argv must not mention mcp_servers (now lives in config.toml), got %v", args)
+	}
+	if strings.Contains(joined, "hunter2") {
+		t.Fatalf("argv must not leak secret env values, got %v", args)
+	}
+	for i := 0; i+1 < len(args); i++ {
+		if (args[i] == "-c" || args[i] == "--config") && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			t.Fatalf("expected no -c mcp_servers.* in argv, got %v", args)
+		}
+	}
+	// Legitimate non-mcp `-c model=…` from custom_args must still survive.
+	foundModel := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && args[i+1] == `model="o3"` {
+			foundModel = true
+		}
+	}
+	if !foundModel {
+		t.Fatalf("expected non-mcp -c override to be preserved, got %v", args)
+	}
+}
+
+func TestCodexExecuteFailsClosedWhenMcpConfigInvalid(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// When the admin has a managed mcp_config but the JSON is malformed
+	// (or any other reason ensureCodexMcpConfig fails), fail closed
+	// instead of silently launching with the user's global MCP — that
+	// would look indistinguishable from "the saved config was applied"
+	// and is exactly the surprise the MCP Tab is supposed to remove.
+	fakePath := writeFakeCodexAppServer(t, "exit 0\n")
+
+	codexHome := t.TempDir()
+	backend, err := New("codex", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"CODEX_HOME": codexHome},
+	})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = backend.Execute(ctx, "prompt", ExecOptions{
+		Timeout:   2 * time.Second,
+		McpConfig: json.RawMessage(`not json`),
+	})
+	if err == nil {
+		t.Fatal("expected Execute to fail closed on malformed mcp_config, got nil error")
+	}
+	if !strings.Contains(err.Error(), "mcp_config") {
+		t.Fatalf("expected error to mention mcp_config, got %q", err)
+	}
+}
+
+func TestCodexExecuteFailsClosedWhenManagedMcpButNoCodexHome(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Managed mcp_config saved but no CODEX_HOME to anchor it — same
+	// fail-closed reasoning: silently launching would inherit whatever
+	// MCP setup the host user has, which is the wrong shape of failure.
+	fakePath := writeFakeCodexAppServer(t, "exit 0\n")
+
+	backend, err := New("codex", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{}, // no CODEX_HOME
+	})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = backend.Execute(ctx, "prompt", ExecOptions{
+		Timeout:   2 * time.Second,
+		McpConfig: json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx"}}}`),
+	})
+	if err == nil {
+		t.Fatal("expected Execute to fail closed when managed mcp_config but no CODEX_HOME, got nil error")
+	}
+	if !strings.Contains(err.Error(), "CODEX_HOME") {
+		t.Fatalf("expected error to mention CODEX_HOME, got %q", err)
+	}
+}
+
+func TestBuildCodexArgsPreservesCustomMcpOverridesWhenUnmanaged(t *testing.T) {
+	t.Parallel()
+
+	// Existing Codex agents may rely on `custom_args: ["-c", "mcp_servers.…"]`
+	// because before MUL-2764 there was no MCP Tab. When the agent has
+	// no managed mcp_config saved, the daemon must leave those entries
+	// alone — silently dropping them would break the only way those
+	// users had to configure MCP. We only claim the `mcp_servers`
+	// namespace once an admin opts in via the MCP Tab.
+	args := buildCodexArgs(ExecOptions{
+		CustomArgs: []string{"-c", `mcp_servers.fetch={ command = "uvx" }`, "-c", `model="o3"`},
+	}, slog.Default())
+	foundMcp := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			foundMcp = true
+		}
+	}
+	if !foundMcp {
+		t.Fatalf("custom_args mcp_servers entry must survive when agent has no managed mcp_config, got %v", args)
+	}
+}
+
+func TestBuildCodexArgsDropsCustomMcpOverridesWhenManaged(t *testing.T) {
+	t.Parallel()
+
+	// Once an admin saves a managed mcp_config, the daemon owns
+	// the `mcp_servers` namespace via $CODEX_HOME/config.toml. Codex's
+	// `-c` is last-wins, so any `-c mcp_servers.…` left in custom_args
+	// would silently shadow the saved managed entries.
+	raw := json.RawMessage(`{"mcpServers":{"managed":{"command":"managed-cmd"}}}`)
+	args := buildCodexArgs(ExecOptions{
+		McpConfig:  raw,
+		CustomArgs: []string{"-c", `mcp_servers.fetch={ command = "evil" }`, "-c", `model="o3"`},
+	}, slog.Default())
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			t.Fatalf("custom_args mcp_servers must be filtered when managed mcp_config is present, got %v", args)
+		}
+	}
+	// Unrelated -c key still passes through.
+	foundModel := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && args[i+1] == `model="o3"` {
+			foundModel = true
+		}
+	}
+	if !foundModel {
+		t.Fatalf("unrelated -c override must still survive, got %v", args)
+	}
+}
+
+func TestFilterCodexCustomConfigOverridesDropsMcpServers(t *testing.T) {
+	t.Parallel()
+
+	// Codex `-c` is last-wins, so a user-supplied `-c mcp_servers.…` in
+	// custom_args would silently shadow whatever the MCP Tab wrote into
+	// CODEX_HOME/config.toml. Verify that all spellings of the override
+	// get dropped, while unrelated `-c` keys pass through.
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "separated -c mcp_servers.fetch=…",
+			in:   []string{"-c", `mcp_servers.fetch={ command = "evil" }`, "-c", `model="o3"`},
+			want: []string{"-c", `model="o3"`},
+		},
+		{
+			name: "inline -c=mcp_servers.fetch=…",
+			in:   []string{`-c=mcp_servers.fetch={ command = "evil" }`, "--listen=keep"},
+			want: []string{"--listen=keep"},
+		},
+		{
+			name: "long form --config mcp_servers.x.env.KEY=val",
+			in:   []string{"--config", `mcp_servers.x.env.KEY="leak"`, "--config", `sandbox="workspace-write"`},
+			want: []string{"--config", `sandbox="workspace-write"`},
+		},
+		{
+			name: "passes through unrelated -c overrides",
+			in:   []string{"-c", `model="o3"`, "-c", `sandbox.network_access=true`},
+			want: []string{"-c", `model="o3"`, "-c", `sandbox.network_access=true`},
+		},
+		{
+			name: "matches mcp_servers root assignment",
+			in:   []string{"-c", `mcp_servers={fetch={command="evil"}}`, "-c", `model="o3"`},
+			want: []string{"-c", `model="o3"`},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterCodexCustomConfigOverrides(tc.in, slog.Default())
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("filterCodexCustomConfigOverrides(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnsureCodexMcpConfigEmptyClearsBlock(t *testing.T) {
+	t.Parallel()
+
+	// When agent.mcp_config is null/empty the managed block is removed
+	// from config.toml, but unrelated content (sandbox block, user-level
+	// `[mcp_servers.user]`) is left untouched.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	initial := "sandbox_mode = \"workspace-write\"\n\n" +
+		multicaCodexMcpBeginMarker + "\n" +
+		"[mcp_servers.fetch]\ncommand = \"uvx\"\n" +
+		multicaCodexMcpEndMarker + "\n\n" +
+		"[mcp_servers.user_global]\ncommand = \"keep\"\n"
+	if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := ensureCodexMcpConfig(tmp, nil, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, multicaCodexMcpBeginMarker) {
+		t.Fatalf("managed block should be cleared, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.user_global]") {
+		t.Fatalf("user-defined mcp_servers should be left alone when agent has no mcp_config, got:\n%s", got)
+	}
+	if !strings.Contains(got, `sandbox_mode = "workspace-write"`) {
+		t.Fatalf("unrelated config preserved, got:\n%s", got)
+	}
+}
+
+func TestEnsureCodexMcpConfigWritesManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	// A non-empty mcp_config writes one `[mcp_servers.<name>]` table per
+	// server, in stable alphabetical order, into the managed block. The
+	// file mode is 0o600 because env values may carry secrets.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"zeta":{"command":"b"},"alpha":{"command":"a","env":{"K":"v"}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, multicaCodexMcpBeginMarker) || !strings.Contains(got, multicaCodexMcpEndMarker) {
+		t.Fatalf("expected managed block markers, got:\n%s", got)
+	}
+	alphaIdx := strings.Index(got, "[mcp_servers.alpha]")
+	zetaIdx := strings.Index(got, "[mcp_servers.zeta]")
+	if alphaIdx == -1 || zetaIdx == -1 {
+		t.Fatalf("expected both server tables, got:\n%s", got)
+	}
+	if alphaIdx > zetaIdx {
+		t.Fatalf("expected alpha before zeta (alphabetical), got:\n%s", got)
+	}
+	for _, want := range []string{
+		`command = "a"`,
+		`env = { K = "v" }`,
+		`command = "b"`,
+		`sandbox_mode = "workspace-write"`, // unrelated user content preserved
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+
+	fi, err := os.Stat(tmp)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := fi.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("expected mode 0o600 for secret-bearing config, got %o", mode)
+	}
+}
+
+func TestEnsureCodexMcpConfigForces0600OnPreexistingFile(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+
+	// `execenv.copyFile` seeds the per-task config.toml at 0o644. Once we
+	// add secret-bearing mcp_servers tables to it, the mode must drop to
+	// 0o600 — `os.WriteFile` alone keeps the existing mode, so the chmod
+	// is the part we need to pin.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","env":{"API_KEY":"secret"}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	fi, err := os.Stat(tmp)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := fi.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("expected 0o600 after overwrite of pre-existing 0o644 file, got %o", mode)
+	}
+}
+
+func TestEnsureCodexMcpConfigStripsUserMcpServersWhenManaged(t *testing.T) {
+	t.Parallel()
+
+	// When agent.mcp_config is non-empty, ALL user-defined `[mcp_servers.*]`
+	// tables (inherited from ~/.codex/config.toml) are stripped to avoid
+	// (a) TOML "table already exists" errors when names collide and (b) the
+	// user's global servers silently being mixed in with the strict
+	// agent-managed list. Sub-tables like `[mcp_servers.x.env]` are also
+	// dropped as part of their parent.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	initial := "sandbox_mode = \"workspace-write\"\n\n" +
+		"[mcp_servers.global_fetch]\ncommand = \"uvx-old\"\n\n" +
+		"[mcp_servers.global_fetch.env]\nOLD_KEY = \"old\"\n\n" +
+		"[other_section]\nkeep_me = true\n"
+	if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"new_server":{"command":"new"}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, _ := os.ReadFile(tmp)
+	got := string(data)
+
+	if strings.Contains(got, "global_fetch") {
+		t.Fatalf("user mcp_servers tables must be stripped when agent has its own mcp_config, got:\n%s", got)
+	}
+	if strings.Contains(got, "OLD_KEY") {
+		t.Fatalf("user mcp_servers sub-tables must be stripped too, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[other_section]") || !strings.Contains(got, "keep_me = true") {
+		t.Fatalf("unrelated tables must survive, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.new_server]") {
+		t.Fatalf("managed server should be written, got:\n%s", got)
+	}
+}
+
+func TestEnsureCodexMcpConfigIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Running ensure twice with the same input must produce byte-identical
+	// output — needed because Prepare and Reuse may both call into this on
+	// the same per-task config.toml across a task's lifetime.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["a","b"]}}}`)
+
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	first, _ := os.ReadFile(tmp)
+
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	second, _ := os.ReadFile(tmp)
+
+	if string(first) != string(second) {
+		t.Fatalf("non-idempotent write:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestEnsureCodexMcpConfigRejectsBadShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"non-json", `not json`},
+		{"server is array", `{"mcpServers":{"x":[1,2]}}`},
+		{"server is string", `{"mcpServers":{"x":"oops"}}`},
+		{"null value inside server", `{"mcpServers":{"x":{"command":null}}}`},
+		{"bad server name", `{"mcpServers":{"has space":{"command":"a"}}}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmp := filepath.Join(t.TempDir(), "config.toml")
+			if err := ensureCodexMcpConfig(tmp, json.RawMessage(tc.raw), slog.Default()); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestEnsureCodexMcpConfigAbsentLeavesUserTablesAlone(t *testing.T) {
+	t.Parallel()
+
+	// nil / `null` map to the API's "absent" state: the agent has no
+	// managed mcp_config, so the daemon must not touch the user's
+	// inherited `[mcp_servers.*]` tables — the run falls back to the
+	// user's global CLI config.
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		tmp := filepath.Join(t.TempDir(), "config.toml")
+		initial := "sandbox_mode = \"workspace-write\"\n\n" +
+			"[mcp_servers.user_global]\ncommand = \"keep\"\n"
+		if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+			t.Fatalf("ensure (%q): %v", string(raw), err)
+		}
+		data, _ := os.ReadFile(tmp)
+		got := string(data)
+		if !strings.Contains(got, "[mcp_servers.user_global]") {
+			t.Fatalf("absent mcp_config (%q) must leave user MCP tables alone, got:\n%s", string(raw), got)
+		}
+		if strings.Contains(got, multicaCodexMcpBeginMarker) {
+			t.Fatalf("absent mcp_config (%q) must not write managed markers, got:\n%s", string(raw), got)
+		}
+	}
+}
+
+func TestEnsureCodexMcpConfigEmptyManagedSetStripsUserMcp(t *testing.T) {
+	t.Parallel()
+
+	// `{}` / `{"mcpServers":{}}` map to the API's "present, empty" state.
+	// The admin saved an explicit (empty) MCP list, so the daemon must
+	// strip inherited user `[mcp_servers.*]` tables and pin the managed
+	// markers — equivalent to Claude's --strict-mcp-config with an empty
+	// servers map. Falling back to the user's global MCP would defeat
+	// the affordance.
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"mcpServers":{}}`),
+	} {
+		tmp := filepath.Join(t.TempDir(), "config.toml")
+		initial := "sandbox_mode = \"workspace-write\"\n\n" +
+			"[mcp_servers.user_global]\ncommand = \"keep\"\n"
+		if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+			t.Fatalf("ensure (%q): %v", string(raw), err)
+		}
+		data, _ := os.ReadFile(tmp)
+		got := string(data)
+		if strings.Contains(got, "user_global") {
+			t.Fatalf("managed empty set (%q) must strip user MCP tables, got:\n%s", string(raw), got)
+		}
+		if !strings.Contains(got, multicaCodexMcpBeginMarker) || !strings.Contains(got, multicaCodexMcpEndMarker) {
+			t.Fatalf("managed empty set (%q) must still write markers so future runs find them, got:\n%s", string(raw), got)
+		}
+		if !strings.Contains(got, `sandbox_mode = "workspace-write"`) {
+			t.Fatalf("unrelated content must survive (%q), got:\n%s", string(raw), got)
+		}
+	}
+}
+
+func TestEnsureCodexMcpConfigEmptyManagedSetIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Running ensure twice with the same `{}` input must produce
+	// byte-identical output — guards against the empty-marker block
+	// accreting blank lines or duplicate markers across reruns.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	raw := json.RawMessage(`{}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	first, _ := os.ReadFile(tmp)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	second, _ := os.ReadFile(tmp)
+	if string(first) != string(second) {
+		t.Fatalf("non-idempotent write:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestHasManagedCodexMcpConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty bytes", json.RawMessage(""), false},
+		{"whitespace only", json.RawMessage("   \n\t"), false},
+		{"json null", json.RawMessage(`null`), false},
+		{"json null with whitespace", json.RawMessage(" null \n"), false},
+		{"empty object", json.RawMessage(`{}`), true},
+		{"empty mcp servers map", json.RawMessage(`{"mcpServers":{}}`), true},
+		{"populated", json.RawMessage(`{"mcpServers":{"x":{"command":"a"}}}`), true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasManagedCodexMcpConfig(tc.raw); got != tc.want {
+				t.Fatalf("hasManagedCodexMcpConfig(%q) = %v, want %v", string(tc.raw), got, tc.want)
+			}
+		})
 	}
 }

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -5,50 +5,41 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
 
 // cursorBackend implements Backend by spawning the Cursor Agent CLI
-// with --output-format stream-json, similar to Claude Code.
+// (cursor-agent) with --output-format stream-json and parsing the JSONL
+// event stream. The protocol is similar to Claude Code's stream-json
+// format: events are newline-delimited JSON objects with a "type" field.
 type cursorBackend struct {
 	cfg Config
 }
 
 func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
-	execPath := b.cfg.ExecutablePath
-	if execPath == "" {
-		execPath = "agent"
+	execName := b.cfg.ExecutablePath
+	if execName == "" {
+		execName = "cursor-agent"
 	}
-	if _, err := exec.LookPath(execPath); err != nil {
-		return nil, fmt.Errorf("cursor agent executable not found at %q: %w", execPath, err)
+	lookedUp, err := exec.LookPath(execName)
+	if err != nil {
+		return nil, fmt.Errorf("cursor-agent executable not found at %q: %w", execName, err)
 	}
 
 	timeout := opts.Timeout
-	if timeout == 0 {
-		timeout = 20 * time.Minute
-	}
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	runCtx, cancel := runContext(ctx, timeout)
 
-	args := []string{
-		"-p",
-		"--output-format", "stream-json",
-		"--force",
-		"--trust",
-	}
-	if opts.Model != "" {
-		args = append(args, "--model", opts.Model)
-	}
-	if opts.MaxTurns > 0 {
-		b.cfg.Logger.Warn("cursor agent does not support --max-turns; ignoring", "maxTurns", opts.MaxTurns)
-	}
-	if opts.ResumeSessionID != "" {
-		args = append(args, "--resume", opts.ResumeSessionID)
-	}
-	args = append(args, prompt)
+	args := buildCursorArgs(prompt, opts, b.cfg.Logger)
+	argv0, cmdArgs := chooseCursorInvocation(execName, lookedUp, args, b.cfg.Logger)
 
-	cmd := exec.CommandContext(runCtx, execPath, args...)
+	cmd := exec.CommandContext(runCtx, argv0, cmdArgs...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", argv0, "args", cmdArgs)
+	cmd.WaitDelay = 500 * time.Millisecond
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
@@ -59,14 +50,15 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("cursor stdout pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[cursor:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[cursor:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
-		return nil, fmt.Errorf("start cursor agent: %w", err)
+		return nil, fmt.Errorf("start cursor-agent: %w", err)
 	}
 
-	b.cfg.Logger.Info("cursor agent started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+	b.cfg.Logger.Info("cursor-agent started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
@@ -76,67 +68,166 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		defer close(msgCh)
 		defer close(resCh)
 
+		// Close stdout when the context is cancelled so scanner.Scan() unblocks.
+		go func() {
+			<-runCtx.Done()
+			_ = stdout.Close()
+		}()
+
 		startTime := time.Now()
 		var output strings.Builder
 		var sessionID string
 		finalStatus := "completed"
 		var finalError string
+		resultSeen := false
+		// stepUsage accumulates per-step token counts from "step_finish" events.
+		// resultUsage holds authoritative session totals from "result" events.
+		// If the result event includes usage, we use resultUsage exclusively;
+		// otherwise we fall back to stepUsage.
+		stepUsage := make(map[string]TokenUsage)
+		resultUsage := make(map[string]TokenUsage)
+		hasResultUsage := false
 
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
 
 		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
+			raw := scanner.Text()
+			line := normalizeCursorStreamLine(raw)
 			if line == "" {
 				continue
 			}
 
-			var msg cursorSDKMessage
-			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			var evt cursorStreamEvent
+			if err := json.Unmarshal([]byte(line), &evt); err != nil {
 				continue
 			}
 
-			switch msg.Type {
-			case "assistant":
-				b.handleAssistant(msg, msgCh, &output)
-			case "user":
-				b.handleUser(msg, msgCh)
+			if sid := evt.readSessionID(); sid != "" {
+				sessionID = sid
+			}
+
+			switch evt.Type {
 			case "system":
-				if msg.SessionID != "" {
-					sessionID = msg.SessionID
+				if evt.Subtype == "init" {
+					trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
 				}
-				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
-			case "result":
-				sessionID = msg.SessionID
-				if msg.ResultText != "" {
-					output.Reset()
-					output.WriteString(msg.ResultText)
+				if evt.Subtype == "error" {
+					errMsg := cursorErrorText(&evt)
+					if errMsg != "" {
+						trySend(msgCh, Message{Type: MessageError, Content: errMsg})
+					}
 				}
-				if msg.IsError {
-					finalStatus = "failed"
-					finalError = msg.ResultText
+
+			case "assistant":
+				b.handleCursorAssistant(&evt, msgCh, &output)
+
+			case "user":
+				// Older cursor-agent builds mirror Claude's stream-json
+				// shape and deliver tool results nested in user messages.
+				b.handleCursorUser(&evt, msgCh)
+
+			case "tool_use":
+				var params map[string]any
+				if evt.Parameters != nil {
+					_ = json.Unmarshal(evt.Parameters, &params)
 				}
+				trySend(msgCh, Message{
+					Type:   MessageToolUse,
+					Tool:   evt.ToolName,
+					CallID: evt.ToolID,
+					Input:  params,
+				})
+
+			case "tool_result":
+				trySend(msgCh, Message{
+					Type:   MessageToolResult,
+					CallID: evt.ToolID,
+					Output: evt.Output,
+				})
+
 			case "tool_call":
-				b.handleToolCall(msg, msgCh, &output)
+				// Legacy event shape: call_id top-level, tool_call keyed by
+				// tool type (e.g. "shellToolCall") with subtype started/completed.
+				b.handleCursorToolCall(&evt, msgCh)
+
+			case "result":
+				resultSeen = true
+				if evt.IsError || evt.Subtype == "error" {
+					finalStatus = "failed"
+					finalError = cursorErrorText(&evt)
+				}
+				if evt.ResultText != "" && output.Len() == 0 {
+					output.WriteString(evt.ResultText)
+				}
+				b.accumulateResultUsage(resultUsage, &evt)
+				if evt.Usage != nil {
+					hasResultUsage = true
+				}
+				// Current Cursor Agent versions can emit the terminal result
+				// event but keep a worker process alive. Treat result as the
+				// protocol boundary so the daemon can report completion.
+				cancel()
+
+			case "error":
+				errMsg := cursorErrorText(&evt)
+				if errMsg != "" {
+					finalError = errMsg
+				}
+				trySend(msgCh, Message{Type: MessageError, Content: errMsg})
+
+			case "text":
+				if evt.Part != nil {
+					var part cursorTextPart
+					_ = json.Unmarshal(evt.Part, &part)
+					if part.Text != "" {
+						output.WriteString(part.Text)
+						trySend(msgCh, Message{Type: MessageText, Content: part.Text})
+					}
+				}
+
+			case "step_finish":
+				if evt.Part != nil {
+					var part cursorStepFinishPart
+					_ = json.Unmarshal(evt.Part, &part)
+					model := evt.Model
+					if model == "" {
+						model = "cursor"
+					}
+					u := stepUsage[model]
+					u.InputTokens += int64(part.Tokens.Input)
+					u.OutputTokens += int64(part.Tokens.Output)
+					u.CacheReadTokens += int64(part.Tokens.Cache.Read)
+					stepUsage[model] = u
+				}
 			}
 		}
 
-		// Wait for process exit.
+		// Use result usage if available (session totals); otherwise fall back
+		// to accumulated step_finish usage.
+		if !hasResultUsage {
+			resultUsage = stepUsage
+		}
+
 		exitErr := cmd.Wait()
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
 			finalStatus = "timeout"
-			finalError = fmt.Sprintf("cursor agent timed out after %s", timeout)
-		} else if runCtx.Err() == context.Canceled {
+			finalError = fmt.Sprintf("cursor-agent timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled && !resultSeen {
 			finalStatus = "aborted"
 			finalError = "execution cancelled"
-		} else if exitErr != nil && finalStatus == "completed" {
+		} else if exitErr != nil && finalStatus == "completed" && !resultSeen {
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("cursor agent exited with error: %v", exitErr)
+			finalError = fmt.Sprintf("cursor-agent exited with error: %v", exitErr)
 		}
 
-		b.cfg.Logger.Info("cursor agent finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+		if finalError != "" && finalStatus != "completed" {
+			finalError = withAgentStderr(finalError, "cursor", stderrBuf.Tail())
+		}
+
+		b.cfg.Logger.Info("cursor-agent finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
 		resCh <- Result{
 			Status:     finalStatus,
@@ -144,21 +235,30 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
 			SessionID:  sessionID,
+			Usage:      resultUsage,
 		}
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-func (b *cursorBackend) handleAssistant(msg cursorSDKMessage, ch chan<- Message, output *strings.Builder) {
-	var content cursorMessageContent
-	if err := json.Unmarshal(msg.Message, &content); err != nil {
+func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- Message, output *strings.Builder) {
+	if evt.Message == nil {
 		return
 	}
 
+	var content cursorAssistantMessage
+	if err := json.Unmarshal(evt.Message, &content); err != nil {
+		return
+	}
+
+	// Note: per-message usage in assistant events is intentionally ignored.
+	// Token usage is taken exclusively from "result" events (session totals)
+	// to avoid double-counting.
+
 	for _, block := range content.Content {
 		switch block.Type {
-		case "text":
+		case "output_text", "text":
 			if block.Text != "" {
 				output.WriteString(block.Text)
 				trySend(ch, Message{Type: MessageText, Content: block.Text})
@@ -182,12 +282,16 @@ func (b *cursorBackend) handleAssistant(msg cursorSDKMessage, ch chan<- Message,
 	}
 }
 
-func (b *cursorBackend) handleUser(msg cursorSDKMessage, ch chan<- Message) {
-	var content cursorMessageContent
-	if err := json.Unmarshal(msg.Message, &content); err != nil {
+// handleCursorUser handles legacy Claude-style user messages that carry
+// tool_result blocks nested in the message content.
+func (b *cursorBackend) handleCursorUser(evt *cursorStreamEvent, ch chan<- Message) {
+	if evt.Message == nil {
 		return
 	}
-
+	var content cursorAssistantMessage
+	if err := json.Unmarshal(evt.Message, &content); err != nil {
+		return
+	}
 	for _, block := range content.Content {
 		if block.Type == "tool_result" {
 			resultStr := ""
@@ -203,11 +307,15 @@ func (b *cursorBackend) handleUser(msg cursorSDKMessage, ch chan<- Message) {
 	}
 }
 
-func (b *cursorBackend) handleToolCall(msg cursorSDKMessage, ch chan<- Message, output *strings.Builder) {
-	// Cursor stream-json format: call_id is top-level; tool_call is a map keyed
-	// by tool type (e.g. "shellToolCall") whose value is the tool-specific payload.
+// handleCursorToolCall handles the legacy "tool_call" event shape: call_id is
+// top-level; tool_call is a map keyed by tool type (e.g. "shellToolCall")
+// whose value is the tool-specific payload.
+func (b *cursorBackend) handleCursorToolCall(evt *cursorStreamEvent, ch chan<- Message) {
+	if evt.ToolCall == nil {
+		return
+	}
 	var toolCallMap map[string]json.RawMessage
-	if err := json.Unmarshal(msg.ToolCall, &toolCallMap); err != nil {
+	if err := json.Unmarshal(evt.ToolCall, &toolCallMap); err != nil {
 		return
 	}
 
@@ -222,7 +330,7 @@ func (b *cursorBackend) handleToolCall(msg cursorSDKMessage, ch chan<- Message, 
 		return
 	}
 
-	switch msg.Subtype {
+	switch evt.Subtype {
 	case "started":
 		var input map[string]any
 		if toolPayload != nil {
@@ -231,7 +339,7 @@ func (b *cursorBackend) handleToolCall(msg cursorSDKMessage, ch chan<- Message, 
 		trySend(ch, Message{
 			Type:   MessageToolUse,
 			Tool:   toolName,
-			CallID: msg.CallID,
+			CallID: evt.CallID,
 			Input:  input,
 		})
 	case "completed":
@@ -242,36 +350,81 @@ func (b *cursorBackend) handleToolCall(msg cursorSDKMessage, ch chan<- Message, 
 		trySend(ch, Message{
 			Type:   MessageToolResult,
 			Tool:   toolName,
-			CallID: msg.CallID,
+			CallID: evt.CallID,
 			Output: resultStr,
 		})
 	}
 }
 
-// ── Cursor SDK JSON types ──
-
-// cursorSDKMessage represents a single JSON line from cursor-agent --output-format stream-json.
-// The format closely mirrors Claude Code's stream-json output, with an additional
-// "tool_call" event type.
-type cursorSDKMessage struct {
-	Type      string          `json:"type"`
-	Subtype   string          `json:"subtype,omitempty"`
-	Message   json.RawMessage `json:"message,omitempty"`
-	SessionID string          `json:"session_id,omitempty"`
-	CallID    string          `json:"call_id,omitempty"`
-
-	// result fields
-	ResultText string  `json:"result,omitempty"`
-	IsError    bool    `json:"is_error,omitempty"`
-	DurationMs float64 `json:"duration_ms,omitempty"`
-
-	// tool_call fields — map keyed by tool type (e.g. "shellToolCall")
-	ToolCall json.RawMessage `json:"tool_call,omitempty"`
+func (b *cursorBackend) accumulateResultUsage(usage map[string]TokenUsage, evt *cursorStreamEvent) {
+	if evt.Usage == nil {
+		return
+	}
+	model := evt.Model
+	if model == "" {
+		model = "cursor"
+	}
+	u := usage[model]
+	u.InputTokens += evt.Usage.InputTokens
+	u.OutputTokens += evt.Usage.OutputTokens
+	u.CacheReadTokens += evt.Usage.CacheReadInputTokens
+	usage[model] = u
 }
 
-type cursorMessageContent struct {
-	Role    string               `json:"role"`
+// ── Cursor stream-json types ──
+
+type cursorStreamEvent struct {
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Model     string `json:"model,omitempty"`
+
+	// assistant fields
+	Message json.RawMessage `json:"message,omitempty"`
+
+	// tool_use fields
+	ToolName   string          `json:"tool_name,omitempty"`
+	ToolID     string          `json:"tool_id,omitempty"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+
+	// tool_result fields
+	Output string `json:"output,omitempty"`
+
+	// legacy tool_call fields — map keyed by tool type (e.g. "shellToolCall")
+	CallID   string          `json:"call_id,omitempty"`
+	ToolCall json.RawMessage `json:"tool_call,omitempty"`
+
+	// result fields
+	ResultText string       `json:"result,omitempty"`
+	IsError    bool         `json:"is_error,omitempty"`
+	Usage      *cursorUsage `json:"usage,omitempty"`
+	TotalCost  float64      `json:"total_cost_usd,omitempty"`
+
+	// error fields
+	ErrorMsg string `json:"error,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+
+	// legacy compat
+	Part json.RawMessage `json:"part,omitempty"`
+}
+
+func (evt *cursorStreamEvent) readSessionID() string {
+	if s := strings.TrimSpace(evt.SessionID); s != "" {
+		return s
+	}
+	return ""
+}
+
+type cursorUsage struct {
+	InputTokens          int64 `json:"input_tokens"`
+	OutputTokens         int64 `json:"output_tokens"`
+	CacheReadInputTokens int64 `json:"cached_input_tokens"`
+}
+
+type cursorAssistantMessage struct {
+	Model   string               `json:"model"`
 	Content []cursorContentBlock `json:"content"`
+	Usage   *cursorUsage         `json:"usage,omitempty"`
 }
 
 type cursorContentBlock struct {
@@ -284,3 +437,84 @@ type cursorContentBlock struct {
 	Content   json.RawMessage `json:"content,omitempty"`
 }
 
+type cursorTextPart struct {
+	Text string `json:"text"`
+}
+
+type cursorStepFinishPart struct {
+	Tokens struct {
+		Input  int `json:"input"`
+		Output int `json:"output"`
+		Cache  struct {
+			Read int `json:"read"`
+		} `json:"cache"`
+	} `json:"tokens"`
+	Cost float64 `json:"cost"`
+}
+
+// ── Helpers ──
+
+// normalizeCursorStreamLine handles the stdout:/stderr: prefix that Cursor
+// CLI may emit in stream-json mode. Returns the trimmed JSON line.
+func normalizeCursorStreamLine(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	// Cursor CLI may prefix lines with "stdout:" or "stderr:" — strip it.
+	if idx := cursorStreamPrefixRe.FindStringIndex(trimmed); idx != nil {
+		return strings.TrimSpace(trimmed[idx[1]:])
+	}
+	return trimmed
+}
+
+var cursorStreamPrefixRe = regexp.MustCompile(`^(?i)(stdout|stderr)\s*[:=]?\s*`)
+
+func cursorErrorText(evt *cursorStreamEvent) string {
+	if evt.ErrorMsg != "" {
+		return evt.ErrorMsg
+	}
+	if evt.Detail != "" {
+		return evt.Detail
+	}
+	if evt.ResultText != "" {
+		return evt.ResultText
+	}
+	return ""
+}
+
+// cursorBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. Overriding these would break
+// the daemon↔cursor-agent communication protocol.
+var cursorBlockedArgs = map[string]blockedArgMode{
+	"-p":              blockedStandalone, // non-interactive print mode
+	"--output-format": blockedWithValue,  // stream-json protocol
+	"--yolo":          blockedStandalone, // auto-approval for autonomous operation
+}
+
+// buildCursorArgs assembles the argv for a one-shot cursor-agent invocation.
+//
+// Usage: cursor-agent -p <prompt> --output-format stream-json
+//
+//	--workspace <cwd> --yolo [--model <m>] [--resume <id>]
+func buildCursorArgs(prompt string, opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{
+		"-p", prompt,
+		"--output-format", "stream-json",
+		"--yolo",
+	}
+	if opts.Cwd != "" {
+		args = append(args, "--workspace", opts.Cwd)
+	}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	// NOTE: cursor-agent CLI does not support --system-prompt or --max-turns.
+	// Instructions are injected via AGENTS.md and .cursor/skills/ files instead.
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	args = append(args, filterCustomArgs(opts.ExtraArgs, cursorBlockedArgs, logger)...)
+	args = append(args, filterCustomArgs(opts.CustomArgs, cursorBlockedArgs, logger)...)
+	return args
+}

--- a/server/pkg/agent/cursor_execute_unix_test.go
+++ b/server/pkg/agent/cursor_execute_unix_test.go
@@ -1,0 +1,77 @@
+//go:build unix
+
+package agent
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCursorExecuteStopsAfterTerminalResult(t *testing.T) {
+	t.Parallel()
+
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-terminal"}'
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sess-terminal"}'
+sleep 10
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+	if result.Output != "done" {
+		t.Fatalf("output = %q, want done", result.Output)
+	}
+	if result.SessionID != "sess-terminal" {
+		t.Fatalf("session id = %q, want sess-terminal", result.SessionID)
+	}
+}
+
+func TestCursorExecuteStopsAfterTerminalErrorResult(t *testing.T) {
+	t.Parallel()
+
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-terminal-error"}'
+printf '%s\n' '{"type":"result","subtype":"error","is_error":true,"result":"failed hard","session_id":"sess-terminal-error"}'
+sleep 10
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed; error=%q", result.Status, result.Error)
+	}
+	if result.Error != "failed hard" {
+		t.Fatalf("error = %q, want failed hard", result.Error)
+	}
+	if result.Output != "failed hard" {
+		t.Fatalf("output = %q, want failed hard", result.Output)
+	}
+	if result.SessionID != "sess-terminal-error" {
+		t.Fatalf("session id = %q, want sess-terminal-error", result.SessionID)
+	}
+}
+
+func executeFakeCursor(t *testing.T, script string) Result {
+	t.Helper()
+
+	fakePath := filepath.Join(t.TempDir(), "cursor-agent")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("cursor", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), "hello", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	result := <-session.Result
+	if result.Status == "timeout" {
+		t.Fatalf("cursor backend timed out instead of stopping after terminal result; error=%q", result.Error)
+	}
+	return result
+}

--- a/server/pkg/agent/cursor_invocation.go
+++ b/server/pkg/agent/cursor_invocation.go
@@ -1,0 +1,28 @@
+package agent
+
+import "log/slog"
+
+// chooseCursorInvocation selects the actual program (argv[0]) and the full
+// argv to spawn a cursor-agent run.
+//
+// Background:
+//   - On macOS/Linux, cursor-agent is a real binary and we can pass argv
+//     directly via os/exec — no rewriting needed.
+//   - On Windows, the official installer ships cursor-agent.cmd whose body is
+//     "powershell ... -File cursor-agent.ps1 %*". CreateProcess for a .cmd
+//     file goes through cmd.exe, and %* in a .cmd batch file is expanded by
+//     re-tokenising the original command line, which mangles arguments that
+//     contain newlines or other whitespace (e.g. multi-line `-p` prompts).
+//     To stay on the official launch path while avoiding that re-tokenisation,
+//     we resolve cursor-agent.ps1 next to the .cmd and invoke PowerShell with
+//     `-File <ps1>` directly, letting Go pass each argv as a separate token.
+//
+// The Windows-specific behaviour is implemented in
+// cursor_invocation_windows.go; on other platforms we fall through to a
+// passthrough.
+func chooseCursorInvocation(execName, lookedUp string, args []string, logger *slog.Logger) (string, []string) {
+	if argv0, full, ok := platformCursorInvocation(lookedUp, args, logger); ok {
+		return argv0, full
+	}
+	return execName, args
+}

--- a/server/pkg/agent/cursor_invocation_other.go
+++ b/server/pkg/agent/cursor_invocation_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package agent
+
+import "log/slog"
+
+// platformCursorInvocation is a no-op on non-Windows platforms: cursor-agent
+// is a native binary and Go's os/exec can pass argv unchanged.
+func platformCursorInvocation(_ string, _ []string, _ *slog.Logger) (string, []string, bool) {
+	return "", nil, false
+}

--- a/server/pkg/agent/cursor_invocation_windows.go
+++ b/server/pkg/agent/cursor_invocation_windows.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package agent
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// powerShellLookup resolves the PowerShell host to use. It is overridable in
+// tests; production callers should leave it at its default.
+var powerShellLookup = defaultPowerShellLookup
+
+// rewriteCmdToPS1 handles the .cmd → PowerShell rewrite for npm-installed
+// agent CLIs on Windows. Each CLI ships a <name>.cmd launcher whose body is
+// effectively
+//
+//	powershell -NoProfile -ExecutionPolicy Bypass -File <name>.ps1 %*
+//
+// Going through cmd.exe causes %* re-expansion to re-tokenise the raw
+// command-line string, which mangles multi-line arguments (most critically
+// the -p prompt). We instead invoke PowerShell with -File <name>.ps1
+// directly so Go passes each argv element as a discrete token.
+//
+// toolName is used both for the log message and to derive the canonical ps1
+// filename (toolName + ".ps1" in the same directory as lookedUp). Using the
+// canonical name rather than the launcher basename ensures we find the right
+// script even when the user has a custom .bat wrapper with a different name.
+func rewriteCmdToPS1(toolName, lookedUp string, args []string, logger *slog.Logger) (string, []string, bool) {
+	ext := strings.ToLower(filepath.Ext(lookedUp))
+	if ext != ".cmd" && ext != ".bat" {
+		return "", nil, false
+	}
+	ps1 := filepath.Join(filepath.Dir(lookedUp), toolName+".ps1")
+	if st, err := os.Stat(ps1); err != nil || st.IsDir() {
+		return "", nil, false
+	}
+
+	psExe, ok := powerShellLookup()
+	if !ok {
+		return "", nil, false
+	}
+
+	full := make([]string, 0, 5+len(args))
+	full = append(full, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", ps1)
+	full = append(full, args...)
+
+	if logger != nil {
+		logger.Info(toolName+": routing through powershell -File to preserve argv tokens",
+			"powershell", psExe,
+			"ps1", ps1,
+			"original", lookedUp,
+		)
+	}
+	return psExe, full, true
+}
+
+// platformCursorInvocation rewrites cursor-agent.cmd → PowerShell -File
+// cursor-agent.ps1 on Windows to avoid cmd.exe %* re-tokenisation.
+func platformCursorInvocation(lookedUp string, args []string, logger *slog.Logger) (string, []string, bool) {
+	return rewriteCmdToPS1("cursor-agent", lookedUp, args, logger)
+}
+
+// defaultPowerShellLookup prefers PowerShell on PATH (PowerShell 7's pwsh.exe
+// or any user-overridden powershell.exe) and falls back to the system path
+// shipped with Windows.
+func defaultPowerShellLookup() (string, bool) {
+	for _, name := range []string{"pwsh.exe", "powershell.exe"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p, true
+		}
+	}
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = `C:\Windows`
+	}
+	candidate := filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+		return candidate, true
+	}
+	return "", false
+}

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -9,12 +9,151 @@ import (
 
 func TestNewReturnsCursorBackend(t *testing.T) {
 	t.Parallel()
-	b, err := New("cursor", Config{ExecutablePath: "/nonexistent/agent"})
+	b, err := New("cursor", Config{ExecutablePath: "/nonexistent/cursor-agent"})
 	if err != nil {
 		t.Fatalf("New(cursor) error: %v", err)
 	}
 	if _, ok := b.(*cursorBackend); !ok {
 		t.Fatalf("expected *cursorBackend, got %T", b)
+	}
+}
+
+func TestBuildCursorArgs(t *testing.T) {
+	t.Parallel()
+
+	args := buildCursorArgs("do something", ExecOptions{
+		Cwd:   "/tmp/work",
+		Model: "composer-1.5",
+	}, slog.Default())
+
+	expected := []string{
+		"-p", "do something",
+		"--output-format", "stream-json",
+		"--yolo",
+		"--workspace", "/tmp/work",
+		"--model", "composer-1.5",
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+func TestBuildCursorArgsWithResume(t *testing.T) {
+	t.Parallel()
+
+	args := buildCursorArgs("continue", ExecOptions{
+		ResumeSessionID: "sess-123",
+	}, slog.Default())
+
+	hasResume := false
+	for i, a := range args {
+		if a == "--resume" && i+1 < len(args) && args[i+1] == "sess-123" {
+			hasResume = true
+		}
+	}
+	if !hasResume {
+		t.Fatalf("expected --resume sess-123, got %v", args)
+	}
+}
+
+func TestBuildCursorArgsMinimal(t *testing.T) {
+	t.Parallel()
+
+	args := buildCursorArgs("hello", ExecOptions{}, slog.Default())
+	expected := []string{"-p", "hello", "--output-format", "stream-json", "--yolo"}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+}
+
+func TestBuildCursorArgsIgnoresSystemPromptAndMaxTurns(t *testing.T) {
+	t.Parallel()
+
+	// cursor-agent CLI does not support --system-prompt or --max-turns;
+	// verify they are NOT emitted even when set in ExecOptions.
+	args := buildCursorArgs("task", ExecOptions{
+		SystemPrompt: "You are helpful",
+		MaxTurns:     5,
+	}, slog.Default())
+
+	for _, a := range args {
+		if a == "--system-prompt" {
+			t.Fatalf("unexpected --system-prompt in args: %v", args)
+		}
+		if a == "--max-turns" {
+			t.Fatalf("unexpected --max-turns in args: %v", args)
+		}
+	}
+}
+
+func TestBuildCursorArgsCustomArgs(t *testing.T) {
+	t.Parallel()
+
+	args := buildCursorArgs("task", ExecOptions{
+		CustomArgs: []string{"--extra", "val", "--yolo", "--output-format", "text"},
+	}, slog.Default())
+
+	// --extra val should be present; --yolo and --output-format should be filtered out
+	hasExtra := false
+	hasBlockedYolo := false
+	hasBlockedFormat := false
+	for i, a := range args {
+		if a == "--extra" && i+1 < len(args) && args[i+1] == "val" {
+			hasExtra = true
+		}
+	}
+	// Count occurrences of --yolo (should be exactly 1 — the hardcoded one)
+	yoloCount := 0
+	for _, a := range args {
+		if a == "--yolo" {
+			yoloCount++
+		}
+		if a == "text" {
+			hasBlockedFormat = true
+		}
+	}
+	if yoloCount > 1 {
+		hasBlockedYolo = true
+	}
+	if !hasExtra {
+		t.Fatalf("expected --extra val in args, got %v", args)
+	}
+	if hasBlockedYolo {
+		t.Fatalf("--yolo from custom args should be filtered, got %v", args)
+	}
+	if hasBlockedFormat {
+		t.Fatalf("--output-format from custom args should be filtered, got %v", args)
+	}
+}
+
+func TestNormalizeCursorStreamLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`stdout: {"type":"init"}`, `{"type":"init"}`},
+		{`stderr: {"type":"error"}`, `{"type":"error"}`},
+		{`stdout:{"type":"init"}`, `{"type":"init"}`},
+		{`  {"type":"assistant"}  `, `{"type":"assistant"}`},
+		{``, ``},
+		{`  `, ``},
+		{`plain text`, `plain text`},
+	}
+
+	for _, tc := range tests {
+		got := normalizeCursorStreamLine(tc.input)
+		if got != tc.want {
+			t.Errorf("normalizeCursorStreamLine(%q) = %q, want %q", tc.input, got, tc.want)
+		}
 	}
 }
 
@@ -25,24 +164,29 @@ func TestCursorHandleAssistantText(t *testing.T) {
 	ch := make(chan Message, 10)
 	var output strings.Builder
 
-	msg := cursorSDKMessage{
+	evt := &cursorStreamEvent{
 		Type: "assistant",
-		Message: mustMarshal(t, cursorMessageContent{
-			Role: "assistant",
+		Message: mustMarshal(t, cursorAssistantMessage{
+			Model: "composer-1.5",
 			Content: []cursorContentBlock{
-				{Type: "text", Text: "Hello from cursor"},
+				{Type: "output_text", Text: "Hello from Cursor"},
+			},
+			Usage: &cursorUsage{
+				InputTokens:  100,
+				OutputTokens: 50,
 			},
 		}),
 	}
 
-	b.handleAssistant(msg, ch, &output)
+	b.handleCursorAssistant(evt, ch, &output)
 
-	if output.String() != "Hello from cursor" {
-		t.Fatalf("expected output 'Hello from cursor', got %q", output.String())
+	if output.String() != "Hello from Cursor" {
+		t.Fatalf("expected output 'Hello from Cursor', got %q", output.String())
 	}
+
 	select {
 	case m := <-ch:
-		if m.Type != MessageText || m.Content != "Hello from cursor" {
+		if m.Type != MessageText || m.Content != "Hello from Cursor" {
 			t.Fatalf("unexpected message: %+v", m)
 		}
 	default:
@@ -57,64 +201,25 @@ func TestCursorHandleAssistantToolUse(t *testing.T) {
 	ch := make(chan Message, 10)
 	var output strings.Builder
 
-	msg := cursorSDKMessage{
+	evt := &cursorStreamEvent{
 		Type: "assistant",
-		Message: mustMarshal(t, cursorMessageContent{
-			Role: "assistant",
+		Message: mustMarshal(t, cursorAssistantMessage{
 			Content: []cursorContentBlock{
 				{
 					Type:  "tool_use",
-					ID:    "call-1",
-					Name:  "Read",
-					Input: mustMarshal(t, map[string]any{"path": "/tmp/foo"}),
+					ID:    "call-42",
+					Name:  "file_edit",
+					Input: mustMarshal(t, map[string]any{"path": "/tmp/foo.go"}),
 				},
 			},
 		}),
 	}
 
-	b.handleAssistant(msg, ch, &output)
+	b.handleCursorAssistant(evt, ch, &output)
 
-	if output.String() != "" {
-		t.Fatalf("tool_use should not add to output, got %q", output.String())
-	}
 	select {
 	case m := <-ch:
-		if m.Type != MessageToolUse || m.Tool != "Read" || m.CallID != "call-1" {
-			t.Fatalf("unexpected message: %+v", m)
-		}
-		if m.Input["path"] != "/tmp/foo" {
-			t.Fatalf("expected input path /tmp/foo, got %v", m.Input["path"])
-		}
-	default:
-		t.Fatal("expected message on channel")
-	}
-}
-
-func TestCursorHandleAssistantThinking(t *testing.T) {
-	t.Parallel()
-
-	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
-	ch := make(chan Message, 10)
-	var output strings.Builder
-
-	msg := cursorSDKMessage{
-		Type: "assistant",
-		Message: mustMarshal(t, cursorMessageContent{
-			Role: "assistant",
-			Content: []cursorContentBlock{
-				{Type: "thinking", Text: "Let me think..."},
-			},
-		}),
-	}
-
-	b.handleAssistant(msg, ch, &output)
-
-	if output.String() != "" {
-		t.Fatalf("thinking should not add to output, got %q", output.String())
-	}
-	select {
-	case m := <-ch:
-		if m.Type != MessageThinking || m.Content != "Let me think..." {
+		if m.Type != MessageToolUse || m.Tool != "file_edit" || m.CallID != "call-42" {
 			t.Fatalf("unexpected message: %+v", m)
 		}
 	default:
@@ -122,192 +227,208 @@ func TestCursorHandleAssistantThinking(t *testing.T) {
 	}
 }
 
-func TestCursorHandleUserToolResult(t *testing.T) {
+func TestCursorErrorText(t *testing.T) {
 	t.Parallel()
 
-	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
-	ch := make(chan Message, 10)
-
-	msg := cursorSDKMessage{
-		Type: "user",
-		Message: mustMarshal(t, cursorMessageContent{
-			Role: "user",
-			Content: []cursorContentBlock{
-				{
-					Type:      "tool_result",
-					ToolUseID: "call-1",
-					Content:   mustMarshal(t, "file contents here"),
-				},
-			},
-		}),
-	}
-
-	b.handleUser(msg, ch)
-
-	select {
-	case m := <-ch:
-		if m.Type != MessageToolResult || m.CallID != "call-1" {
-			t.Fatalf("unexpected message: %+v", m)
-		}
-	default:
-		t.Fatal("expected message on channel")
-	}
-}
-
-func TestCursorHandleToolCallStarted(t *testing.T) {
-	t.Parallel()
-
-	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
-	ch := make(chan Message, 10)
-	var output strings.Builder
-
-	// New Cursor format: call_id at top level, tool_call keyed by tool type.
-	msg := cursorSDKMessage{
-		Type:     "tool_call",
-		Subtype:  "started",
-		CallID:   "tc-1",
-		ToolCall: mustMarshal(t, map[string]any{"shellToolCall": map[string]any{"command": "ls -la"}}),
-	}
-
-	b.handleToolCall(msg, ch, &output)
-
-	select {
-	case m := <-ch:
-		if m.Type != MessageToolUse || m.Tool != "shellToolCall" || m.CallID != "tc-1" {
-			t.Fatalf("unexpected message: %+v", m)
-		}
-		if m.Input["command"] != "ls -la" {
-			t.Fatalf("expected input command 'ls -la', got %v", m.Input["command"])
-		}
-	default:
-		t.Fatal("expected message on channel")
-	}
-}
-
-func TestCursorHandleToolCallCompleted(t *testing.T) {
-	t.Parallel()
-
-	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
-	ch := make(chan Message, 10)
-	var output strings.Builder
-
-	// New Cursor format: call_id at top level, tool_call keyed by tool type.
-	msg := cursorSDKMessage{
-		Type:    "tool_call",
-		Subtype: "completed",
-		CallID:  "tc-1",
-		ToolCall: mustMarshal(t, map[string]any{
-			"shellToolCall": map[string]any{
-				"exitCode": 0,
-				"stdout":   "total 42\ndrwxr-xr-x ...",
-				"stderr":   "",
-			},
-		}),
-	}
-
-	b.handleToolCall(msg, ch, &output)
-
-	select {
-	case m := <-ch:
-		if m.Type != MessageToolResult || m.Tool != "shellToolCall" || m.CallID != "tc-1" {
-			t.Fatalf("unexpected message: %+v", m)
-		}
-		if m.Output == "" {
-			t.Fatal("expected non-empty output")
-		}
-	default:
-		t.Fatal("expected message on channel")
-	}
-}
-
-func TestCursorHandleToolCallFixture(t *testing.T) {
-	t.Parallel()
-
-	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
-
-	// Real modern Cursor stream-json tool_call events.
-	startedLine := `{"type":"tool_call","subtype":"started","call_id":"curs-42","tool_call":{"shellToolCall":{"command":"echo hello"}}}`
-	completedLine := `{"type":"tool_call","subtype":"completed","call_id":"curs-42","tool_call":{"shellToolCall":{"exitCode":0,"stdout":"hello\n","stderr":""}}}`
-
-	for _, tc := range []struct {
-		line        string
-		wantMsgType MessageType
-		wantTool    string
-		wantCallID  string
+	tests := []struct {
+		name string
+		evt  cursorStreamEvent
+		want string
 	}{
-		{startedLine, MessageToolUse, "shellToolCall", "curs-42"},
-		{completedLine, MessageToolResult, "shellToolCall", "curs-42"},
-	} {
-		var msg cursorSDKMessage
-		if err := json.Unmarshal([]byte(tc.line), &msg); err != nil {
-			t.Fatalf("unmarshal fixture: %v", err)
-		}
+		{"error field", cursorStreamEvent{ErrorMsg: "bad request"}, "bad request"},
+		{"detail field", cursorStreamEvent{Detail: "not found"}, "not found"},
+		{"result field", cursorStreamEvent{ResultText: "failed"}, "failed"},
+		{"empty", cursorStreamEvent{}, ""},
+	}
 
-		ch := make(chan Message, 10)
-		var out strings.Builder
-		b.handleToolCall(msg, ch, &out)
-
-		select {
-		case m := <-ch:
-			if m.Type != tc.wantMsgType {
-				t.Errorf("line %q: Type = %q, want %q", tc.line, m.Type, tc.wantMsgType)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cursorErrorText(&tc.evt)
+			if got != tc.want {
+				t.Errorf("cursorErrorText = %q, want %q", got, tc.want)
 			}
-			if m.Tool != tc.wantTool {
-				t.Errorf("line %q: Tool = %q, want %q", tc.line, m.Tool, tc.wantTool)
-			}
-			if m.CallID != tc.wantCallID {
-				t.Errorf("line %q: CallID = %q, want %q", tc.line, m.CallID, tc.wantCallID)
-			}
-		default:
-			t.Fatalf("line %q: expected message on channel", tc.line)
-		}
+		})
 	}
 }
 
-func TestCursorHandleAssistantInvalidJSON(t *testing.T) {
+func TestCursorAccumulateResultUsage(t *testing.T) {
+	t.Parallel()
+
+	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+	usage := make(map[string]TokenUsage)
+
+	evt := &cursorStreamEvent{
+		Model: "gpt-5.3",
+		Usage: &cursorUsage{
+			InputTokens:          200,
+			OutputTokens:         100,
+			CacheReadInputTokens: 50,
+		},
+	}
+
+	b.accumulateResultUsage(usage, evt)
+
+	u := usage["gpt-5.3"]
+	if u.InputTokens != 200 || u.OutputTokens != 100 || u.CacheReadTokens != 50 {
+		t.Fatalf("unexpected usage: %+v", u)
+	}
+}
+
+func TestCursorUsageOnlyFromResult(t *testing.T) {
 	t.Parallel()
 
 	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 10)
 	var output strings.Builder
 
-	msg := cursorSDKMessage{
-		Type:    "assistant",
-		Message: json.RawMessage(`invalid json`),
+	evt := &cursorStreamEvent{
+		Type: "assistant",
+		Message: mustMarshal(t, cursorAssistantMessage{
+			Model: "gpt-5",
+			Content: []cursorContentBlock{
+				{Type: "text", Text: "hello"},
+			},
+			Usage: &cursorUsage{
+				InputTokens:  999,
+				OutputTokens: 888,
+			},
+		}),
 	}
 
-	// Should not panic
-	b.handleAssistant(msg, ch, &output)
+	b.handleCursorAssistant(evt, ch, &output)
 
-	if output.String() != "" {
-		t.Fatalf("expected empty output for invalid JSON, got %q", output.String())
+	if output.String() != "hello" {
+		t.Fatalf("expected 'hello', got %q", output.String())
 	}
-	select {
-	case m := <-ch:
-		t.Fatalf("expected no message, got %+v", m)
-	default:
+
+	// handleCursorAssistant should NOT have accumulated usage anywhere —
+	// usage is only taken from result events to avoid double-counting.
+	// (no usage map to check; this test documents the intent)
+}
+
+func TestCursorStepFinishParsing(t *testing.T) {
+	t.Parallel()
+
+	part := cursorStepFinishPart{}
+	data := `{"tokens":{"input":500,"output":200,"cache":{"read":100}},"cost":0.01}`
+	if err := json.Unmarshal([]byte(data), &part); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if part.Tokens.Input != 500 || part.Tokens.Output != 200 || part.Tokens.Cache.Read != 100 {
+		t.Fatalf("unexpected part: %+v", part)
 	}
 }
 
-func TestCursorHandleToolCallInvalidJSON(t *testing.T) {
+// TestCursorUsageNoDoubleCount verifies that step_finish and result usage
+// are never double-counted. When a result event includes usage (session
+// totals), step_finish values must be discarded entirely.
+func TestCursorUsageNoDoubleCount(t *testing.T) {
 	t.Parallel()
 
-	b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
-	ch := make(chan Message, 10)
-	var output strings.Builder
-
-	msg := cursorSDKMessage{
-		Type:     "tool_call",
-		Subtype:  "started",
-		ToolCall: json.RawMessage(`invalid json`),
+	type jsonlEvent struct {
+		raw string
 	}
 
-	// Should not panic
-	b.handleToolCall(msg, ch, &output)
+	tests := []struct {
+		name  string
+		lines []string
+		want  map[string]TokenUsage
+	}{
+		{
+			name: "result_only — use result usage",
+			lines: []string{
+				`{"type":"result","model":"gpt-5","usage":{"input_tokens":1000,"output_tokens":500,"cached_input_tokens":200}}`,
+			},
+			want: map[string]TokenUsage{
+				"gpt-5": {InputTokens: 1000, OutputTokens: 500, CacheReadTokens: 200},
+			},
+		},
+		{
+			name: "step_finish_only — fallback to step usage",
+			lines: []string{
+				`{"type":"step_finish","model":"gpt-5","part":{"tokens":{"input":300,"output":100,"cache":{"read":50}}}}`,
+				`{"type":"step_finish","model":"gpt-5","part":{"tokens":{"input":200,"output":80,"cache":{"read":30}}}}`,
+				`{"type":"result","model":"gpt-5"}`,
+			},
+			want: map[string]TokenUsage{
+				"gpt-5": {InputTokens: 500, OutputTokens: 180, CacheReadTokens: 80},
+			},
+		},
+		{
+			name: "step_finish_then_result — result wins, no double count",
+			lines: []string{
+				`{"type":"step_finish","model":"gpt-5","part":{"tokens":{"input":300,"output":100,"cache":{"read":50}}}}`,
+				`{"type":"step_finish","model":"gpt-5","part":{"tokens":{"input":200,"output":80,"cache":{"read":30}}}}`,
+				`{"type":"result","model":"gpt-5","usage":{"input_tokens":500,"output_tokens":180,"cached_input_tokens":80}}`,
+			},
+			want: map[string]TokenUsage{
+				"gpt-5": {InputTokens: 500, OutputTokens: 180, CacheReadTokens: 80},
+			},
+		},
+		{
+			name: "multi_model — each model tracked independently",
+			lines: []string{
+				`{"type":"step_finish","model":"gpt-5","part":{"tokens":{"input":100,"output":50,"cache":{"read":10}}}}`,
+				`{"type":"step_finish","model":"sonnet-4","part":{"tokens":{"input":200,"output":80,"cache":{"read":20}}}}`,
+				`{"type":"result","model":"gpt-5","usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":10}}`,
+			},
+			want: map[string]TokenUsage{
+				// result had usage → use result only, discard all step_finish
+				"gpt-5": {InputTokens: 100, OutputTokens: 50, CacheReadTokens: 10},
+			},
+		},
+	}
 
-	select {
-	case m := <-ch:
-		t.Fatalf("expected no message, got %+v", m)
-	default:
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stepUsage := make(map[string]TokenUsage)
+			resultUsage := make(map[string]TokenUsage)
+			hasResultUsage := false
+
+			b := &cursorBackend{cfg: Config{Logger: slog.Default()}}
+
+			for _, line := range tc.lines {
+				var evt cursorStreamEvent
+				if err := json.Unmarshal([]byte(line), &evt); err != nil {
+					t.Fatalf("unmarshal %q: %v", line, err)
+				}
+
+				switch evt.Type {
+				case "result":
+					b.accumulateResultUsage(resultUsage, &evt)
+					if evt.Usage != nil {
+						hasResultUsage = true
+					}
+				case "step_finish":
+					if evt.Part != nil {
+						var part cursorStepFinishPart
+						_ = json.Unmarshal(evt.Part, &part)
+						model := evt.Model
+						if model == "" {
+							model = "cursor"
+						}
+						u := stepUsage[model]
+						u.InputTokens += int64(part.Tokens.Input)
+						u.OutputTokens += int64(part.Tokens.Output)
+						u.CacheReadTokens += int64(part.Tokens.Cache.Read)
+						stepUsage[model] = u
+					}
+				}
+			}
+
+			if !hasResultUsage {
+				resultUsage = stepUsage
+			}
+
+			if len(resultUsage) != len(tc.want) {
+				t.Fatalf("got %d models, want %d: %+v", len(resultUsage), len(tc.want), resultUsage)
+			}
+			for model, want := range tc.want {
+				got := resultUsage[model]
+				if got != want {
+					t.Errorf("model %q: got %+v, want %+v", model, got, want)
+				}
+			}
+		})
 	}
 }

--- a/server/pkg/agent/exec_fixture_unix_test.go
+++ b/server/pkg/agent/exec_fixture_unix_test.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package agent
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// writeTestExecutable writes content to path with exec perms while holding
+// syscall.ForkLock.RLock, so no concurrent t.Parallel() sibling can fork
+// between our OpenFile and Close. Without this, Linux ETXTBSY fires when
+// the sibling's fork child inherits our still-open write fd and the
+// subsequent exec of the file sees "text file busy" (seen on CI as
+// TestKimiBackendInvokesACPSubcommand: fork/exec ... text file busy).
+func writeTestExecutable(tb testing.TB, path string, content []byte) {
+	tb.Helper()
+	syscall.ForkLock.RLock()
+	defer syscall.ForkLock.RUnlock()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		tb.Fatalf("write test executable %s: open: %v", path, err)
+	}
+	if _, err := f.Write(content); err != nil {
+		_ = f.Close()
+		tb.Fatalf("write test executable %s: write: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		tb.Fatalf("write test executable %s: close: %v", path, err)
+	}
+}

--- a/server/pkg/agent/exec_fixture_windows_test.go
+++ b/server/pkg/agent/exec_fixture_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"testing"
+)
+
+// writeTestExecutable is the Windows counterpart to the //go:build unix
+// implementation in exec_fixture_unix_test.go. ETXTBSY is a Linux/Unix
+// fork-exec race; Windows doesn't have that pathology, so a plain
+// os.WriteFile is sufficient.
+//
+// The helper is referenced by claude_test.go / codex_test.go /
+// kimi_test.go, so the absence of a Windows impl made
+// `go test ./pkg/agent` fail to build on Windows. Lifted from #1719
+// (Codex) with attribution.
+func writeTestExecutable(tb testing.TB, path string, content []byte) {
+	tb.Helper()
+	if err := os.WriteFile(path, content, 0o755); err != nil {
+		tb.Fatalf("write test executable %s: %v", path, err)
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -1,0 +1,528 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Model describes a single LLM model exposed by an agent provider.
+// The dropdown groups by Provider when the ID uses the
+// `provider/model` form (e.g. "openai/gpt-4o" from opencode).
+// Default is a *display* hint: the UI badges the entry the
+// runtime advertises as its preferred pick. It has no effect
+// at execution time — when agent model config is empty the daemon
+// passes "" to the backend so each provider's own CLI resolves its
+// own default, which is always closer to what the user's account /
+// environment actually supports than a static guess here.
+type Model struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Provider string `json:"provider,omitempty"`
+	Default  bool   `json:"default,omitempty"`
+	// Thinking advertises the runtime's reasoning/effort catalog for this
+	// model. nil means the runtime/model has no thinking-level control
+	// (or the daemon couldn't discover one); the UI hides its picker. The
+	// catalog is per-model because Codex's `codex debug models` is itself
+	// per-model and Claude's `--effort` superset has known per-model gaps
+	// (`xhigh` is Opus-only, `max` is session-only).
+	Thinking *ModelThinking `json:"thinking,omitempty"`
+}
+
+// ModelThinking carries the per-model reasoning/effort catalog
+// surfaced by an agent runtime. Values are runtime-native — Codex
+// emits "none|minimal|low|medium|high|xhigh"; Claude emits
+// "low|medium|high|xhigh|max". The frontend renders SupportedLevels
+// as-is so what users see matches each CLI's own UI.
+type ModelThinking struct {
+	SupportedLevels []ThinkingLevel `json:"supported_levels"`
+	// DefaultLevel is the value the runtime picks when no override is
+	// provided. Empty means "the runtime picks, we don't know" — the
+	// UI shows "Default" as a generic option.
+	DefaultLevel string `json:"default_level,omitempty"`
+}
+
+// ThinkingLevel is one entry in a ModelThinking.SupportedLevels list.
+// Value is the literal token passed to the CLI (Claude `--effort <value>`
+// or Codex `model_reasoning_effort=<value>`); Label is a display string;
+// Description is optional helper copy lifted from the upstream catalog
+// when available (Codex's `description` field).
+type ThinkingLevel struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+// modelCache memoizes dynamic discovery calls so repeated UI loads
+// don't re-shell the agent CLI. Entries expire after modelCacheTTL.
+type modelCacheEntry struct {
+	models    []Model
+	expiresAt time.Time
+}
+
+var (
+	modelCacheMu sync.Mutex
+	modelCache   = map[string]modelCacheEntry{}
+)
+
+const modelCacheTTL = 60 * time.Second
+
+// ListModels returns the models supported by the given agent provider.
+// For providers with a known static catalog it returns the baked-in
+// list; for providers with a CLI discovery mechanism (cursor, opencode)
+// it shells out with caching and falls back to the static list on failure.
+//
+// For claude, codex, and opencode, the catalog is augmented with per-model
+// thinking-level options discovered from the local CLI. Discovery failures
+// silently leave Thinking == nil on each entry, which the UI treats as
+// "no picker for this model" rather than blocking model selection.
+//
+// executablePath lets the caller point at a non-default binary; pass
+// "" to use the provider's default name on PATH.
+func ListModels(ctx context.Context, providerType, executablePath string) ([]Model, error) {
+	switch providerType {
+	case "claude":
+		models := claudeStaticModels()
+		annotateClaudeThinking(ctx, models, executablePath)
+		return models, nil
+	case "codex":
+		models := codexStaticModels()
+		annotateCodexThinking(ctx, models, executablePath)
+		return models, nil
+	case "cursor":
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
+			return discoverCursorModels(ctx, executablePath)
+		})
+	case "opencode":
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
+			return discoverOpenCodeModels(ctx, executablePath)
+		})
+	default:
+		return nil, fmt.Errorf("unknown agent type: %q", providerType)
+	}
+}
+
+// ModelSelectionSupported reports whether setting an agent-level model has
+// any effect for the given provider. Every built-in provider honours
+// `opts.Model` end-to-end.
+//
+// The hook is retained — rather than inlining `true` at the call sites — so
+// a future model-less runtime can opt out in one place, which makes the UI
+// render a disabled "Managed by runtime" picker instead of an empty
+// dropdown plus a silently-ignored manual-entry field.
+func ModelSelectionSupported(providerType string) bool {
+	return true
+}
+
+// cachedDiscovery invokes fn and caches the result for modelCacheTTL.
+func cachedDiscovery(key string, fn func() ([]Model, error)) ([]Model, error) {
+	modelCacheMu.Lock()
+	if entry, ok := modelCache[key]; ok && time.Now().Before(entry.expiresAt) {
+		out := entry.models
+		modelCacheMu.Unlock()
+		return out, nil
+	}
+	modelCacheMu.Unlock()
+
+	models, err := fn()
+	if err != nil {
+		return nil, err
+	}
+
+	// Don't cache an empty result. Zero models is almost always a transient
+	// failure (discovery CLI timeout, not-logged-in, network blip) rather than
+	// a runtime that genuinely has no models; caching it would keep the picker
+	// blank for the full TTL even after the cause clears. Skipping the cache
+	// lets the next request retry immediately.
+	if len(models) == 0 {
+		return models, nil
+	}
+
+	modelCacheMu.Lock()
+	modelCache[key] = modelCacheEntry{models: models, expiresAt: time.Now().Add(modelCacheTTL)}
+	modelCacheMu.Unlock()
+	return models, nil
+}
+
+func discoveryCacheKey(providerType, executablePath string) string {
+	if executablePath == "" {
+		return providerType
+	}
+	return providerType + ":" + executablePath
+}
+
+// ── Static catalogs ──
+
+// claudeStaticModels reflects the Claude Code CLI's accepted --model
+// values. Keep this list short and current; stale entries here
+// mislead users more than they help. Default = the latest flagship
+// so newly created agents pick it up out of the box.
+func claudeStaticModels() []Model {
+	return []Model{
+		{ID: "claude-fable-5", Label: "Claude Fable 5", Provider: "anthropic", Default: true},
+		{ID: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6", Provider: "anthropic"},
+		{ID: "claude-opus-4-8", Label: "Claude Opus 4.8", Provider: "anthropic"},
+		{ID: "claude-opus-4-7", Label: "Claude Opus 4.7", Provider: "anthropic"},
+		{ID: "claude-haiku-4-5-20251001", Label: "Claude Haiku 4.5", Provider: "anthropic"},
+		{ID: "claude-opus-4-6", Label: "Claude Opus 4.6", Provider: "anthropic"},
+		{ID: "claude-sonnet-4-5", Label: "Claude Sonnet 4.5", Provider: "anthropic"},
+	}
+}
+
+func codexStaticModels() []Model {
+	return []Model{
+		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai", Default: true},
+		{ID: "gpt-5.5-mini", Label: "GPT-5.5 mini", Provider: "openai"},
+		{ID: "gpt-5.4", Label: "GPT-5.4", Provider: "openai"},
+		{ID: "gpt-5.4-mini", Label: "GPT-5.4 mini", Provider: "openai"},
+		{ID: "gpt-5.3-codex", Label: "GPT-5.3 Codex", Provider: "openai"},
+		{ID: "gpt-5", Label: "GPT-5", Provider: "openai"},
+		{ID: "o3", Label: "o3", Provider: "openai"},
+		{ID: "o3-mini", Label: "o3-mini", Provider: "openai"},
+	}
+}
+
+// cursorStaticModels is a minimal fallback used when
+// `cursor-agent --list-models` isn't available (binary missing,
+// offline, etc). The real catalog is fetched dynamically because
+// Cursor's model IDs shift often and any static list we ship goes
+// stale fast.
+func cursorStaticModels() []Model {
+	return []Model{
+		{ID: "auto", Label: "Auto", Provider: "cursor", Default: true},
+	}
+}
+
+// ── Dynamic discovery ──
+
+// discoverCursorModels runs `cursor-agent --list-models` and parses
+// the `id - Label` rows. Cursor's catalog changes often and ships
+// many variants of the same base model (thinking / fast / max
+// suffixes) — static baking would be obsolete within weeks. On any
+// failure we fall back to the minimal static catalog so the UI
+// stays usable when cursor-agent isn't installed on the daemon host.
+func discoverCursorModels(ctx context.Context, executablePath string) ([]Model, error) {
+	if executablePath == "" {
+		executablePath = "cursor-agent"
+	}
+	if _, err := exec.LookPath(executablePath); err != nil {
+		return cursorStaticModels(), nil
+	}
+	// 15s to match the other network-backed discovery paths; cursor-agent
+	// fetches its frequently-changing catalog, so a tight cap can time out
+	// and fall back to the minimal static list.
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
+	hideAgentWindow(cmd)
+	out, err := cmd.Output()
+	if err != nil && len(out) == 0 {
+		return cursorStaticModels(), nil
+	}
+	models := parseCursorModels(string(out))
+	if len(models) == 0 {
+		return cursorStaticModels(), nil
+	}
+	return models, nil
+}
+
+// parseCursorModels extracts model IDs from `cursor-agent --list-models`.
+// Output format (as of cursor-agent 2026.04):
+//
+//	Available models
+//	<blank>
+//	auto - Auto
+//	composer-2-fast - Composer 2 Fast (current, default)
+//	composer-2 - Composer 2
+//	…
+//
+// The model tagged `(default)` is surfaced as Default=true so the
+// UI badge points at cursor's own recommendation rather than a
+// hard-coded guess from our catalog.
+func parseCursorModels(output string) []Model {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var models []Model
+	seen := map[string]bool{}
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		// Row format: "<id> - <label>". Skip the "Available models" header.
+		idx := strings.Index(line, " - ")
+		if idx <= 0 {
+			continue
+		}
+		id := strings.TrimSpace(line[:idx])
+		label := strings.TrimSpace(line[idx+3:])
+		if !isModelIdentifier(id) {
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		isDefault := strings.Contains(label, "default")
+		// Strip the "(current, default)" suffix from the display
+		// label since we surface that through the Default flag.
+		if paren := strings.Index(label, "("); paren > 0 {
+			label = strings.TrimSpace(label[:paren])
+		}
+		if label == "" {
+			label = id
+		}
+		models = append(models, Model{
+			ID:       id,
+			Label:    label,
+			Provider: "cursor",
+			Default:  isDefault,
+		})
+	}
+	return models
+}
+
+// isModelIdentifier reports whether s looks like a model identifier
+// (alnum first char, then alnum + `-._/`). Anything that fails it is
+// either malformed or a header/decoration line.
+func isModelIdentifier(s string) bool {
+	if s == "" || strings.HasSuffix(s, ":") {
+		return false
+	}
+	first := s[0]
+	if !((first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z')) {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.' || r == '/':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// discoverOpenCodeModels runs `opencode models --verbose` and parses its
+// output. The CLI prints `provider/model` rows, followed by JSON metadata
+// when verbose mode is enabled; we emit IDs verbatim so what the user sees
+// matches what `--model` accepts, and project any model `variants` into the
+// thinking-level picker because OpenCode's `run --variant` flag is its
+// provider-specific reasoning-effort surface.
+// On any failure (CLI missing, parse error, timeout) we fall back to
+// an empty list so the creatable UI still works.
+func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model, error) {
+	if executablePath == "" {
+		executablePath = "opencode"
+	}
+	if _, err := exec.LookPath(executablePath); err != nil {
+		return []Model{}, nil
+	}
+	// Newer opencode syncs its hosted free-model catalog over the network on
+	// `opencode models`, which can take several seconds; a tight cap times
+	// out and returns an empty list while the runtime stays online.
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, executablePath, "models", "--verbose")
+	hideAgentWindow(cmd)
+	// Parse whatever the verbose command printed, even on a non-zero exit — a
+	// stale config entry can make `opencode models` exit non-zero while still
+	// listing the resolvable catalog.
+	out, _ := cmd.Output()
+	models := parseOpenCodeModels(string(out))
+	if len(models) == 0 {
+		// Verbose yielded nothing usable (unsupported flag, error text, or an
+		// empty list). Retry the plain command, which omits the per-model JSON
+		// but still prints the IDs.
+		cmd = exec.CommandContext(runCtx, executablePath, "models")
+		hideAgentWindow(cmd)
+		out, _ = cmd.Output()
+		models = parseOpenCodeModels(string(out))
+	}
+	if len(models) == 0 {
+		return []Model{}, nil
+	}
+	return models, nil
+}
+
+// parseOpenCodeModels accepts the `opencode models` text output and
+// extracts IDs. Non-verbose output is one `provider/model` row per line.
+// Verbose output appends a pretty-printed JSON object after each ID; when
+// that object contains `variants`, each enabled variant becomes a thinking
+// level that the backend later passes through `opencode run --variant`.
+func parseOpenCodeModels(output string) []Model {
+	lines := strings.Split(output, "\n")
+	var models []Model
+	indexByID := map[string]int{}
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		id := parseOpenCodeModelIDLine(line)
+		if id == "" {
+			continue
+		}
+		idx, seen := indexByID[id]
+		if !seen {
+			provider := ""
+			if slash := strings.Index(id, "/"); slash > 0 {
+				provider = id[:slash]
+			}
+			idx = len(models)
+			indexByID[id] = idx
+			models = append(models, Model{ID: id, Label: id, Provider: provider})
+		}
+
+		next := i + 1
+		for next < len(lines) && strings.TrimSpace(lines[next]) == "" {
+			next++
+		}
+		if next >= len(lines) || !strings.HasPrefix(strings.TrimSpace(lines[next]), "{") {
+			continue
+		}
+		raw, resumeAt := collectOpenCodeModelJSON(lines, next)
+		if json.Valid(raw) {
+			annotateOpenCodeModelMetadata(&models[idx], raw)
+		}
+		i = resumeAt - 1
+	}
+	return models
+}
+
+func parseOpenCodeModelIDLine(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+	id := fields[0]
+	if strings.HasPrefix(id, `"`) || strings.HasPrefix(id, "{") || strings.HasPrefix(id, "[") {
+		return ""
+	}
+	if !strings.Contains(id, "/") {
+		return ""
+	}
+	// Skip header rows such as PROVIDER/MODEL.
+	if id == strings.ToUpper(id) {
+		return ""
+	}
+	return id
+}
+
+func collectOpenCodeModelJSON(lines []string, start int) ([]byte, int) {
+	var b strings.Builder
+	for i := start; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if i > start && parseOpenCodeModelIDLine(line) != "" {
+			return []byte(b.String()), i
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(lines[i])
+		if json.Valid([]byte(b.String())) {
+			return []byte(b.String()), i + 1
+		}
+	}
+	return []byte(b.String()), len(lines)
+}
+
+type opencodeModelMetadata struct {
+	Reasoning bool                            `json:"reasoning"`
+	Variants  map[string]opencodeModelVariant `json:"variants"`
+}
+
+type opencodeModelVariant struct {
+	Disabled        bool            `json:"disabled"`
+	ReasoningEffort string          `json:"reasoningEffort"`
+	Thinking        json.RawMessage `json:"thinking"`
+}
+
+var opencodeVariantLabel = map[string]string{
+	"none":    "None",
+	"minimal": "Minimal",
+	"low":     "Low",
+	"medium":  "Medium",
+	"high":    "High",
+	"xhigh":   "Extra high",
+	"max":     "Max",
+}
+
+var opencodeVariantOrder = map[string]int{
+	"none":    0,
+	"minimal": 1,
+	"low":     2,
+	"medium":  3,
+	"high":    4,
+	"xhigh":   5,
+	"max":     6,
+}
+
+func annotateOpenCodeModelMetadata(model *Model, raw []byte) {
+	var meta opencodeModelMetadata
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return
+	}
+	if !meta.Reasoning && !openCodeVariantsLookReasoning(meta.Variants) {
+		return
+	}
+	levels := openCodeThinkingLevelsFromVariants(meta.Variants)
+	if len(levels) == 0 {
+		return
+	}
+	model.Thinking = &ModelThinking{SupportedLevels: levels}
+}
+
+func openCodeVariantsLookReasoning(variants map[string]opencodeModelVariant) bool {
+	for name, variant := range variants {
+		if _, known := opencodeVariantOrder[name]; known {
+			return true
+		}
+		if variant.ReasoningEffort != "" || len(variant.Thinking) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func openCodeThinkingLevelsFromVariants(variants map[string]opencodeModelVariant) []ThinkingLevel {
+	if len(variants) == 0 {
+		return nil
+	}
+	values := make([]string, 0, len(variants))
+	for value, variant := range variants {
+		if value == "" || variant.Disabled {
+			continue
+		}
+		values = append(values, value)
+	}
+	sort.Slice(values, func(i, j int) bool {
+		left, leftKnown := opencodeVariantOrder[values[i]]
+		right, rightKnown := opencodeVariantOrder[values[j]]
+		if leftKnown && rightKnown {
+			return left < right
+		}
+		if leftKnown != rightKnown {
+			return leftKnown
+		}
+		return values[i] < values[j]
+	})
+	levels := make([]ThinkingLevel, 0, len(values))
+	for _, value := range values {
+		label, ok := opencodeVariantLabel[value]
+		if !ok {
+			label = strings.Title(strings.ReplaceAll(value, "-", " ")) //nolint:staticcheck
+		}
+		levels = append(levels, ThinkingLevel{Value: value, Label: label})
+	}
+	return levels
+}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1,0 +1,389 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestListModelsStaticProviders(t *testing.T) {
+	ctx := context.Background()
+	for _, provider := range []string{"claude", "codex", "cursor"} {
+		got, err := ListModels(ctx, provider, "")
+		if err != nil {
+			t.Fatalf("ListModels(%q) error: %v", provider, err)
+		}
+		if len(got) == 0 {
+			t.Errorf("ListModels(%q) returned no models", provider)
+		}
+		for i, m := range got {
+			if m.ID == "" {
+				t.Errorf("ListModels(%q)[%d] has empty ID", provider, i)
+			}
+			if m.Label == "" {
+				t.Errorf("ListModels(%q)[%d] has empty Label", provider, i)
+			}
+		}
+	}
+}
+
+func TestClaudeStaticModelsExposesFable5AsDefault(t *testing.T) {
+	models := claudeStaticModels()
+	ids := map[string]Model{}
+	defaults := 0
+	for _, m := range models {
+		ids[m.ID] = m
+		if m.Default {
+			defaults++
+		}
+	}
+
+	fable, ok := ids["claude-fable-5"]
+	if !ok {
+		t.Fatalf("missing Claude Fable 5 in: %+v", models)
+	}
+	if fable.Label != "Claude Fable 5" || fable.Provider != "anthropic" {
+		t.Errorf("unexpected Fable entry: %+v", fable)
+	}
+	// The latest flagship is the display default so newly created agents
+	// pick it up out of the box.
+	if defaults != 1 || !fable.Default {
+		t.Errorf("expected Fable 5 to be the sole default, got defaults=%d models=%+v", defaults, models)
+	}
+}
+
+func TestCodexStaticModelsExposesGPT55(t *testing.T) {
+	models := codexStaticModels()
+	ids := map[string]Model{}
+	for _, m := range models {
+		ids[m.ID] = m
+	}
+	for _, want := range []string{
+		"gpt-5.5", "gpt-5.5-mini",
+		"gpt-5.4", "gpt-5.4-mini",
+		"gpt-5.3-codex", "gpt-5",
+		"o3", "o3-mini",
+	} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("missing expected Codex model %q in: %+v", want, models)
+		}
+	}
+	latest, ok := ids["gpt-5.5"]
+	if !ok || !latest.Default {
+		t.Errorf("expected gpt-5.5 to be the default Codex entry, got %+v", latest)
+	}
+}
+
+func TestListModelsUnknownProvider(t *testing.T) {
+	ctx := context.Background()
+	_, err := ListModels(ctx, "nonexistent", "")
+	if err == nil {
+		t.Fatal("ListModels(unknown) expected error")
+	}
+}
+
+func TestStaticCatalogsHaveAtMostOneDefault(t *testing.T) {
+	// Each catalog should tag at most one entry as the display
+	// default so the UI badge is unambiguous. More than one
+	// usually means a copy/paste slip when adding new models.
+	catalogs := map[string][]Model{
+		"claude": claudeStaticModels(),
+		"codex":  codexStaticModels(),
+		"cursor": cursorStaticModels(),
+	}
+	for provider, models := range catalogs {
+		count := 0
+		for _, m := range models {
+			if m.Default {
+				count++
+			}
+		}
+		if count > 1 {
+			t.Errorf("%s: %d models marked Default, want 0 or 1", provider, count)
+		}
+	}
+}
+
+func TestParseOpenCodeModels(t *testing.T) {
+	input := `PROVIDER/MODEL                     CONTEXT  MAX_OUT
+openai/gpt-4o                      128000   16384
+anthropic/claude-sonnet-4-6        200000   8192
+openai/gpt-4o                      128000   16384
+nonprefixed-line
+`
+	models := parseOpenCodeModels(input)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models (header skipped, duplicate deduped, non-slash skipped), got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "openai/gpt-4o" || models[0].Provider != "openai" {
+		t.Errorf("unexpected first model: %+v", models[0])
+	}
+	if models[1].ID != "anthropic/claude-sonnet-4-6" || models[1].Provider != "anthropic" {
+		t.Errorf("unexpected second model: %+v", models[1])
+	}
+}
+
+func TestParseOpenCodeModelsVerboseVariants(t *testing.T) {
+	input := `openai/gpt-5
+{
+  "id": "gpt-5",
+  "name": "GPT-5",
+  "reasoning": true,
+  "variants": {
+    "high": { "reasoningEffort": "high" },
+    "low": { "reasoningEffort": "low" },
+    "xhigh": { "reasoningEffort": "xhigh" },
+    "fast-mode": { "reasoningEffort": "low" },
+    "disabled": { "disabled": true }
+  }
+}
+anthropic/claude-sonnet-4-6
+{
+  "id": "claude-sonnet-4-6",
+  "reasoning": true,
+  "variants": {
+    "max": { "thinking": { "type": "enabled", "budgetTokens": 32000 } },
+    "high": { "thinking": { "type": "enabled", "budgetTokens": 16000 } }
+  }
+}
+`
+	models := parseOpenCodeModels(input)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d: %+v", len(models), models)
+	}
+	if models[0].Thinking == nil {
+		t.Fatalf("expected first model to expose thinking variants")
+	}
+	got := make([]string, 0, len(models[0].Thinking.SupportedLevels))
+	for _, lvl := range models[0].Thinking.SupportedLevels {
+		got = append(got, lvl.Value)
+		if lvl.Value == "xhigh" && lvl.Label != "Extra high" {
+			t.Errorf("xhigh label: got %q, want Extra high", lvl.Label)
+		}
+		if lvl.Value == "fast-mode" && lvl.Label != "Fast Mode" {
+			t.Errorf("custom variant label: got %q, want Fast Mode", lvl.Label)
+		}
+	}
+	want := []string{"low", "high", "xhigh", "fast-mode"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("variant order/values: got %v, want %v", got, want)
+	}
+	if models[1].Thinking == nil || len(models[1].Thinking.SupportedLevels) != 2 {
+		t.Fatalf("expected second model variants, got %+v", models[1].Thinking)
+	}
+}
+
+func TestParseOpenCodeModelsMalformedVerboseBlockKeepsFollowingModels(t *testing.T) {
+	input := `openai/gpt-5
+{
+  "id": "gpt-5",
+  "reasoning": true,
+  "variants": {
+    "high": {}
+  }
+anthropic/claude-sonnet-4-6
+{
+  "id": "claude-sonnet-4-6",
+  "reasoning": true,
+  "variants": {
+    "high": {},
+    "max": {}
+  }
+}
+`
+	models := parseOpenCodeModels(input)
+	if len(models) != 2 {
+		t.Fatalf("expected both model rows to survive malformed JSON, got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "openai/gpt-5" {
+		t.Fatalf("unexpected first model: %+v", models[0])
+	}
+	if models[0].Thinking != nil {
+		t.Fatalf("malformed first JSON block should not annotate thinking: %+v", models[0].Thinking)
+	}
+	if models[1].ID != "anthropic/claude-sonnet-4-6" {
+		t.Fatalf("unexpected second model: %+v", models[1])
+	}
+	if models[1].Thinking == nil || len(models[1].Thinking.SupportedLevels) != 2 {
+		t.Fatalf("valid following JSON block should still annotate thinking: %+v", models[1].Thinking)
+	}
+}
+
+func TestDiscoverOpenCodeModelsFallsBackWhenVerboseFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "opencode")
+	script := `#!/bin/sh
+if [ "$1" = "models" ] && [ "$2" = "--verbose" ]; then
+  exit 2
+fi
+if [ "$1" = "models" ]; then
+  cat <<'EOF'
+PROVIDER/MODEL                     CONTEXT  MAX_OUT
+openai/gpt-4o                      128000   16384
+EOF
+  exit 0
+fi
+exit 1
+`
+	writeTestExecutable(t, fake, []byte(script))
+
+	models, err := discoverOpenCodeModels(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("discoverOpenCodeModels: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected fallback non-verbose model, got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "openai/gpt-4o" || models[0].Thinking != nil {
+		t.Fatalf("unexpected fallback model: %+v", models[0])
+	}
+}
+
+// TestCachedDiscoveryDoesNotCacheEmpty verifies that an empty discovery result
+// is not cached, so a transient failure doesn't keep the model picker blank
+// for the full TTL. A non-empty result is still cached.
+func TestCachedDiscoveryDoesNotCacheEmpty(t *testing.T) {
+	const emptyKey, nonEmptyKey = "test-cache-empty", "test-cache-nonempty"
+	// modelCache is a package-level global; clear our keys up front and on
+	// cleanup so the test stays hermetic under `go test -count=N`.
+	resetCache := func() {
+		modelCacheMu.Lock()
+		delete(modelCache, emptyKey)
+		delete(modelCache, nonEmptyKey)
+		modelCacheMu.Unlock()
+	}
+	resetCache()
+	t.Cleanup(resetCache)
+
+	emptyCalls := 0
+	empty := func() ([]Model, error) {
+		emptyCalls++
+		return []Model{}, nil
+	}
+	for i := 0; i < 2; i++ {
+		got, err := cachedDiscovery(emptyKey, empty)
+		if err != nil {
+			t.Fatalf("cachedDiscovery: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty result, got %+v", got)
+		}
+	}
+	if emptyCalls != 2 {
+		t.Fatalf("empty result must not be cached: expected fn called 2x, got %d", emptyCalls)
+	}
+
+	nonEmptyCalls := 0
+	nonEmpty := func() ([]Model, error) {
+		nonEmptyCalls++
+		return []Model{{ID: "provider/model"}}, nil
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := cachedDiscovery(nonEmptyKey, nonEmpty); err != nil {
+			t.Fatalf("cachedDiscovery: %v", err)
+		}
+	}
+	if nonEmptyCalls != 1 {
+		t.Fatalf("non-empty result must be cached: expected fn called 1x, got %d", nonEmptyCalls)
+	}
+}
+
+func TestDiscoverOpenCodeModelsFallsBackOnVerboseNoise(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake opencode binary is a /bin/sh script")
+	}
+
+	// `opencode models --verbose` => $2 == "--verbose": emit noise + exit 1.
+	// `opencode models`           => no $2: print the plain catalog.
+	script := "#!/bin/sh\n" +
+		"if [ \"$2\" = \"--verbose\" ]; then\n" +
+		"  echo 'panic: catalog sync failed'\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"echo 'openai/gpt-4o'\n"
+
+	fakePath := filepath.Join(t.TempDir(), "opencode")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	models, err := discoverOpenCodeModels(context.Background(), fakePath)
+	if err != nil {
+		t.Fatalf("discoverOpenCodeModels: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "openai/gpt-4o" {
+		t.Fatalf("expected fallback to plain `opencode models` to yield [openai/gpt-4o], got %+v", models)
+	}
+}
+
+func TestParseCursorModels(t *testing.T) {
+	input := `Available models
+
+auto - Auto
+composer-2-fast - Composer 2 Fast (current, default)
+composer-2 - Composer 2
+claude-4.6-sonnet-medium - Sonnet 4.6 1M
+claude-opus-4-7-high - Opus 4.7 1M
+gemini-3.1-pro - Gemini 3.1 Pro
+`
+	models := parseCursorModels(input)
+	if len(models) != 6 {
+		t.Fatalf("expected 6 models, got %d: %+v", len(models), models)
+	}
+	ids := map[string]Model{}
+	for _, m := range models {
+		ids[m.ID] = m
+	}
+	for _, want := range []string{"auto", "composer-2-fast", "composer-2", "claude-4.6-sonnet-medium", "claude-opus-4-7-high", "gemini-3.1-pro"} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("missing expected model %q in: %+v", want, models)
+		}
+	}
+	if def := ids["composer-2-fast"]; !def.Default {
+		t.Errorf("composer-2-fast should be marked default, got %+v", def)
+	}
+	if def := ids["composer-2-fast"]; def.Label != "Composer 2 Fast" {
+		t.Errorf("default label should be stripped of parenthetical, got %q", def.Label)
+	}
+	// Non-default entry should not carry Default=true.
+	if auto := ids["auto"]; auto.Default {
+		t.Errorf("non-default entry should not be flagged default: %+v", auto)
+	}
+}
+
+func TestParseCursorModelsSkipsHeaderAndBlankLines(t *testing.T) {
+	input := `Available models
+
+composer-2 - Composer 2
+`
+	models := parseCursorModels(input)
+	if len(models) != 1 || models[0].ID != "composer-2" {
+		t.Fatalf("unexpected: %+v", models)
+	}
+}
+
+func TestCachedDiscovery(t *testing.T) {
+	calls := 0
+	fn := func() ([]Model, error) {
+		calls++
+		return []Model{{ID: "x", Label: "x"}}, nil
+	}
+	// First call populates the cache; reset for isolation.
+	modelCacheMu.Lock()
+	delete(modelCache, "testkey")
+	modelCacheMu.Unlock()
+
+	if _, err := cachedDiscovery("testkey", fn); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cachedDiscovery("testkey", fn); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 underlying call due to cache, got %d", calls)
+	}
+}

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -11,6 +11,14 @@ import (
 	"time"
 )
 
+// opencodeBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args.
+var opencodeBlockedArgs = map[string]blockedArgMode{
+	"--format":  blockedWithValue, // json output format for daemon communication
+	"--dir":     blockedWithValue, // task workdir anchor for skill / AGENTS.md discovery
+	"--variant": blockedWithValue, // owned by agent.thinking_level
+}
+
 // opencodeBackend implements Backend by spawning `opencode run --format json`
 // and reading streaming JSON events from stdout — the same pattern as Claude.
 type opencodeBackend struct {
@@ -27,14 +35,20 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 
 	timeout := opts.Timeout
-	if timeout == 0 {
-		timeout = 20 * time.Minute
-	}
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	runCtx, cancel := runContext(ctx, timeout)
 
 	args := []string{"run", "--format", "json"}
+	// Anchor OpenCode's project discovery (AGENTS.md walk-up + skills scan)
+	// at the task workdir. Without this, OpenCode falls back to PWD inherited
+	// from the daemon process and can silently bypass the per-task workdir.
+	if opts.Cwd != "" {
+		args = append(args, "--dir", opts.Cwd)
+	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
+	}
+	if opts.ThinkingLevel != "" {
+		args = append(args, "--variant", opts.ThinkingLevel)
 	}
 	if opts.SystemPrompt != "" {
 		args = append(args, "--prompt", opts.SystemPrompt)
@@ -45,9 +59,14 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	if opts.ResumeSessionID != "" {
 		args = append(args, "--session", opts.ResumeSessionID)
 	}
+	args = append(args, filterCustomArgs(opts.ExtraArgs, opencodeBlockedArgs, b.cfg.Logger)...)
+	args = append(args, filterCustomArgs(opts.CustomArgs, opencodeBlockedArgs, b.cfg.Logger)...)
 	args = append(args, prompt)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
+	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
@@ -55,6 +74,12 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	env := buildEnv(b.cfg.Env)
 	// Auto-approve all tool use in daemon mode.
 	env = append(env, `OPENCODE_PERMISSION={"*":"allow"}`)
+	// Override PWD so the child OpenCode process resolves its discovery root
+	// to the task workdir. cmd.Dir alone is not enough: OpenCode reads PWD
+	// (inherited from the parent daemon) before falling back to process.cwd().
+	if opts.Cwd != "" {
+		env = append(env, "PWD="+opts.Cwd)
+	}
 	cmd.Env = env
 
 	stdout, err := cmd.StdoutPipe()
@@ -62,7 +87,8 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		cancel()
 		return nil, fmt.Errorf("opencode stdout pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[opencode:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[opencode:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -78,6 +104,12 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
+
+		// Close stdout when the context is cancelled so scanner.Scan() unblocks.
+		go func() {
+			<-runCtx.Done()
+			_ = stdout.Close()
+		}()
 
 		startTime := time.Now()
 		scanResult := b.processEvents(stdout, msgCh)
@@ -95,6 +127,10 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if exitErr != nil && scanResult.status == "completed" {
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("opencode exited with error: %v", exitErr)
+		}
+
+		if scanResult.errMsg != "" {
+			scanResult.errMsg = withAgentStderr(scanResult.errMsg, "opencode", stderrBuf.Tail())
 		}
 
 		b.cfg.Logger.Info("opencode finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package agent
+
+import "os/exec"
+
+// hideAgentWindow is a no-op on non-Windows platforms.
+func hideAgentWindow(cmd *exec.Cmd) {}

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package agent
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// createNewConsole allocates a fresh console for the child process. Combined
+// with HideWindow=true (STARTF_USESHOWWINDOW + SW_HIDE) the console window
+// stays off-screen, and — critically — any grandchildren the agent spawns
+// (tool subprocesses like bash, cmd, netstat, findstr) inherit this hidden
+// console instead of each allocating their own visible one.
+//
+// Using CREATE_NO_WINDOW here instead would strip the console entirely,
+// which forces Windows to allocate a new visible console per grandchild
+// when the grandchild is a console-subsystem program that doesn't itself
+// pass CREATE_NO_WINDOW.
+const createNewConsole = 0x00000010
+
+// hideAgentWindow configures cmd to suppress the console window on Windows
+// while still giving descendant processes a hidden console to inherit.
+// Stdio pipes set via cmd.StdoutPipe/StdinPipe keep working because
+// STARTF_USESTDHANDLES takes precedence over the new console's stdio.
+func hideAgentWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNewConsole
+}

--- a/server/pkg/agent/stderr_tail.go
+++ b/server/pkg/agent/stderr_tail.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"io"
+	"strings"
+	"sync"
+)
+
+// agentStderrTailBytes bounds the stderr tail captured for inclusion in
+// error messages when an agent CLI exits before emitting a structured
+// error (e.g. V8 abort on Windows, Bun panic, OOM). Large enough to
+// contain typical CLI error lines, small enough to stay sensible inside
+// a task-level Result.Error string.
+const agentStderrTailBytes = 2048
+
+// stderrTail forwards writes to an inner writer (typically the daemon's
+// log) while also retaining a bounded tail of the bytes written. Consumers
+// call Tail() to include that context in error messages when the agent
+// process exits before it emits a structured error — otherwise all the
+// user sees is "exit status N", with the real reason stuck in daemon logs.
+//
+// All backends that supervise a child CLI process should wire their
+// cmd.Stderr through this type, and on failure include Tail() in
+// Result.Error via withAgentStderr. That makes root-causing CLI crashes
+// possible without having to crawl the daemon host's log files.
+type stderrTail struct {
+	inner io.Writer
+	max   int
+
+	mu  sync.Mutex
+	buf []byte
+}
+
+func newStderrTail(inner io.Writer, max int) *stderrTail {
+	if max <= 0 {
+		max = agentStderrTailBytes
+	}
+	return &stderrTail{inner: inner, max: max}
+}
+
+func (s *stderrTail) Write(p []byte) (int, error) {
+	if _, err := s.inner.Write(p); err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	s.buf = append(s.buf, p...)
+	if len(s.buf) > s.max {
+		s.buf = s.buf[len(s.buf)-s.max:]
+	}
+	s.mu.Unlock()
+	return len(p), nil
+}
+
+// Tail returns the captured stderr with leading/trailing whitespace
+// trimmed; empty string means nothing was written or everything was
+// whitespace.
+func (s *stderrTail) Tail() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return strings.TrimSpace(string(s.buf))
+}
+
+// withAgentStderr appends a stderr tail hint to an error message when
+// non-empty, otherwise returns msg unchanged. The tail is prefixed with a
+// short label so the composed string stays readable even when the original
+// msg is already verbose.
+func withAgentStderr(msg, label, tail string) string {
+	if tail == "" {
+		return msg
+	}
+	return msg + "; " + label + " stderr: " + tail
+}

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -1,0 +1,498 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// thinking.go discovers per-model reasoning/effort catalogs for the
+// claude, codex, and opencode backends so the daemon can advertise them to
+// the UI without hard-coding (and getting wrong) what's installed locally.
+//
+// We deliberately do not flatten Claude's `low|medium|high|xhigh|max` and
+// Codex's `none|minimal|low|medium|high|xhigh` onto a shared enum. OpenCode
+// exposes provider-specific model variants through `opencode run --variant`,
+// and those names can be extended by local opencode.json config. What users
+// pick must round-trip exactly through each CLI's own value vocabulary.
+
+// ── Cache ────────────────────────────────────────────────────────────
+//
+// Discovery is keyed on (provider, executablePath, cliVersion). Bumping
+// the local CLI invalidates entries that referenced the older version's
+// help/`debug models` output.
+
+type thinkingCacheKey struct {
+	provider       string
+	executablePath string
+	cliVersion     string
+}
+
+type thinkingCacheEntry struct {
+	value     map[string]*ModelThinking // keyed by model ID
+	expiresAt time.Time
+}
+
+const thinkingDiscoveryTTL = 10 * time.Minute
+
+var (
+	thinkingCacheMu sync.Mutex
+	thinkingCache   = map[thinkingCacheKey]thinkingCacheEntry{}
+)
+
+func thinkingCacheGet(key thinkingCacheKey) (map[string]*ModelThinking, bool) {
+	thinkingCacheMu.Lock()
+	defer thinkingCacheMu.Unlock()
+	entry, ok := thinkingCache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.value, true
+}
+
+func thinkingCachePut(key thinkingCacheKey, value map[string]*ModelThinking) {
+	thinkingCacheMu.Lock()
+	defer thinkingCacheMu.Unlock()
+	thinkingCache[key] = thinkingCacheEntry{value: value, expiresAt: time.Now().Add(thinkingDiscoveryTTL)}
+}
+
+// resetThinkingCacheForTests is exposed for tests only; production code
+// must rely on the TTL or process restart for invalidation.
+func resetThinkingCacheForTests() {
+	thinkingCacheMu.Lock()
+	thinkingCache = map[thinkingCacheKey]thinkingCacheEntry{}
+	thinkingCacheMu.Unlock()
+}
+
+// ── Claude ───────────────────────────────────────────────────────────
+//
+// `claude --help` advertises `--effort <level>` with the full superset
+// in parentheses; we parse that line to learn which levels the CLI
+// version on this host accepts. Per-model gaps (Opus-only `xhigh`,
+// session-only `max`) come from a hand-maintained table because the
+// CLI does not expose model→effort mappings programmatically.
+
+// claudeEffortRe matches the help line emitted by `claude --help`:
+//
+//	--effort <level>   Effort level for the current session (low, medium, high, xhigh, max)
+//
+// Anchored on `--effort` and lenient about whitespace so flag-name
+// reformats (`--effort=…`, indented help blocks) do not break parsing.
+var claudeEffortRe = regexp.MustCompile(`--effort\s*(?:<[^>]+>)?\s*(?:Effort level[^(]*)?\(([^)]+)\)`)
+
+// claudeEffortLabel maps Claude's raw level token to the display label
+// the UI should render. Title-case matches Anthropic's own slash UI.
+var claudeEffortLabel = map[string]string{
+	"low":    "Low",
+	"medium": "Medium",
+	"high":   "High",
+	"xhigh":  "Extra high",
+	"max":    "Max",
+}
+
+// claudeModelEffortAllow restricts the level set per model where the
+// upstream documentation says only some are valid. Empty / missing
+// model → use the parsed superset as-is (current Claude Code default).
+// Update this map when Anthropic publishes a new model that does not
+// support `xhigh` / `max`.
+var claudeModelEffortAllow = map[string]map[string]bool{
+	// Opus is the only model that publicly supports xhigh; the help
+	// list still includes it for Sonnet / Haiku so we filter here.
+	"claude-opus-4-8":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
+	"claude-opus-4-7":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
+	"claude-opus-4-6":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
+	"claude-sonnet-4-6":         {"low": true, "medium": true, "high": true, "max": true},
+	"claude-sonnet-4-5":         {"low": true, "medium": true, "high": true, "max": true},
+	"claude-haiku-4-5-20251001": {"low": true, "medium": true, "high": true},
+}
+
+// claudeStaticEffortFallback is the conservative subset used when
+// parsing the `--effort` help line fails (binary missing, output drift,
+// etc.). Picked from the lowest-common-denominator across recent
+// Claude Code releases.
+var claudeStaticEffortFallback = []string{"low", "medium", "high"}
+
+// claudeStaticEffortFullSuperset is the full list recent Claude Code
+// releases advertise. Used as the catalog superset when a model isn't in
+// the per-model allow-list — we'd rather over-offer and let the CLI
+// reject than artificially block valid combinations.
+var claudeStaticEffortFullSuperset = []string{"low", "medium", "high", "xhigh", "max"}
+
+// annotateClaudeThinking populates each entry's Thinking field by
+// running `claude --help` once and projecting the parsed superset
+// through claudeModelEffortAllow. Errors are silently absorbed so a
+// missing CLI doesn't break model listing — the UI just hides the
+// picker for that model.
+func annotateClaudeThinking(ctx context.Context, models []Model, executablePath string) {
+	mapping := loadClaudeThinkingByModel(ctx, executablePath)
+	for i := range models {
+		if t, ok := mapping[models[i].ID]; ok && t != nil {
+			models[i].Thinking = t
+		}
+	}
+}
+
+func loadClaudeThinkingByModel(ctx context.Context, executablePath string) map[string]*ModelThinking {
+	if executablePath == "" {
+		executablePath = "claude"
+	}
+	version, _ := DetectVersion(ctx, executablePath)
+	key := thinkingCacheKey{provider: "claude", executablePath: executablePath, cliVersion: version}
+	if cached, ok := thinkingCacheGet(key); ok {
+		return cached
+	}
+
+	superset := claudeEffortSuperset(ctx, executablePath)
+	result := map[string]*ModelThinking{}
+	for _, m := range claudeStaticModels() {
+		allow := claudeModelEffortAllow[m.ID]
+		levels := projectClaudeLevels(superset, allow)
+		if len(levels) == 0 {
+			continue
+		}
+		result[m.ID] = &ModelThinking{
+			SupportedLevels: levels,
+			DefaultLevel:    "medium",
+		}
+	}
+	thinkingCachePut(key, result)
+	return result
+}
+
+// claudeEffortSuperset returns the parsed `--effort` value list. When
+// parsing fails it returns the static fallback rather than nothing so
+// callers can still render a usable picker.
+func claudeEffortSuperset(ctx context.Context, executablePath string) []string {
+	cmd := exec.CommandContext(ctx, executablePath, "--help")
+	hideAgentWindow(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return append([]string(nil), claudeStaticEffortFallback...)
+	}
+	parsed := parseClaudeEffortHelp(string(out))
+	if len(parsed) == 0 {
+		// Help format drifted — fall back to the last known good
+		// superset rather than the conservative subset, so newer
+		// levels are still offered until we hand-edit the fallback.
+		return append([]string(nil), claudeStaticEffortFullSuperset...)
+	}
+	return parsed
+}
+
+// parseClaudeEffortHelp extracts the comma-separated value list from a
+// `--effort` help line. Returns nil if the line is missing or the
+// captured group is empty so callers can pick a fallback path.
+func parseClaudeEffortHelp(helpText string) []string {
+	match := claudeEffortRe.FindStringSubmatch(helpText)
+	if len(match) < 2 {
+		return nil
+	}
+	var out []string
+	for _, raw := range strings.Split(match[1], ",") {
+		token := strings.TrimSpace(raw)
+		if token == "" {
+			continue
+		}
+		out = append(out, token)
+	}
+	return out
+}
+
+func projectClaudeLevels(superset []string, allow map[string]bool) []ThinkingLevel {
+	out := make([]ThinkingLevel, 0, len(superset))
+	for _, value := range superset {
+		if allow != nil && !allow[value] {
+			continue
+		}
+		label, ok := claudeEffortLabel[value]
+		if !ok {
+			// New value the daemon hasn't been taught yet — surface
+			// it raw so power users can still pick it.
+			label = strings.Title(value) //nolint:staticcheck
+		}
+		out = append(out, ThinkingLevel{Value: value, Label: label})
+	}
+	return out
+}
+
+// ── Codex ────────────────────────────────────────────────────────────
+//
+// `codex debug models` is the structured discovery hook. It returns the
+// per-model reasoning catalog directly, including the model's documented
+// default. The subcommand emits JSON on stdout by default. We add
+// `--bundled` to skip the network refresh: the bundled catalog is what
+// determines which `model_reasoning_effort` tokens the local binary
+// actually accepts, which is the only thing we need for validation.
+//
+// On older Codex versions / failures, the picker just disappears for
+// that model rather than offering a wrong list.
+
+// codexEffortLabel is the human display string for each Codex effort
+// value, matching Codex's own TUI (`Extra high`, `Minimal`, …) so
+// users see the same labels across our picker and `codex /model`.
+var codexEffortLabel = map[string]string{
+	"none":    "None",
+	"minimal": "Minimal",
+	"low":     "Low",
+	"medium":  "Medium",
+	"high":    "High",
+	"xhigh":   "Extra high",
+}
+
+// codexDebugModelsResponse mirrors the JSON shape emitted by
+// `codex debug models` (Codex 0.131.0+). Only the fields we
+// consume are typed; unknown keys are ignored.
+type codexDebugModelsResponse struct {
+	Models []struct {
+		Slug                    string `json:"slug"`
+		DefaultReasoningLevel   string `json:"default_reasoning_level"`
+		SupportedReasoningLevel []struct {
+			Effort      string `json:"effort"`
+			Description string `json:"description"`
+		} `json:"supported_reasoning_levels"`
+	} `json:"models"`
+}
+
+// annotateCodexThinking decorates each model entry with its reasoning
+// catalog. Models the CLI doesn't know about (older codex install,
+// brand-new ID we haven't shipped) get Thinking=nil — the UI hides
+// the picker for those rows rather than guessing.
+func annotateCodexThinking(ctx context.Context, models []Model, executablePath string) {
+	mapping := loadCodexThinkingByModel(ctx, executablePath)
+	for i := range models {
+		if t, ok := mapping[models[i].ID]; ok && t != nil {
+			models[i].Thinking = t
+		}
+	}
+}
+
+func loadCodexThinkingByModel(ctx context.Context, executablePath string) map[string]*ModelThinking {
+	if executablePath == "" {
+		executablePath = "codex"
+	}
+	version, _ := DetectVersion(ctx, executablePath)
+	key := thinkingCacheKey{provider: "codex", executablePath: executablePath, cliVersion: version}
+	if cached, ok := thinkingCacheGet(key); ok {
+		return cached
+	}
+
+	raw, err := runCodexDebugModels(ctx, executablePath)
+	if err != nil {
+		// Cache the empty result so repeated UI polls don't re-shell
+		// the missing binary; TTL eventually retries.
+		thinkingCachePut(key, map[string]*ModelThinking{})
+		return map[string]*ModelThinking{}
+	}
+	parsed := parseCodexDebugModels(raw)
+	thinkingCachePut(key, parsed)
+	return parsed
+}
+
+// codexDebugModelsArgs is the argv we pass to discover the local Codex
+// catalog. Kept as a package-level var (not a literal at the call site)
+// so tests can assert the exact form a real `codex` invocation receives.
+var codexDebugModelsArgs = []string{"debug", "models", "--bundled"}
+
+func runCodexDebugModels(ctx context.Context, executablePath string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, executablePath, codexDebugModelsArgs...)
+	hideAgentWindow(cmd)
+	return cmd.Output()
+}
+
+// parseCodexDebugModels takes the JSON payload from `codex debug
+// models` and projects it into a per-model thinking catalog.
+// Returns an empty map (never nil) so callers can compose safely
+// without nil-checking the result.
+func parseCodexDebugModels(raw []byte) map[string]*ModelThinking {
+	out := map[string]*ModelThinking{}
+	var resp codexDebugModelsResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return out
+	}
+	for _, m := range resp.Models {
+		if m.Slug == "" || len(m.SupportedReasoningLevel) == 0 {
+			continue
+		}
+		levels := make([]ThinkingLevel, 0, len(m.SupportedReasoningLevel))
+		for _, lvl := range m.SupportedReasoningLevel {
+			if lvl.Effort == "" {
+				continue
+			}
+			label, ok := codexEffortLabel[lvl.Effort]
+			if !ok {
+				label = strings.Title(lvl.Effort) //nolint:staticcheck
+			}
+			levels = append(levels, ThinkingLevel{
+				Value:       lvl.Effort,
+				Label:       label,
+				Description: lvl.Description,
+			})
+		}
+		if len(levels) == 0 {
+			continue
+		}
+		out[m.Slug] = &ModelThinking{
+			SupportedLevels: levels,
+			DefaultLevel:    m.DefaultReasoningLevel,
+		}
+	}
+	return out
+}
+
+// ── Shared validation ────────────────────────────────────────────────
+
+// ValidateThinkingLevel reports whether `value` is in the supported
+// catalog for the given (provider, model) pair. Empty value is always
+// valid — it means "use the runtime default".
+//
+// Empty model is treated as "use the provider's default model"; we
+// resolve it through ListModels so the daemon's pre-execution guard
+// behaves the same whether the agent picked an explicit model or
+// inherited the runtime default. Without this, a default-model task
+// with a valid thinking_level would be rejected on the grounds that
+// the empty string is not in the catalog.
+//
+// The lookup goes through ListModels so it sees the *current* CLI
+// catalog (including dynamic discovery), not just a static map. The
+// function is intentionally pure of HTTP concerns so the daemon's
+// pre-execution guard and the server's UpdateAgent gate can share the
+// same source of truth.
+func ValidateThinkingLevel(ctx context.Context, providerType, executablePath, model, value string) (bool, error) {
+	if value == "" {
+		return true, nil
+	}
+	models, err := ListModels(ctx, providerType, executablePath)
+	if err != nil {
+		return false, err
+	}
+	target := model
+	if target == "" {
+		// Default model = the entry the catalog marks as Default. If no
+		// entry is flagged, fall through to the no-match return; that
+		// matches the existing semantics where an unknown model fails
+		// closed rather than guessing.
+		for _, m := range models {
+			if m.Default {
+				target = m.ID
+				break
+			}
+		}
+		if target == "" {
+			if providerType == "opencode" {
+				return anyModelSupportsThinkingValue(models, value), nil
+			}
+			return false, nil
+		}
+	}
+	for _, m := range models {
+		if m.ID != target {
+			continue
+		}
+		if m.Thinking == nil {
+			return false, nil
+		}
+		for _, lvl := range m.Thinking.SupportedLevels {
+			if lvl.Value == value {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return false, nil
+}
+
+func anyModelSupportsThinkingValue(models []Model, value string) bool {
+	for _, m := range models {
+		if m.Thinking == nil {
+			continue
+		}
+		for _, lvl := range m.Thinking.SupportedLevels {
+			if lvl.Value == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// providerThinkingEnums is the server-side accept-list for runtimes with a
+// fixed reasoning-effort vocabulary. OpenCode is deliberately absent because
+// its `--variant` values come from the local model catalog and custom
+// opencode.json entries can define additional variant names.
+//
+// The server doesn't have local CLI binaries, so it cannot do per-model
+// discovery the way the daemon can; what it CAN do is reject values that are
+// not in any version of the provider's enum at all. Per-model gaps (e.g. user
+// sets `xhigh` while the chosen model only supports up to `high`) are handled
+// by the daemon's pre-execution guard, which logs and skips injection rather
+// than mutating persisted agent state. That split keeps API behaviour
+// consistent: always 400 on literal-invalid, never auto-clear on
+// combination-invalid.
+//
+// Keep these lists permissive: they're a "is this a known token in this
+// runtime's universe" check, not an "is this the right level for this
+// model" check. Adding a new level upstream means adding it here too so
+// users can persist it before the next discovery refresh.
+var providerThinkingEnums = map[string]map[string]bool{
+	"claude": {
+		"low":    true,
+		"medium": true,
+		"high":   true,
+		"xhigh":  true,
+		"max":    true,
+	},
+	"codex": {
+		"none":    true,
+		"minimal": true,
+		"low":     true,
+		"medium":  true,
+		"high":    true,
+		"xhigh":   true,
+	},
+}
+
+// IsKnownThinkingValue reports whether `value` is a recognised effort
+// token for the given provider. Empty string is always accepted (means
+// "use runtime default"). Unknown providers (no thinking concept) accept
+// only empty; OpenCode accepts well-formed variant names because its local
+// catalog can be extended by opencode.json.
+//
+// This is the cheap synchronous gate the server uses on CreateAgent /
+// UpdateAgent. Unlike ValidateThinkingLevel it does NOT consult the live
+// catalog or per-model subset.
+func IsKnownThinkingValue(providerType, value string) bool {
+	if value == "" {
+		return true
+	}
+	if providerType == "opencode" {
+		return isValidOpenCodeVariantName(value)
+	}
+	enum, ok := providerThinkingEnums[providerType]
+	if !ok {
+		return false
+	}
+	return enum[value]
+}
+
+func isValidOpenCodeVariantName(value string) bool {
+	if len(value) > 64 {
+		return false
+	}
+	for i, r := range value {
+		valid := r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' || r == '_' || r == '.'
+		if !valid {
+			return false
+		}
+		if i == 0 && (r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
+}

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -1,0 +1,722 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// ── Claude help parsing ──────────────────────────────────────────────
+
+func TestParseClaudeEffortHelp_OldFormat(t *testing.T) {
+	t.Parallel()
+	// claude 2.1.109 — the older help omits xhigh.
+	help := `Usage: claude [options]
+
+Options:
+  --model <model>     Model to use
+  --effort <level>    Effort level for the current session (low, medium, high, max)
+  --verbose
+`
+	got := parseClaudeEffortHelp(help)
+	want := []string{"low", "medium", "high", "max"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseClaudeEffortHelp: got %v, want %v", got, want)
+	}
+}
+
+func TestParseClaudeEffortHelp_NewFormat(t *testing.T) {
+	t.Parallel()
+	// claude 2.1.121 — the newer help adds xhigh.
+	help := `Usage: claude [options]
+
+Options:
+  --effort <level>    Effort level for the current session (low, medium, high, xhigh, max)
+`
+	got := parseClaudeEffortHelp(help)
+	want := []string{"low", "medium", "high", "xhigh", "max"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseClaudeEffortHelp: got %v, want %v", got, want)
+	}
+}
+
+func TestParseClaudeEffortHelp_Missing(t *testing.T) {
+	t.Parallel()
+	help := `Usage: claude [options]
+
+Options:
+  --model <model>     Model to use
+  --verbose
+`
+	got := parseClaudeEffortHelp(help)
+	if got != nil {
+		t.Fatalf("parseClaudeEffortHelp: expected nil, got %v", got)
+	}
+}
+
+func TestProjectClaudeLevels_PerModelSubset(t *testing.T) {
+	t.Parallel()
+	superset := []string{"low", "medium", "high", "xhigh", "max"}
+	// Sonnet should drop xhigh per claudeModelEffortAllow.
+	got := projectClaudeLevels(superset, claudeModelEffortAllow["claude-sonnet-4-6"])
+	values := make([]string, 0, len(got))
+	for _, lvl := range got {
+		values = append(values, lvl.Value)
+	}
+	want := []string{"low", "medium", "high", "max"}
+	if !reflect.DeepEqual(values, want) {
+		t.Fatalf("projectClaudeLevels: got %v, want %v", values, want)
+	}
+	// Opus keeps xhigh.
+	got = projectClaudeLevels(superset, claudeModelEffortAllow["claude-opus-4-7"])
+	values = values[:0]
+	for _, lvl := range got {
+		values = append(values, lvl.Value)
+	}
+	if !reflect.DeepEqual(values, superset) {
+		t.Fatalf("projectClaudeLevels for Opus: got %v, want %v", values, superset)
+	}
+}
+
+// ── Codex discovery argv ────────────────────────────────────────────
+//
+// Elon's PR1 review found that `codex debug models --output json` is
+// rejected by codex-cli 0.131.0 — there is no `--output` flag on the
+// subcommand. The fix was to drop the flag and add `--bundled` (which
+// just skips network refresh). These two tests pin the contract:
+//
+//   - TestCodexDebugModelsArgs_Pinned asserts the literal argv we pass
+//     so a future "let's add a flag" refactor breaks loudly instead of
+//     silently swallowing the discovery output.
+//   - TestRunCodexDebugModels_ArgvSeenByBinary plugs a fake `codex`
+//     binary on PATH and verifies that what *actually* reaches the
+//     process matches the pinned argv, not just what the var holds.
+
+func TestCodexDebugModelsArgs_Pinned(t *testing.T) {
+	t.Parallel()
+	want := []string{"debug", "models", "--bundled"}
+	if !reflect.DeepEqual(codexDebugModelsArgs, want) {
+		t.Fatalf("codexDebugModelsArgs drifted: got %v, want %v", codexDebugModelsArgs, want)
+	}
+	for _, arg := range codexDebugModelsArgs {
+		if arg == "--output" || arg == "-o" {
+			t.Errorf("--output / -o leaked back into argv (codex CLI does not accept it): %v", codexDebugModelsArgs)
+		}
+	}
+}
+
+// TestRunCodexDebugModels_ArgvSeenByBinary executes runCodexDebugModels
+// against a shell-script stand-in for `codex` that records its argv to
+// a file and prints a minimal valid JSON payload. The check is on what
+// the binary actually received (one argument per element, no merging
+// or splitting), not just the package var — the original bug surfaced
+// because a real codex saw `--output json` as two extra unknown args.
+func TestRunCodexDebugModels_ArgvSeenByBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	argvFile := filepath.Join(dir, "argv.txt")
+	fake := filepath.Join(dir, "codex")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > '" + argvFile + "'\n" +
+		"echo '{\"models\":[]}'\n"
+	// Use the ForkLock-protected helper instead of os.WriteFile: under
+	// t.Parallel() with the rest of this package, a sibling test's
+	// concurrent fork can inherit our still-open write fd, causing
+	// Linux ETXTBSY when we exec the file (Go #22315).
+	writeTestExecutable(t, fake, []byte(script))
+
+	raw, err := runCodexDebugModels(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("runCodexDebugModels: %v (output=%q)", err, raw)
+	}
+
+	data, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read argv file: %v", err)
+	}
+	got := splitNonEmptyLines(string(data))
+	want := []string{"debug", "models", "--bundled"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fake codex received argv %v, want %v", got, want)
+	}
+}
+
+func splitNonEmptyLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// ── Codex debug models JSON parsing ──────────────────────────────────
+
+func TestParseCodexDebugModels(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"models": [
+			{
+				"slug": "gpt-5.5",
+				"default_reasoning_level": "medium",
+				"supported_reasoning_levels": [
+					{"effort": "low", "description": "Fast"},
+					{"effort": "medium", "description": "Balanced"},
+					{"effort": "high", "description": "Deeper"},
+					{"effort": "xhigh", "description": "Maximum"}
+				]
+			},
+			{
+				"slug": "gpt-5",
+				"default_reasoning_level": "low",
+				"supported_reasoning_levels": [
+					{"effort": "minimal", "description": "Quick"},
+					{"effort": "low", "description": "Fast"}
+				]
+			},
+			{
+				"slug": "no-reasoning",
+				"supported_reasoning_levels": []
+			}
+		]
+	}`)
+	got := parseCodexDebugModels(raw)
+
+	gpt55, ok := got["gpt-5.5"]
+	if !ok || gpt55 == nil {
+		t.Fatalf("missing gpt-5.5 entry: %+v", got)
+	}
+	if gpt55.DefaultLevel != "medium" {
+		t.Errorf("gpt-5.5 default: got %q, want medium", gpt55.DefaultLevel)
+	}
+	if len(gpt55.SupportedLevels) != 4 {
+		t.Errorf("gpt-5.5 supported count: got %d, want 4", len(gpt55.SupportedLevels))
+	}
+	// Labels should come from codexEffortLabel mapping, not from raw effort.
+	for _, lvl := range gpt55.SupportedLevels {
+		if lvl.Value == "xhigh" && lvl.Label != "Extra high" {
+			t.Errorf("xhigh label: got %q, want Extra high", lvl.Label)
+		}
+	}
+
+	gpt5, ok := got["gpt-5"]
+	if !ok || gpt5 == nil {
+		t.Fatalf("missing gpt-5 entry: %+v", got)
+	}
+	if gpt5.DefaultLevel != "low" {
+		t.Errorf("gpt-5 default: got %q, want low", gpt5.DefaultLevel)
+	}
+
+	// Models with empty supported_reasoning_levels should be omitted to
+	// keep the wire payload small and avoid rendering empty pickers.
+	if _, ok := got["no-reasoning"]; ok {
+		t.Errorf("no-reasoning should be omitted, got %+v", got["no-reasoning"])
+	}
+}
+
+func TestParseCodexDebugModels_Malformed(t *testing.T) {
+	t.Parallel()
+	got := parseCodexDebugModels([]byte("not json"))
+	if len(got) != 0 {
+		t.Fatalf("expected empty map on malformed input, got %+v", got)
+	}
+}
+
+// ── IsKnownThinkingValue (server-side enum gate) ─────────────────────
+
+func TestIsKnownThinkingValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		provider string
+		value    string
+		want     bool
+	}{
+		{"claude", "", true},
+		{"claude", "low", true},
+		{"claude", "xhigh", true},
+		{"claude", "max", true},
+		{"claude", "none", false}, // Codex-only token rejected for Claude
+		{"codex", "", true},
+		{"codex", "none", true},
+		{"codex", "minimal", true},
+		{"codex", "xhigh", true},
+		{"codex", "max", false}, // Claude-only token rejected for Codex
+		{"opencode", "", true},
+		{"opencode", "max", true},
+		{"opencode", "fast-mode", true},  // custom opencode.json variant names are valid
+		{"opencode", ".hidden", false},   // reject suspicious / malformed names server-side
+		{"opencode", "bad value", false}, // spaces are not valid variant names
+		{"hermes", "", true},
+		{"hermes", "low", false}, // hermes has no thinking concept
+	}
+	for _, tc := range tests {
+		if got := IsKnownThinkingValue(tc.provider, tc.value); got != tc.want {
+			t.Errorf("IsKnownThinkingValue(%q, %q) = %v, want %v",
+				tc.provider, tc.value, got, tc.want)
+		}
+	}
+}
+
+// ── ValidateThinkingLevel default-model handling ─────────────────────
+//
+// Elon's PR1 review called out that an empty model on a default-model
+// task must not be misjudged as "unknown model → reject". The fix is to
+// resolve empty model to the catalog's default entry inside the
+// validator. Both the daemon's per-model guard and the server's API
+// layer call this; if it gets default-model wrong, any agent without an
+// explicit model set would have its thinking_level dropped silently.
+
+func TestValidateThinkingLevel_EmptyModelResolvesToDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+	t.Parallel()
+
+	// We need a `claude` whose --help advertises the full superset
+	// (low/medium/high/xhigh/max) so per-model projection actually has
+	// something to filter. A non-existent path falls back to a conservative
+	// [low,medium,high] which would hide the per-model behaviour we're
+	// trying to verify.
+	fakeClaude := writeFakeClaudeHelpBinary(t)
+	resetThinkingCacheForTests()
+	defer resetThinkingCacheForTests()
+
+	ctx := context.Background()
+
+	t.Run("valid level on default model passes", func(t *testing.T) {
+		// Claude's catalog flags Fable 5 as Default. Fable is not in the
+		// per-model allow-list, so it inherits the parsed superset and
+		// "high" must round-trip when model is left empty.
+		ok, err := ValidateThinkingLevel(ctx, "claude", fakeClaude, "", "high")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !ok {
+			t.Errorf("default-model high should be valid for claude; got false")
+		}
+	})
+
+	t.Run("invalid level on default model fails", func(t *testing.T) {
+		// A token outside the CLI's advertised superset must be rejected
+		// when the empty model resolves to the catalog default.
+		ok, err := ValidateThinkingLevel(ctx, "claude", fakeClaude, "", "warp9")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if ok {
+			t.Errorf("warp9 should be invalid on the default model; got true")
+		}
+	})
+
+	t.Run("per-model gap still rejected on explicit sonnet", func(t *testing.T) {
+		// "xhigh" is opus-only; an explicit Sonnet pick must reject it
+		// even though the superset advertises it.
+		ok, err := ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-sonnet-4-6", "xhigh")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if ok {
+			t.Errorf("xhigh should be invalid on sonnet; got true")
+		}
+	})
+
+	t.Run("empty value always valid", func(t *testing.T) {
+		// Empty value means "use runtime default" — should pass
+		// regardless of model resolution.
+		ok, err := ValidateThinkingLevel(ctx, "claude", fakeClaude, "", "")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !ok {
+			t.Errorf("empty value must always be valid")
+		}
+	})
+}
+
+func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+	t.Parallel()
+	fakeClaude := writeFakeClaudeHelpBinary(t)
+	resetThinkingCacheForTests()
+	defer resetThinkingCacheForTests()
+
+	ctx := context.Background()
+
+	// xhigh IS valid on Opus 4.7.
+	ok, err := ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-opus-4-7", "xhigh")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Errorf("xhigh should be valid on opus-4-7; got false")
+	}
+
+	// xhigh is NOT valid on Sonnet — should fail.
+	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-sonnet-4-6", "xhigh")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Errorf("xhigh must not be valid on sonnet-4-6; got true")
+	}
+
+	// An unknown model with a valid token still fails closed (no guess).
+	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-nonexistent", "high")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Errorf("unknown model must fail closed; got true")
+	}
+}
+
+func TestValidateThinkingLevel_OpenCodeEmptyModelUsesAdvertisedVariants(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+
+	modelCacheMu.Lock()
+	delete(modelCache, "opencode")
+	modelCacheMu.Unlock()
+	defer func() {
+		modelCacheMu.Lock()
+		delete(modelCache, "opencode")
+		modelCacheMu.Unlock()
+	}()
+
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "opencode")
+	script := `#!/bin/sh
+if [ "$1" = "models" ]; then
+  cat <<'EOF'
+opencode/deepseek-v4
+{
+  "id": "deepseek-v4",
+  "reasoning": true,
+  "variants": {
+    "high": {},
+    "max": {}
+  }
+}
+EOF
+  exit 0
+fi
+echo "opencode 9.9.9"
+`
+	writeTestExecutable(t, fake, []byte(script))
+
+	ctx := context.Background()
+	ok, err := ValidateThinkingLevel(ctx, "opencode", fake, "", "max")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected empty-model opencode max to pass when any advertised model supports it")
+	}
+
+	ok, err = ValidateThinkingLevel(ctx, "opencode", fake, "", "xhigh")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Fatalf("xhigh should fail when no advertised OpenCode model exposes it")
+	}
+}
+
+// writeFakeClaudeHelpBinary writes a small shell script that mimics
+// `claude --help`, emitting the full effort superset line so per-model
+// projection has something to filter. Returns the path to the executable.
+func writeFakeClaudeHelpBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	script := "#!/bin/sh\n" +
+		"cat <<'EOF'\n" +
+		"Usage: claude [options]\n" +
+		"\n" +
+		"Options:\n" +
+		"  --model <model>     Model to use\n" +
+		"  --effort <level>    Effort level for the current session (low, medium, high, xhigh, max)\n" +
+		"EOF\n"
+	// Same ForkLock rationale as TestRunCodexDebugModels_ArgvSeenByBinary —
+	// the parser tests that consume this helper exec the script in parallel,
+	// so a sibling fork can otherwise inherit our write fd and trip ETXTBSY.
+	writeTestExecutable(t, path, []byte(script))
+	return path
+}
+
+// ── Cache key invalidation ───────────────────────────────────────────
+
+func TestThinkingCacheKeyDistinct(t *testing.T) {
+	t.Parallel()
+	resetThinkingCacheForTests()
+	defer resetThinkingCacheForTests()
+
+	a := thinkingCacheKey{provider: "claude", executablePath: "/bin/claude", cliVersion: "2.1.121"}
+	b := thinkingCacheKey{provider: "claude", executablePath: "/bin/claude", cliVersion: "2.1.122"}
+	c := thinkingCacheKey{provider: "claude", executablePath: "/opt/claude", cliVersion: "2.1.121"}
+
+	thinkingCachePut(a, map[string]*ModelThinking{"x": {DefaultLevel: "a"}})
+	thinkingCachePut(b, map[string]*ModelThinking{"x": {DefaultLevel: "b"}})
+	thinkingCachePut(c, map[string]*ModelThinking{"x": {DefaultLevel: "c"}})
+
+	if got, _ := thinkingCacheGet(a); got["x"].DefaultLevel != "a" {
+		t.Errorf("cache key A: got %q, want a", got["x"].DefaultLevel)
+	}
+	if got, _ := thinkingCacheGet(b); got["x"].DefaultLevel != "b" {
+		t.Errorf("cache key B: got %q, want b", got["x"].DefaultLevel)
+	}
+	if got, _ := thinkingCacheGet(c); got["x"].DefaultLevel != "c" {
+		t.Errorf("cache key C: got %q, want c", got["x"].DefaultLevel)
+	}
+}
+
+// ── Shared injection fixture (Trump's MUL-2339 constraint) ───────────
+//
+// The three Codex injection points (thread/start.config,
+// thread/resume.config, turn/start.effort) must encode the same
+// thinking_level value, in the same shape per call type, with no
+// drift. This fixture defines the expected payload once and asserts
+// it across all three sites so a future refactor of any one site
+// breaks the test if the other two aren't kept in sync.
+
+// codexReasoningInjection is the shared expectation table for the
+// three Codex injection points. value→{turnStartEffort, configKey}.
+// One row per scenario.
+type codexReasoningCase struct {
+	name  string
+	level string
+}
+
+var codexReasoningCases = []codexReasoningCase{
+	{"empty-level-is-noop", ""},
+	{"low", "low"},
+	{"medium", "medium"},
+	{"high", "high"},
+	{"xhigh", "xhigh"},
+	{"none-codex-only", "none"},
+}
+
+func TestApplyCodexReasoningEffort_ThreePoints(t *testing.T) {
+	t.Parallel()
+	for _, tc := range codexReasoningCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// 1. thread/start params shape.
+			startParams := map[string]any{
+				"model": "gpt-5.5",
+				"cwd":   "/work",
+			}
+			applyCodexReasoningEffort(startParams, tc.level)
+			assertCodexThreadConfigEffort(t, "thread/start", startParams, tc.level)
+
+			// 2. thread/resume params shape.
+			resumeParams := map[string]any{
+				"threadId": "thr_prior",
+				"cwd":      "/work",
+				"model":    "gpt-5.5",
+			}
+			applyCodexReasoningEffort(resumeParams, tc.level)
+			assertCodexThreadConfigEffort(t, "thread/resume", resumeParams, tc.level)
+
+			// 3. turn/start params shape.
+			turnParams := map[string]any{
+				"threadId": "thr_x",
+				"input":    []map[string]any{{"type": "text", "text": "hi"}},
+			}
+			applyCodexReasoningEffort(turnParams, tc.level)
+			assertCodexTurnEffort(t, "turn/start", turnParams, tc.level)
+		})
+	}
+}
+
+// assertCodexThreadConfigEffort verifies the nested
+// `config.model_reasoning_effort` shape used by thread/start and
+// thread/resume. Empty level means the helper must be a no-op
+// (no key emitted), not an empty-string value.
+func assertCodexThreadConfigEffort(t *testing.T, method string, params map[string]any, want string) {
+	t.Helper()
+	cfgAny, hasCfg := params["config"]
+	if want == "" {
+		// Empty level → helper must not touch `config`. We allow the
+		// caller to have pre-populated config with other keys, but the
+		// reasoning effort key must NOT appear.
+		if !hasCfg {
+			return
+		}
+		cfg, _ := cfgAny.(map[string]any)
+		if _, has := cfg["model_reasoning_effort"]; has {
+			t.Errorf("%s: empty level must not emit model_reasoning_effort, got %v", method, cfg["model_reasoning_effort"])
+		}
+		return
+	}
+	if !hasCfg {
+		t.Fatalf("%s: expected config block when level=%q", method, want)
+	}
+	cfg, ok := cfgAny.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: config has wrong type %T", method, cfgAny)
+	}
+	got, ok := cfg["model_reasoning_effort"]
+	if !ok {
+		t.Fatalf("%s: missing config.model_reasoning_effort for level=%q (params=%+v)", method, want, params)
+	}
+	if got != want {
+		t.Errorf("%s: config.model_reasoning_effort = %v, want %q", method, got, want)
+	}
+	// `effort` (turn/start key) must NOT leak into a thread call.
+	if _, leaked := params["effort"]; leaked {
+		t.Errorf("%s: top-level effort key leaked into thread params: %+v", method, params)
+	}
+}
+
+// assertCodexTurnEffort verifies the top-level `effort` shape used by
+// turn/start. Empty level means the helper must be a no-op (no key
+// emitted), not an empty-string value.
+func assertCodexTurnEffort(t *testing.T, method string, params map[string]any, want string) {
+	t.Helper()
+	got, has := params["effort"]
+	if want == "" {
+		if has {
+			t.Errorf("%s: empty level must not emit effort, got %v", method, got)
+		}
+		// Nested config must also stay empty for the turn/start shape.
+		if cfg, hasCfg := params["config"]; hasCfg {
+			t.Errorf("%s: turn-shape params must not gain a config block, got %v", method, cfg)
+		}
+		return
+	}
+	if !has {
+		t.Fatalf("%s: missing top-level effort for level=%q (params=%+v)", method, want, params)
+	}
+	if got != want {
+		t.Errorf("%s: effort = %v, want %q", method, got, want)
+	}
+	// `config.model_reasoning_effort` must NOT leak into a turn call.
+	if cfg, hasCfg := params["config"]; hasCfg {
+		cfgMap, _ := cfg.(map[string]any)
+		if _, leaked := cfgMap["model_reasoning_effort"]; leaked {
+			t.Errorf("%s: config.model_reasoning_effort leaked into turn params: %+v", method, params)
+		}
+	}
+}
+
+func TestApplyCodexReasoningEffort_NilParamsSafe(t *testing.T) {
+	t.Parallel()
+	// Must not panic — defensive against future call sites passing nil.
+	applyCodexReasoningEffort(nil, "high")
+}
+
+func TestApplyCodexReasoningEffort_PreservesPreExistingConfig(t *testing.T) {
+	t.Parallel()
+	// thread/start may already have other config keys (e.g. future Codex
+	// fields). Reasoning effort must be additive, not destructive.
+	startParams := map[string]any{
+		"model": "gpt-5.5",
+		"config": map[string]any{
+			"some_future_key": "preserve_me",
+		},
+	}
+	applyCodexReasoningEffort(startParams, "high")
+	cfg, _ := startParams["config"].(map[string]any)
+	if cfg["some_future_key"] != "preserve_me" {
+		t.Errorf("pre-existing config key was clobbered: %+v", cfg)
+	}
+	if cfg["model_reasoning_effort"] != "high" {
+		t.Errorf("reasoning effort not injected: %+v", cfg)
+	}
+}
+
+// ── End-to-end: build*Args + thinking_level wiring ───────────────────
+
+func TestBuildClaudeArgs_InjectsEffort(t *testing.T) {
+	t.Parallel()
+	args := buildClaudeArgs(ExecOptions{Model: "claude-opus-4-7", ThinkingLevel: "xhigh"}, slog.Default())
+	if !containsAdjacent(args, "--effort", "xhigh") {
+		t.Errorf("expected --effort xhigh in args: %v", args)
+	}
+	// Must appear after --model (cosmetic but enforced for log readability).
+	modelIdx := argIndexOf(args, "--model")
+	effortIdx := argIndexOf(args, "--effort")
+	if modelIdx < 0 || effortIdx < 0 || modelIdx > effortIdx {
+		t.Errorf("expected --model before --effort: %v", args)
+	}
+}
+
+func TestBuildClaudeArgs_OmitsEffortWhenEmpty(t *testing.T) {
+	t.Parallel()
+	args := buildClaudeArgs(ExecOptions{Model: "claude-sonnet-4-6"}, slog.Default())
+	if argIndexOf(args, "--effort") >= 0 {
+		t.Errorf("expected no --effort when level empty: %v", args)
+	}
+}
+
+func TestBuildClaudeArgs_BlocksUserEffortOverride(t *testing.T) {
+	t.Parallel()
+	args := buildClaudeArgs(ExecOptions{
+		Model:         "claude-opus-4-7",
+		ThinkingLevel: "high",
+		CustomArgs:    []string{"--effort", "max", "--keep-me"},
+	}, slog.Default())
+	// Daemon-injected --effort survives.
+	if !containsAdjacent(args, "--effort", "high") {
+		t.Errorf("daemon-injected --effort high should remain: %v", args)
+	}
+	// User attempt to override is filtered out: no second --effort,
+	// no `max` token.
+	count := 0
+	for _, a := range args {
+		if a == "--effort" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one --effort, got %d: %v", count, args)
+	}
+	if argIndexOf(args, "max") >= 0 {
+		t.Errorf("filtered user --effort value still appears: %v", args)
+	}
+	// Other custom args pass through.
+	if argIndexOf(args, "--keep-me") < 0 {
+		t.Errorf("non-blocked custom arg was dropped: %v", args)
+	}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+func containsAdjacent(haystack []string, a, b string) bool {
+	for i := 0; i < len(haystack)-1; i++ {
+		if haystack[i] == a && haystack[i+1] == b {
+			return true
+		}
+	}
+	return false
+}
+
+func argIndexOf(slice []string, target string) int {
+	for i, v := range slice {
+		if v == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/server/pkg/agent/version.go
+++ b/server/pkg/agent/version.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// MinVersions defines the minimum required CLI version for each agent type.
+// Versions below these will be rejected during daemon registration.
+var MinVersions = map[string]string{
+	"claude": "2.0.0",
+	"codex":  "0.100.0", // app-server --listen stdio:// added in 0.100.0
+}
+
+// semver holds a parsed semantic version (major.minor.patch).
+type semver struct {
+	Major, Minor, Patch int
+}
+
+// versionRe matches version strings like "2.1.100", "v2.0.0", or
+// "2.1.100 (Claude Code)" — it extracts the first three numeric components.
+var versionRe = regexp.MustCompile(`v?(\d+)\.(\d+)\.(\d+)`)
+
+// parseSemver extracts a semver from a version string.
+func parseSemver(raw string) (semver, error) {
+	m := versionRe.FindStringSubmatch(raw)
+	if m == nil {
+		return semver{}, fmt.Errorf("cannot parse version %q", raw)
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	patch, _ := strconv.Atoi(m[3])
+	return semver{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// lessThan returns true if v < other.
+func (v semver) lessThan(other semver) bool {
+	if v.Major != other.Major {
+		return v.Major < other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor < other.Minor
+	}
+	return v.Patch < other.Patch
+}
+
+// CheckMinVersion validates that detectedVersion meets the minimum for agentType.
+// Returns nil if the version is acceptable or no minimum is defined.
+func CheckMinVersion(agentType, detectedVersion string) error {
+	minRaw, ok := MinVersions[agentType]
+	if !ok {
+		return nil
+	}
+	min, err := parseSemver(minRaw)
+	if err != nil {
+		return fmt.Errorf("invalid minimum version %q for %s: %w", minRaw, agentType, err)
+	}
+	detected, err := parseSemver(detectedVersion)
+	if err != nil {
+		return fmt.Errorf("cannot parse detected %s version %q: %w", agentType, detectedVersion, err)
+	}
+	if detected.lessThan(min) {
+		return fmt.Errorf("%s version %s is below minimum required %s — please upgrade", agentType, detectedVersion, minRaw)
+	}
+	return nil
+}

--- a/server/pkg/agent/version_test.go
+++ b/server/pkg/agent/version_test.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    semver
+		wantErr bool
+	}{
+		{"2.0.0", semver{2, 0, 0}, false},
+		{"v2.1.100", semver{2, 1, 100}, false},
+		{"2.1.100 (Claude Code)", semver{2, 1, 100}, false},
+		{"codex-cli 0.118.0", semver{0, 118, 0}, false},
+		{"1.0.20", semver{1, 0, 20}, false},
+		{"invalid", semver{}, true},
+		{"", semver{}, true},
+	}
+	for _, tt := range tests {
+		got, err := parseSemver(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseSemver(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseSemver(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSemverLessThan(t *testing.T) {
+	tests := []struct {
+		a, b semver
+		want bool
+	}{
+		{semver{1, 0, 0}, semver{2, 0, 0}, true},
+		{semver{2, 0, 0}, semver{1, 0, 0}, false},
+		{semver{2, 0, 0}, semver{2, 1, 0}, true},
+		{semver{2, 1, 0}, semver{2, 0, 0}, false},
+		{semver{2, 1, 12}, semver{2, 1, 13}, true},
+		{semver{2, 1, 13}, semver{2, 1, 12}, false},
+		{semver{2, 0, 0}, semver{2, 0, 0}, false},
+	}
+	for _, tt := range tests {
+		got := tt.a.lessThan(tt.b)
+		if got != tt.want {
+			t.Errorf("%v.lessThan(%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestExtractVersionLine(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "bare semver",
+			raw:  "0.42.0\n",
+			want: "0.42.0",
+		},
+		{
+			name: "claude full string preserved",
+			raw:  "2.1.5 (Claude Code)\n",
+			want: "2.1.5 (Claude Code)",
+		},
+		{
+			name: "codex prefix preserved",
+			raw:  "codex-cli 0.118.0\n",
+			want: "codex-cli 0.118.0",
+		},
+		// Reproduces #2516: gemini's Windows shim emits `chcp` output to stdout
+		// before the real version. The chcp line has no dotted-number form,
+		// so the semver scan skips it and picks up "0.42.0" from the next line.
+		{
+			name: "windows chcp prefix before version",
+			raw:  "Active code page: 65001\n0.42.0\n",
+			want: "0.42.0",
+		},
+		{
+			name: "windows chcp prefix CRLF",
+			raw:  "Active code page: 65001\r\n0.42.0\r\n",
+			want: "0.42.0",
+		},
+		{
+			name: "leading blank lines",
+			raw:  "\n\n  0.42.0\n",
+			want: "0.42.0",
+		},
+		{
+			name: "non-semver output falls back to trimmed raw",
+			raw:  "  some-build-id  \n",
+			want: "some-build-id",
+		},
+		{
+			name: "empty input",
+			raw:  "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractVersionLine(tt.raw); got != tt.want {
+				t.Errorf("extractVersionLine(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckMinVersion(t *testing.T) {
+	tests := []struct {
+		agentType string
+		version   string
+		wantErr   bool
+	}{
+		{"claude", "2.0.0", false},
+		{"claude", "2.1.100", false},
+		{"claude", "2.1.100 (Claude Code)", false},
+		{"claude", "v2.0.0", false},
+		{"claude", "1.0.128", true},
+		{"claude", "1.9.99", true},
+		{"claude", "invalid", true},
+		{"codex", "codex-cli 0.118.0", false},
+		{"codex", "codex-cli 0.100.0", false},
+		{"codex", "codex-cli 0.99.0", true},
+		{"codex", "codex-cli 0.50.0", true},
+		{"unknown", "1.0.0", false},
+	}
+	for _, tt := range tests {
+		err := CheckMinVersion(tt.agentType, tt.version)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("CheckMinVersion(%q, %q) error = %v, wantErr %v", tt.agentType, tt.version, err, tt.wantErr)
+		}
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config
 `
 
 type ArchiveAgentParams struct {
@@ -46,6 +46,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }
@@ -215,9 +216,9 @@ func (q *Queries) CountRunningTasks(ctx context.Context, agentID pgtype.UUID) (i
 const createAgent = `-- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, providers, visibility, owner_id,
-    tools, triggers, instructions, github_code_access, default_provider, default_daemon_id, max_concurrent_tasks
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+    tools, triggers, instructions, github_code_access, default_provider, default_daemon_id, max_concurrent_tasks, model_config
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config
 `
 
 type CreateAgentParams struct {
@@ -235,6 +236,7 @@ type CreateAgentParams struct {
 	DefaultProvider    pgtype.Text `json:"default_provider"`
 	DefaultDaemonID    pgtype.UUID `json:"default_daemon_id"`
 	MaxConcurrentTasks int32       `json:"max_concurrent_tasks"`
+	ModelConfig        []byte      `json:"model_config"`
 }
 
 func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent, error) {
@@ -253,6 +255,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.DefaultProvider,
 		arg.DefaultDaemonID,
 		arg.MaxConcurrentTasks,
+		arg.ModelConfig,
 	)
 	var i Agent
 	err := row.Scan(
@@ -276,6 +279,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }
@@ -407,7 +411,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config FROM agent
 WHERE id = $1
 `
 
@@ -435,12 +439,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config FROM agent
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -473,6 +478,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }
@@ -715,7 +721,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
 ORDER BY created_at ASC
 `
@@ -750,6 +756,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.DefaultDaemonID,
 			&i.MaxConcurrentTasks,
 			&i.DefaultProvider,
+			&i.ModelConfig,
 		); err != nil {
 			return nil, err
 		}
@@ -762,7 +769,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider FROM agent
+SELECT id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -797,6 +804,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.DefaultDaemonID,
 			&i.MaxConcurrentTasks,
 			&i.DefaultProvider,
+			&i.ModelConfig,
 		); err != nil {
 			return nil, err
 		}
@@ -899,7 +907,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -926,6 +934,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }
@@ -1017,9 +1026,10 @@ UPDATE agent SET
     default_provider = $12,
     default_daemon_id = $13,
     max_concurrent_tasks = COALESCE($14, max_concurrent_tasks),
+    model_config = COALESCE($15, model_config),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config
 `
 
 type UpdateAgentParams struct {
@@ -1037,6 +1047,7 @@ type UpdateAgentParams struct {
 	DefaultProvider    pgtype.Text `json:"default_provider"`
 	DefaultDaemonID    pgtype.UUID `json:"default_daemon_id"`
 	MaxConcurrentTasks pgtype.Int4 `json:"max_concurrent_tasks"`
+	ModelConfig        []byte      `json:"model_config"`
 }
 
 func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent, error) {
@@ -1055,6 +1066,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.DefaultProvider,
 		arg.DefaultDaemonID,
 		arg.MaxConcurrentTasks,
+		arg.ModelConfig,
 	)
 	var i Agent
 	err := row.Scan(
@@ -1078,6 +1090,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }
@@ -1085,7 +1098,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider
+RETURNING id, workspace_id, name, avatar_url, visibility, status, owner_id, created_at, updated_at, description, tools, triggers, instructions, archived_at, archived_by, github_code_access, providers, default_daemon_id, max_concurrent_tasks, default_provider, model_config
 `
 
 type UpdateAgentStatusParams struct {
@@ -1117,6 +1130,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.DefaultDaemonID,
 		&i.MaxConcurrentTasks,
 		&i.DefaultProvider,
+		&i.ModelConfig,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -40,6 +40,7 @@ type Agent struct {
 	DefaultDaemonID    pgtype.UUID        `json:"default_daemon_id"`
 	MaxConcurrentTasks int32              `json:"max_concurrent_tasks"`
 	DefaultProvider    pgtype.Text        `json:"default_provider"`
+	ModelConfig        []byte             `json:"model_config"`
 }
 
 type AgentRuntime struct {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -19,8 +19,8 @@ WHERE id = $1 AND workspace_id = $2;
 -- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, providers, visibility, owner_id,
-    tools, triggers, instructions, github_code_access, default_provider, default_daemon_id, max_concurrent_tasks
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, sqlc.narg(default_provider), sqlc.narg(default_daemon_id), @max_concurrent_tasks)
+    tools, triggers, instructions, github_code_access, default_provider, default_daemon_id, max_concurrent_tasks, model_config
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, sqlc.narg(default_provider), sqlc.narg(default_daemon_id), @max_concurrent_tasks, @model_config)
 RETURNING *;
 
 -- name: UpdateAgent :one
@@ -38,6 +38,7 @@ UPDATE agent SET
     default_provider = sqlc.narg('default_provider'),
     default_daemon_id = sqlc.narg('default_daemon_id'),
     max_concurrent_tasks = COALESCE(sqlc.narg('max_concurrent_tasks'), max_concurrent_tasks),
+    model_config = COALESCE(sqlc.narg('model_config'), model_config),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## Summary

- **Per-provider agent model selection from the web UI.** New `agent.model_config` JSONB column stores a model + thinking level per provider. The frontend discovers the live model catalog through an async pending-request flow (UI initiates → daemon picks it up via heartbeat `pending_model_lists` → runs local CLI discovery → reports back → UI polls). The agents Settings tab gets a per-provider model + thinking picker; the create dialog pre-selects the latest flagship model (claude-fable-5 / gpt-5.5). Claim responses resolve the selection to a single `(model, thinking_level)` pair for the task's provider; the daemon resolves agent config → `MULTICA_<PROVIDER>_MODEL` → CLI default, and drops thinking levels the chosen model doesn't support instead of failing the task.
- **Daemon auto-update.** The daemon checks GitHub Releases every 6h (`--auto-update-interval`, `MULTICA_DAEMON_AUTO_UPDATE_INTERVAL`) and self-updates via the existing brew-or-download path, then restarts into the new binary. A claim barrier (`pauseClaims`/`claimsInFlight`) guarantees an upgrade restart can never cancel a task claimed between the idle check and the upgrade. Opt out with `--no-auto-update` or `MULTICA_DAEMON_AUTO_UPDATE=false`; dev builds are always skipped.
- **Production-grade agent backends.** Claude: stream-json stdin input with the stdio deadlock fix (+ regression test), resume-failure session handling, stderr tails, token usage, `--strict-mcp-config`/`--effort`. Codex: `thread/resume` with fallback (resume previously didn't work at all), semantic-inactivity + first-turn no-progress timeouts, graceful shutdown that preserves telemetry, managed MCP via `config.toml`, thread-id multiplex filtering, usage with JSONL fallback. Cursor: native stream-json event protocol, result-as-completion boundary (previously could hang until the 20-min timeout), `cursor-agent` binary + `--yolo` + `--workspace`, Windows invocation support. Shared: model/thinking catalogs (`ListModels`, `ValidateThinkingLevel`), min-version gates at registration, `runContext`, custom-arg filtering.

## Test plan

- [x] `make test` passes (TS typecheck, 210 Vitest tests, Go tests, 20 E2E tests, all in Docker)
- [x] Ported the claude stdio deadlock regression test plus insights' claude/codex/cursor/models/thinking test suites
- [x] New unit tests: `ModelListStore` lifecycle/timeouts, `validateModelConfig`, auto-update barrier semantics (`auto_update_test.go`), release-version helpers
- [ ] Manual: pick a model on an agent in the web UI with a live daemon and confirm the task launches with `--model`
- [ ] Manual: run a release-build daemon against an older version and observe idle self-update + restart


Made with [Cursor](https://cursor.com)