### PR TITLE
feat(notifications): add Telegram preference controls

### DIFF
--- a/apps/web/app/(account)/account/_components/notifications-tab.tsx
+++ b/apps/web/app/(account)/account/_components/notifications-tab.tsx
@@ -9,7 +9,12 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { api } from "@/shared/api";
-import type { NotificationChannel } from "@/shared/types";
+import {
+  normalizeTelegramPreferences,
+  personalTelegramPreferenceCategories,
+  type NotificationChannel,
+  type TelegramPreferenceCategory,
+} from "@/shared/types";
 
 export function NotificationsTab() {
   const [telegramChannel, setTelegramChannel] = useState<NotificationChannel | null>(null);
@@ -35,6 +40,7 @@ export function NotificationsTab() {
       const updated = await api.upsertTelegramChannel({
         chat_id: chatId,
         enabled: telegramChannel?.enabled ?? true,
+        preferences: normalizeTelegramPreferences(telegramChannel?.preferences),
       });
       setTelegramChannel(updated);
       toast.success("Telegram channel saved");
@@ -51,6 +57,7 @@ export function NotificationsTab() {
       const updated = await api.upsertTelegramChannel({
         chat_id: telegramChannel.channel_id,
         enabled,
+        preferences: normalizeTelegramPreferences(telegramChannel.preferences),
       });
       setTelegramChannel(updated);
     } catch (e) {
@@ -66,6 +73,30 @@ export function NotificationsTab() {
       toast.success("Telegram channel removed");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed to remove Telegram channel");
+    }
+  };
+
+  const handleTelegramPreferenceToggle = async (
+    category: TelegramPreferenceCategory,
+    enabled: boolean,
+  ) => {
+    if (!telegramChannel) return;
+    const preferences = {
+      ...normalizeTelegramPreferences(telegramChannel.preferences),
+      [category]: enabled,
+    };
+    setTelegramSaving(true);
+    try {
+      const updated = await api.upsertTelegramChannel({
+        chat_id: telegramChannel.channel_id,
+        enabled: telegramChannel.enabled,
+        preferences,
+      });
+      setTelegramChannel(updated);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update Telegram preferences");
+    } finally {
+      setTelegramSaving(false);
     }
   };
 
@@ -124,12 +155,41 @@ export function NotificationsTab() {
                   </div>
                 </div>
                 {telegramChannel && (
-                  <div className="flex items-center justify-between">
-                    <Label className="text-xs text-muted-foreground">Enable Telegram notifications</Label>
-                    <Switch
-                      checked={telegramChannel.enabled}
-                      onCheckedChange={handleTelegramToggle}
-                    />
+                  <div className="space-y-4 border-t pt-4">
+                    <div className="flex items-center justify-between">
+                      <Label className="text-xs text-muted-foreground">Enable Telegram notifications</Label>
+                      <Switch
+                        checked={telegramChannel.enabled}
+                        onCheckedChange={handleTelegramToggle}
+                        disabled={telegramSaving}
+                      />
+                    </div>
+
+                    <div className="space-y-3">
+                      <div>
+                        <p className="text-xs font-medium">Notification types</p>
+                        <p className="text-xs text-muted-foreground">
+                          Choose which private Telegram notifications you receive.
+                        </p>
+                      </div>
+                      {personalTelegramPreferenceCategories.map((category) => {
+                        const preferences = normalizeTelegramPreferences(telegramChannel.preferences);
+                        return (
+                          <div key={category.id} className="flex items-start justify-between gap-4">
+                            <div className="space-y-0.5">
+                              <Label className="text-xs">{category.label}</Label>
+                              <p className="text-xs text-muted-foreground">{category.description}</p>
+                            </div>
+                            <Switch
+                              checked={preferences[category.id]}
+                              onCheckedChange={(enabled) => handleTelegramPreferenceToggle(category.id, enabled)}
+                              disabled={telegramSaving}
+                              aria-label={`Toggle ${category.label}`}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
                   </div>
                 )}
               </div>

--- a/apps/web/app/(dashboard)/settings/_components/workspace-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/workspace-tab.tsx
@@ -22,7 +22,12 @@ import { toast } from "sonner";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore } from "@/features/workspace";
 import { api } from "@/shared/api";
-import type { WorkspaceTelegramSettings } from "@/shared/types";
+import {
+  normalizeTelegramPreferences,
+  telegramPreferenceCategories,
+  type TelegramPreferenceCategory,
+  type WorkspaceTelegramSettings,
+} from "@/shared/types";
 
 export function WorkspaceTab() {
   const user = useAuthStore((s) => s.user);
@@ -78,6 +83,7 @@ export function WorkspaceTab() {
       const updated = await api.upsertWorkspaceTelegramNotifications(workspace.id, {
         chat_id: chatId,
         enabled: telegramGroup?.enabled ?? true,
+        preferences: normalizeTelegramPreferences(telegramGroup?.preferences),
       });
       setTelegramGroup(updated);
       toast.success("Telegram group saved");
@@ -94,6 +100,7 @@ export function WorkspaceTab() {
       const updated = await api.upsertWorkspaceTelegramNotifications(workspace.id, {
         chat_id: telegramGroup.chat_id,
         enabled,
+        preferences: normalizeTelegramPreferences(telegramGroup.preferences),
       });
       setTelegramGroup(updated);
     } catch (e) {
@@ -110,6 +117,30 @@ export function WorkspaceTab() {
       toast.success("Telegram group removed");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed to remove Telegram group");
+    }
+  };
+
+  const handleTelegramGroupPreferenceToggle = async (
+    category: TelegramPreferenceCategory,
+    enabled: boolean,
+  ) => {
+    if (!workspace || !telegramGroup?.configured || !telegramGroup.chat_id) return;
+    const preferences = {
+      ...normalizeTelegramPreferences(telegramGroup.preferences),
+      [category]: enabled,
+    };
+    setTelegramSaving(true);
+    try {
+      const updated = await api.upsertWorkspaceTelegramNotifications(workspace.id, {
+        chat_id: telegramGroup.chat_id,
+        enabled: telegramGroup.enabled ?? true,
+        preferences,
+      });
+      setTelegramGroup(updated);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update Telegram group preferences");
+    } finally {
+      setTelegramSaving(false);
     }
   };
 
@@ -279,16 +310,46 @@ export function WorkspaceTab() {
                 </div>
 
                 {telegramGroup?.configured && (
-                  <div className="flex items-center gap-2">
-                    <Switch
-                      checked={telegramGroup.enabled ?? true}
-                      onCheckedChange={handleTelegramGroupToggle}
-                      disabled={!canManageWorkspace}
-                      id="telegram-group-enabled"
-                    />
-                    <Label htmlFor="telegram-group-enabled" className="text-xs text-muted-foreground cursor-pointer">
-                      Notifications enabled
-                    </Label>
+                  <div className="space-y-4 border-t pt-4">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        checked={telegramGroup.enabled ?? true}
+                        onCheckedChange={handleTelegramGroupToggle}
+                        disabled={!canManageWorkspace || telegramSaving}
+                        id="telegram-group-enabled"
+                      />
+                      <Label htmlFor="telegram-group-enabled" className="text-xs text-muted-foreground cursor-pointer">
+                        Notifications enabled
+                      </Label>
+                    </div>
+
+                    <div className="space-y-3">
+                      <div>
+                        <p className="text-xs font-medium">Notification types</p>
+                        <p className="text-xs text-muted-foreground">
+                          Choose which updates are posted to the workspace Telegram group.
+                        </p>
+                      </div>
+                      {telegramPreferenceCategories.map((category) => {
+                        const preferences = normalizeTelegramPreferences(telegramGroup.preferences);
+                        return (
+                          <div key={category.id} className="flex items-start justify-between gap-4">
+                            <div className="space-y-0.5">
+                              <Label className="text-xs">{category.label}</Label>
+                              <p className="text-xs text-muted-foreground">{category.description}</p>
+                            </div>
+                            <Switch
+                              checked={preferences[category.id]}
+                              onCheckedChange={(nextEnabled) => (
+                                handleTelegramGroupPreferenceToggle(category.id, nextEnabled)
+                              )}
+                              disabled={!canManageWorkspace || telegramSaving}
+                              aria-label={`Toggle ${category.label}`}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
                   </div>
                 )}
 

--- a/apps/web/shared/types/index.ts
+++ b/apps/web/shared/types/index.ts
@@ -44,6 +44,7 @@ export type * from "./events";
 export type * from "./api";
 export type { Attachment } from "./attachment";
 export type { NotificationChannel, NotificationChannelType, UpsertTelegramChannelRequest } from "./notification_channel";
+export * from "./telegram_preferences";
 export type { WorkspaceTelegramSettings, UpsertWorkspaceTelegramRequest } from "./workspace_telegram";
 export type {
   Routine,

--- a/apps/web/shared/types/notification_channel.ts
+++ b/apps/web/shared/types/notification_channel.ts
@@ -1,9 +1,12 @@
+import type { TelegramNotificationPreferences } from "./telegram_preferences";
+
 export type NotificationChannelType = "telegram";
 
 export interface NotificationChannel {
   channel_type: NotificationChannelType;
   channel_id: string;
   enabled: boolean;
+  preferences: TelegramNotificationPreferences;
   created_at: string;
   updated_at: string;
 }
@@ -11,4 +14,5 @@ export interface NotificationChannel {
 export interface UpsertTelegramChannelRequest {
   chat_id: string;
   enabled?: boolean;
+  preferences?: Partial<TelegramNotificationPreferences>;
 }

--- a/apps/web/shared/types/telegram_preferences.ts
+++ b/apps/web/shared/types/telegram_preferences.ts
@@ -1,0 +1,58 @@
+export const telegramPreferenceCategories = [
+  {
+    id: "assignments_mentions",
+    label: "Assignments & mentions",
+    description: "Direct assignments, unassignments, and @mentions.",
+  },
+  {
+    id: "comments",
+    label: "Comments",
+    description: "New comments on subscribed issues.",
+  },
+  {
+    id: "field_changes",
+    label: "Field changes",
+    description: "Status, priority, due date, and assignee updates.",
+  },
+  {
+    id: "task_results",
+    label: "Task results",
+    description: "Agent task completions and failures.",
+  },
+  {
+    id: "reactions",
+    label: "Reactions",
+    description: "Emoji reactions on issues and comments.",
+  },
+  {
+    id: "new_issues",
+    label: "New issues",
+    description: "Issues created in the workspace group.",
+  },
+] as const;
+
+export type TelegramPreferenceCategory = typeof telegramPreferenceCategories[number]["id"];
+export type TelegramNotificationPreferences = Record<TelegramPreferenceCategory, boolean>;
+
+export function defaultTelegramPreferences(): TelegramNotificationPreferences {
+  return Object.fromEntries(
+    telegramPreferenceCategories.map((category) => [category.id, true]),
+  ) as TelegramNotificationPreferences;
+}
+
+export function normalizeTelegramPreferences(
+  preferences?: Partial<Record<string, boolean>> | null,
+): TelegramNotificationPreferences {
+  const normalized = defaultTelegramPreferences();
+  for (const category of telegramPreferenceCategories) {
+    const value = preferences?.[category.id];
+    if (typeof value === "boolean") {
+      normalized[category.id] = value;
+    }
+  }
+  return normalized;
+}
+
+export const personalTelegramPreferenceCategories = telegramPreferenceCategories.filter(
+  (category) => category.id !== "new_issues",
+);

--- a/apps/web/shared/types/workspace_telegram.ts
+++ b/apps/web/shared/types/workspace_telegram.ts
@@ -1,10 +1,14 @@
+import type { TelegramNotificationPreferences } from "./telegram_preferences";
+
 export interface WorkspaceTelegramSettings {
   configured: boolean;
   chat_id?: string;
   enabled?: boolean;
+  preferences?: TelegramNotificationPreferences;
 }
 
 export interface UpsertWorkspaceTelegramRequest {
   chat_id: string;
   enabled?: boolean;
+  preferences?: Partial<TelegramNotificationPreferences>;
 }

--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -24,7 +24,6 @@ type mention struct {
 	ID   string // user_id, agent_id, issue_id, or "all"
 }
 
-
 // statusLabels maps DB status values to human-readable labels for notifications.
 var statusLabels = map[string]string{
 	"backlog":     "Backlog",
@@ -199,7 +198,7 @@ func notifySubscribers(
 		telegramRecipients = append(telegramRecipients, sub.UserID)
 	}
 
-	sendTelegramToSubscribers(ctx, queries, bot, telegramRecipients, telegramMessage(notifType, title, issuePageURL(issueID), body))
+	sendTelegramToSubscribers(ctx, queries, bot, telegramRecipients, notifType, telegramMessage(notifType, title, issuePageURL(issueID), body))
 }
 
 // notifyDirect creates an inbox item for a specific recipient. Skips if the
@@ -331,14 +330,33 @@ func notifyMentionedMembers(
 		})
 		telegramRecipients = append(telegramRecipients, parseUUID(id))
 	}
-	sendTelegramToSubscribers(context.Background(), queries, bot, telegramRecipients,
+	sendTelegramToSubscribers(context.Background(), queries, bot, telegramRecipients, "mentioned",
 		telegramMessage("mentioned", issueTitle, issuePageURL(issueID), body))
+}
+
+func telegramCategoryForType(notifType string) string {
+	switch notifType {
+	case "issue_created":
+		return handler.TelegramCategoryNewIssues
+	case "issue_assigned", "unassigned", "mentioned":
+		return handler.TelegramCategoryAssignmentsMentions
+	case "new_comment":
+		return handler.TelegramCategoryComments
+	case "assignee_changed", "status_changed", "priority_changed", "due_date_changed":
+		return handler.TelegramCategoryFieldChanges
+	case "task_completed", "task_failed":
+		return handler.TelegramCategoryTaskResults
+	case "reaction_added":
+		return handler.TelegramCategoryReactions
+	default:
+		return ""
+	}
 }
 
 // sendWorkspaceTelegramGroup delivers a message to the workspace Telegram group
 // chat if one is configured and enabled. Delivery failures are logged without
 // affecting the caller.
-func sendWorkspaceTelegramGroup(ctx context.Context, queries *db.Queries, bot *telegram.Bot, workspaceID, text string) {
+func sendWorkspaceTelegramGroup(ctx context.Context, queries *db.Queries, bot *telegram.Bot, workspaceID, notifType, text string) {
 	if bot == nil {
 		return
 	}
@@ -351,13 +369,16 @@ func sendWorkspaceTelegramGroup(ctx context.Context, queries *db.Queries, bot *t
 	if s == nil || !s.Enabled || s.ChatID == "" {
 		return
 	}
+	if !handler.TelegramPreferenceEnabled(s.Preferences, telegramCategoryForType(notifType)) {
+		return
+	}
 	bot.SendMessageAsync(s.ChatID, text)
 }
 
 // sendTelegramToSubscribers looks up enabled Telegram channels for the given
 // member user IDs and delivers the message asynchronously. Delivery errors are
 // logged without affecting the caller.
-func sendTelegramToSubscribers(ctx context.Context, queries *db.Queries, bot *telegram.Bot, userIDs []pgtype.UUID, text string) {
+func sendTelegramToSubscribers(ctx context.Context, queries *db.Queries, bot *telegram.Bot, userIDs []pgtype.UUID, notifType, text string) {
 	if bot == nil || len(userIDs) == 0 {
 		return
 	}
@@ -366,7 +387,11 @@ func sendTelegramToSubscribers(ctx context.Context, queries *db.Queries, bot *te
 		slog.Error("telegram: failed to look up channels", "error", err)
 		return
 	}
+	category := telegramCategoryForType(notifType)
 	for _, ch := range channels {
+		if !handler.TelegramPreferenceEnabled(handler.TelegramPreferencesFromRaw(ch.Preferences), category) {
+			continue
+		}
 		bot.SendMessageAsync(ch.ChannelID, text)
 	}
 }
@@ -454,7 +479,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 			)
 			sendTelegramToSubscribers(ctx, queries, bot,
 				[]pgtype.UUID{parseUUID(*issue.AssigneeID)},
-				telegramMessage("issue_assigned", issue.Title, issuePageURL(issue.ID), ""))
+				"issue_assigned", telegramMessage("issue_assigned", issue.Title, issuePageURL(issue.ID), ""))
 		}
 
 		// Notify @mentions in description
@@ -466,7 +491,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 
 		// Workspace group notification
 		sendWorkspaceTelegramGroup(ctx, queries, bot, issue.WorkspaceID,
-			telegramMessage("issue_created", issue.Title, issuePageURL(issue.ID), ""))
+			"issue_created", telegramMessage("issue_created", issue.Title, issuePageURL(issue.ID), ""))
 	})
 
 	// issue:updated — handle assignee changes, status changes, priority, due date
@@ -489,18 +514,18 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 		// Workspace group: send one notification per meaningful change type
 		if assigneeChanged {
 			sendWorkspaceTelegramGroup(ctx, queries, bot, e.WorkspaceID,
-				telegramMessage("assignee_changed", issue.Title, issuePageURL(issue.ID), ""))
+				"assignee_changed", telegramMessage("assignee_changed", issue.Title, issuePageURL(issue.ID), ""))
 		}
 		if statusChanged {
 			prevStatus, _ := payload["prev_status"].(string)
 			sendWorkspaceTelegramGroup(ctx, queries, bot, e.WorkspaceID,
-				telegramMessage("status_changed", issue.Title, issuePageURL(issue.ID),
+				"status_changed", telegramMessage("status_changed", issue.Title, issuePageURL(issue.ID),
 					statusLabel(prevStatus)+" → "+statusLabel(issue.Status)))
 		}
 		if priorityChanged, _ := payload["priority_changed"].(bool); priorityChanged {
 			prevPriority, _ := payload["prev_priority"].(string)
 			sendWorkspaceTelegramGroup(ctx, queries, bot, e.WorkspaceID,
-				telegramMessage("priority_changed", issue.Title, issuePageURL(issue.ID),
+				"priority_changed", telegramMessage("priority_changed", issue.Title, issuePageURL(issue.ID),
 					priorityLabel(prevPriority)+" → "+priorityLabel(issue.Priority)))
 		}
 
@@ -545,7 +570,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 				if *issue.AssigneeType == "member" {
 					sendTelegramToSubscribers(ctx, queries, bot,
 						[]pgtype.UUID{parseUUID(*issue.AssigneeID)},
-						telegramMessage("issue_assigned", issue.Title, issuePageURL(issue.ID), ""))
+						"issue_assigned", telegramMessage("issue_assigned", issue.Title, issuePageURL(issue.ID), ""))
 				}
 			}
 
@@ -561,7 +586,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 				)
 				sendTelegramToSubscribers(ctx, queries, bot,
 					[]pgtype.UUID{parseUUID(*prevAssigneeID)},
-					telegramMessage("unassigned", issue.Title, issuePageURL(issue.ID), ""))
+					"unassigned", telegramMessage("unassigned", issue.Title, issuePageURL(issue.ID), ""))
 			}
 
 			// Subscriber: notify remaining subscribers about assignee change,
@@ -697,7 +722,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 
 		// Workspace group notification
 		sendWorkspaceTelegramGroup(ctx, queries, bot, e.WorkspaceID,
-			telegramMessage("new_comment", issueTitle, issuePageURL(issueID), commentContent))
+			"new_comment", telegramMessage("new_comment", issueTitle, issuePageURL(issueID), commentContent))
 	})
 
 	// issue_reaction:added — notify the issue creator
@@ -736,7 +761,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 		if creatorType == "member" {
 			sendTelegramToSubscribers(ctx, queries, bot,
 				[]pgtype.UUID{parseUUID(creatorID)},
-				telegramMessage("reaction_added", issueTitle, issuePageURL(issueID), reaction.Emoji))
+				"reaction_added", telegramMessage("reaction_added", issueTitle, issuePageURL(issueID), reaction.Emoji))
 		}
 	})
 
@@ -781,7 +806,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 		if commentAuthorType == "member" {
 			sendTelegramToSubscribers(ctx, queries, bot,
 				[]pgtype.UUID{parseUUID(commentAuthorID)},
-				telegramMessage("reaction_added", issueTitle, issuePageURL(issueID), reaction.Emoji))
+				"reaction_added", telegramMessage("reaction_added", issueTitle, issuePageURL(issueID), reaction.Emoji))
 		}
 	})
 
@@ -801,7 +826,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 			return
 		}
 		sendWorkspaceTelegramGroup(ctx, queries, bot, e.WorkspaceID,
-			telegramMessage("task_completed", issue.Title, issuePageURL(issueID), ""))
+			"task_completed", telegramMessage("task_completed", issue.Title, issuePageURL(issueID), ""))
 	})
 
 	// task:failed — notify all subscribers except the agent
@@ -847,7 +872,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries, bot *te
 
 		// Workspace group notification
 		sendWorkspaceTelegramGroup(ctx, queries, bot, e.WorkspaceID,
-			telegramMessage("task_failed", issue.Title, issuePageURL(issueID), taskFailedBody))
+			"task_failed", telegramMessage("task_failed", issue.Title, issuePageURL(issueID), taskFailedBody))
 	})
 }
 

--- a/server/cmd/server/workspace_telegram_test.go
+++ b/server/cmd/server/workspace_telegram_test.go
@@ -75,6 +75,27 @@ func setWorkspaceTelegramGroup(t *testing.T, workspaceID, chatID string, enabled
 	}
 }
 
+// setWorkspaceTelegramGroupWithPreferences configures the workspace Telegram group
+// and category preferences for delivery filtering tests.
+func setWorkspaceTelegramGroupWithPreferences(t *testing.T, workspaceID, chatID string, enabled bool, preferences map[string]bool) {
+	t.Helper()
+	settings := map[string]any{
+		"telegram_group": map[string]any{
+			"chat_id":     chatID,
+			"enabled":     enabled,
+			"preferences": preferences,
+		},
+	}
+	b, _ := json.Marshal(settings)
+	_, err := testPool.Exec(context.Background(),
+		`UPDATE workspace SET settings = $1 WHERE id = $2`,
+		b, workspaceID,
+	)
+	if err != nil {
+		t.Fatalf("setWorkspaceTelegramGroupWithPreferences: %v", err)
+	}
+}
+
 // clearWorkspaceTelegramGroup removes the telegram_group key from workspace settings.
 func clearWorkspaceTelegramGroup(t *testing.T, workspaceID string) {
 	t.Helper()
@@ -292,6 +313,145 @@ func TestWorkspaceTelegram_StatusChanged(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected status change message to group chat %s, got: %v", groupChatID, msgs)
+	}
+}
+
+// TestWorkspaceTelegram_CategoryPreferences verifies group category preferences
+// suppress disabled notification categories without disabling the whole channel.
+func TestWorkspaceTelegram_CategoryPreferences(t *testing.T) {
+	srv, getMsgs := fakeTelegramServer(t)
+	bot := telegram.NewBotWithURL("test-token", srv.URL)
+
+	const groupChatID = "-1001234567893"
+	setWorkspaceTelegramGroupWithPreferences(t, testWorkspaceID, groupChatID, true, map[string]bool{
+		"new_issues":    true,
+		"field_changes": false,
+	})
+	t.Cleanup(func() { clearWorkspaceTelegramGroup(t, testWorkspaceID) })
+
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+	registerNotificationListeners(bus, queries, bot)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:          issueID,
+				WorkspaceID: testWorkspaceID,
+				Title:       "blocked field change telegram test",
+				Status:      "in_progress",
+				Priority:    "medium",
+				CreatorType: "member",
+				CreatorID:   testUserID,
+			},
+			"status_changed": true,
+			"prev_status":    "todo",
+		},
+	})
+
+	time.Sleep(150 * time.Millisecond)
+	if msgs := getMsgs(); len(msgs) != 0 {
+		t.Fatalf("expected no field change Telegram messages, got: %v", msgs)
+	}
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:          issueID,
+				WorkspaceID: testWorkspaceID,
+				Title:       "allowed new issue telegram test",
+				Status:      "todo",
+				Priority:    "medium",
+				CreatorType: "member",
+				CreatorID:   testUserID,
+			},
+		},
+	})
+
+	msgs := waitForMsgs(getMsgs, 1)
+	if len(msgs) == 0 {
+		t.Fatal("expected new issue Telegram message to be delivered")
+	}
+}
+
+// TestPersonalTelegram_CategoryPreferences verifies per-user category
+// preferences suppress private Telegram delivery for disabled categories.
+func TestPersonalTelegram_CategoryPreferences(t *testing.T) {
+	srv, getMsgs := fakeTelegramServer(t)
+	bot := telegram.NewBotWithURL("test-token", srv.URL)
+
+	clearWorkspaceTelegramGroup(t, testWorkspaceID)
+
+	subscriberEmail := "telegram-pref-subscriber@multica.ai"
+	subscriberID := createTestUser(t, subscriberEmail)
+	t.Cleanup(func() { cleanupTestUser(t, subscriberEmail) })
+
+	const privateChatID = "123456789"
+	_, err := testPool.Exec(context.Background(), `
+		INSERT INTO user_notification_channel (user_id, channel_type, channel_id, enabled, preferences)
+		VALUES ($1, 'telegram', $2, TRUE, '{"comments": false}'::jsonb)
+		ON CONFLICT (user_id, channel_type) DO UPDATE SET
+			channel_id = EXCLUDED.channel_id,
+			enabled = EXCLUDED.enabled,
+			preferences = EXCLUDED.preferences
+	`, subscriberID, privateChatID)
+	if err != nil {
+		t.Fatalf("insert user notification channel: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM user_notification_channel WHERE user_id = $1 AND channel_type = 'telegram'`,
+			subscriberID)
+	})
+
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+	registerNotificationListeners(bus, queries, bot)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	addTestSubscriber(t, issueID, "member", subscriberID, "manual")
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventCommentCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"comment": handler.CommentResponse{
+				ID:      "00000000-0000-0000-0000-000000000001",
+				IssueID: issueID,
+				Content: "comment should not trigger private telegram",
+			},
+			"issue_title":  "personal telegram preference test",
+			"issue_status": "todo",
+		},
+	})
+
+	time.Sleep(150 * time.Millisecond)
+	for _, msg := range getMsgs() {
+		if msg.ChatID == privateChatID {
+			t.Fatalf("unexpected private Telegram message for disabled comments category: %v", msg)
+		}
 	}
 }
 

--- a/server/internal/handler/notification_channel.go
+++ b/server/internal/handler/notification_channel.go
@@ -5,15 +5,17 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	db "github.com/nullne/multica/server/pkg/db/generated"
 )
 
 type NotificationChannelResponse struct {
-	ChannelType string `json:"channel_type"`
-	ChannelID   string `json:"channel_id"`
-	Enabled     bool   `json:"enabled"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	ChannelType string          `json:"channel_type"`
+	ChannelID   string          `json:"channel_id"`
+	Enabled     bool            `json:"enabled"`
+	CreatedAt   string          `json:"created_at"`
+	UpdatedAt   string          `json:"updated_at"`
+	Preferences map[string]bool `json:"preferences"`
 }
 
 func notificationChannelToResponse(c db.UserNotificationChannel) NotificationChannelResponse {
@@ -23,6 +25,7 @@ func notificationChannelToResponse(c db.UserNotificationChannel) NotificationCha
 		Enabled:     c.Enabled,
 		CreatedAt:   timestampToString(c.CreatedAt),
 		UpdatedAt:   timestampToString(c.UpdatedAt),
+		Preferences: TelegramPreferencesFromRaw(c.Preferences),
 	}
 }
 
@@ -47,8 +50,9 @@ func (h *Handler) ListNotificationChannels(w http.ResponseWriter, r *http.Reques
 }
 
 type UpsertTelegramChannelRequest struct {
-	ChatID  string `json:"chat_id"`
-	Enabled *bool  `json:"enabled"`
+	ChatID      string          `json:"chat_id"`
+	Enabled     *bool           `json:"enabled"`
+	Preferences map[string]bool `json:"preferences"`
 }
 
 // UpsertTelegramChannel creates or updates the user's Telegram notification channel.
@@ -75,11 +79,32 @@ func (h *Handler) UpsertTelegramChannel(w http.ResponseWriter, r *http.Request) 
 		enabled = *req.Enabled
 	}
 
+	preferences := req.Preferences
+	if preferences == nil {
+		existing, err := h.Queries.GetUserNotificationChannel(r.Context(), db.GetUserNotificationChannelParams{
+			UserID:      parseUUID(userID),
+			ChannelType: "telegram",
+		})
+		if err != nil && err != pgx.ErrNoRows {
+			writeError(w, http.StatusInternalServerError, "failed to load channel")
+			return
+		}
+		if err == nil {
+			preferences = TelegramPreferencesFromRaw(existing.Preferences)
+		}
+	}
+	preferencesJSON, err := encodeTelegramPreferences(preferences)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode preferences")
+		return
+	}
+
 	channel, err := h.Queries.UpsertUserNotificationChannel(r.Context(), db.UpsertUserNotificationChannelParams{
 		UserID:      parseUUID(userID),
 		ChannelType: "telegram",
 		ChannelID:   chatID,
 		Enabled:     enabled,
+		Preferences: preferencesJSON,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to save channel")

--- a/server/internal/handler/notification_channel_test.go
+++ b/server/internal/handler/notification_channel_test.go
@@ -34,6 +34,10 @@ func TestNotificationChannelAPI(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := newRequest("PUT", "/api/me/notification-channels/telegram", map[string]any{
 			"chat_id": "12345678",
+			"preferences": map[string]bool{
+				"comments":      false,
+				"field_changes": true,
+			},
 		})
 		testHandler.UpsertTelegramChannel(w, req)
 		if w.Code != http.StatusOK {
@@ -49,6 +53,15 @@ func TestNotificationChannelAPI(t *testing.T) {
 		}
 		if !ch.Enabled {
 			t.Fatal("expected channel to be enabled by default")
+		}
+		if ch.Preferences["comments"] {
+			t.Fatal("expected comments preference to be disabled")
+		}
+		if !ch.Preferences["field_changes"] {
+			t.Fatal("expected field_changes preference to be enabled")
+		}
+		if !ch.Preferences["assignments_mentions"] {
+			t.Fatal("expected omitted assignment preference to default enabled")
 		}
 	})
 
@@ -66,6 +79,9 @@ func TestNotificationChannelAPI(t *testing.T) {
 		}
 		if channels[0].ChannelType != "telegram" {
 			t.Fatalf("expected telegram, got %q", channels[0].ChannelType)
+		}
+		if channels[0].Preferences["comments"] {
+			t.Fatal("expected stored comments preference to remain disabled")
 		}
 	})
 

--- a/server/internal/handler/telegram_preferences.go
+++ b/server/internal/handler/telegram_preferences.go
@@ -1,0 +1,61 @@
+package handler
+
+import "encoding/json"
+
+const (
+	TelegramCategoryAssignmentsMentions = "assignments_mentions"
+	TelegramCategoryComments            = "comments"
+	TelegramCategoryFieldChanges        = "field_changes"
+	TelegramCategoryTaskResults         = "task_results"
+	TelegramCategoryReactions           = "reactions"
+	TelegramCategoryNewIssues           = "new_issues"
+)
+
+var telegramPreferenceCategories = []string{
+	TelegramCategoryAssignmentsMentions,
+	TelegramCategoryComments,
+	TelegramCategoryFieldChanges,
+	TelegramCategoryTaskResults,
+	TelegramCategoryReactions,
+	TelegramCategoryNewIssues,
+}
+
+func defaultTelegramPreferences() map[string]bool {
+	prefs := make(map[string]bool, len(telegramPreferenceCategories))
+	for _, category := range telegramPreferenceCategories {
+		prefs[category] = true
+	}
+	return prefs
+}
+
+// NormalizeTelegramPreferences applies the default-on behavior and drops
+// unknown categories so stored settings remain stable as UI labels evolve.
+func NormalizeTelegramPreferences(input map[string]bool) map[string]bool {
+	prefs := defaultTelegramPreferences()
+	for _, category := range telegramPreferenceCategories {
+		if value, ok := input[category]; ok {
+			prefs[category] = value
+		}
+	}
+	return prefs
+}
+
+func TelegramPreferencesFromRaw(raw []byte) map[string]bool {
+	var prefs map[string]bool
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &prefs)
+	}
+	return NormalizeTelegramPreferences(prefs)
+}
+
+func encodeTelegramPreferences(input map[string]bool) ([]byte, error) {
+	return json.Marshal(NormalizeTelegramPreferences(input))
+}
+
+func TelegramPreferenceEnabled(preferences map[string]bool, category string) bool {
+	if category == "" {
+		return true
+	}
+	enabled, ok := NormalizeTelegramPreferences(preferences)[category]
+	return !ok || enabled
+}

--- a/server/internal/handler/workspace_telegram.go
+++ b/server/internal/handler/workspace_telegram.go
@@ -12,8 +12,9 @@ import (
 
 // WorkspaceTelegramSettings holds the workspace-level Telegram group chat configuration.
 type WorkspaceTelegramSettings struct {
-	ChatID  string `json:"chat_id"`
-	Enabled bool   `json:"enabled"`
+	ChatID      string          `json:"chat_id"`
+	Enabled     bool            `json:"enabled"`
+	Preferences map[string]bool `json:"preferences"`
 }
 
 // ParseTelegramGroupSettings extracts the telegram_group section from the raw
@@ -34,6 +35,7 @@ func ParseTelegramGroupSettings(raw []byte) *WorkspaceTelegramSettings {
 	if err := json.Unmarshal(tgRaw, &s); err != nil {
 		return nil
 	}
+	s.Preferences = NormalizeTelegramPreferences(s.Preferences)
 	return &s
 }
 
@@ -61,6 +63,7 @@ func mergeTelegramGroupIntoWorkspace(raw []byte, s WorkspaceTelegramSettings) ([
 	if full == nil {
 		full = make(map[string]json.RawMessage)
 	}
+	s.Preferences = NormalizeTelegramPreferences(s.Preferences)
 	b, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
@@ -101,15 +104,17 @@ func (h *Handler) GetWorkspaceTelegramNotifications(w http.ResponseWriter, r *ht
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"configured": true,
-		"chat_id":    s.ChatID,
-		"enabled":    s.Enabled,
+		"configured":  true,
+		"chat_id":     s.ChatID,
+		"enabled":     s.Enabled,
+		"preferences": s.Preferences,
 	})
 }
 
 type UpsertWorkspaceTelegramRequest struct {
-	ChatID  string `json:"chat_id"`
-	Enabled *bool  `json:"enabled"`
+	ChatID      string          `json:"chat_id"`
+	Enabled     *bool           `json:"enabled"`
+	Preferences map[string]bool `json:"preferences"`
 }
 
 // UpsertWorkspaceTelegramNotifications saves or updates the workspace Telegram group chat ID.
@@ -137,10 +142,17 @@ func (h *Handler) UpsertWorkspaceTelegramNotifications(w http.ResponseWriter, r 
 	if req.Enabled != nil {
 		enabled = *req.Enabled
 	}
+	preferences := req.Preferences
+	if preferences == nil {
+		if existing := ParseTelegramGroupSettings(ws.Settings); existing != nil {
+			preferences = existing.Preferences
+		}
+	}
 
 	merged, err := mergeTelegramGroupIntoWorkspace(ws.Settings, WorkspaceTelegramSettings{
-		ChatID:  chatID,
-		Enabled: enabled,
+		ChatID:      chatID,
+		Enabled:     enabled,
+		Preferences: preferences,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to encode settings")
@@ -158,9 +170,10 @@ func (h *Handler) UpsertWorkspaceTelegramNotifications(w http.ResponseWriter, r 
 	h.publish(protocol.EventWorkspaceUpdated, id, "member", userID, map[string]any{"workspace": workspaceToResponse(ws)})
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"configured": true,
-		"chat_id":    chatID,
-		"enabled":    enabled,
+		"configured":  true,
+		"chat_id":     chatID,
+		"enabled":     enabled,
+		"preferences": NormalizeTelegramPreferences(preferences),
 	})
 }
 

--- a/server/migrations/071_telegram_notification_preferences.down.sql
+++ b/server/migrations/071_telegram_notification_preferences.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_notification_channel
+DROP COLUMN IF EXISTS preferences;

--- a/server/migrations/071_telegram_notification_preferences.up.sql
+++ b/server/migrations/071_telegram_notification_preferences.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_notification_channel
+ADD COLUMN preferences JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -459,6 +459,7 @@ type UserNotificationChannel struct {
 	Enabled     bool               `json:"enabled"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	Preferences []byte             `json:"preferences"`
 }
 
 type VerificationCode struct {

--- a/server/pkg/db/generated/notification_channel.sql.go
+++ b/server/pkg/db/generated/notification_channel.sql.go
@@ -27,7 +27,7 @@ func (q *Queries) DeleteUserNotificationChannel(ctx context.Context, arg DeleteU
 }
 
 const getUserNotificationChannel = `-- name: GetUserNotificationChannel :one
-SELECT user_id, channel_type, channel_id, enabled, created_at, updated_at FROM user_notification_channel
+SELECT user_id, channel_type, channel_id, enabled, created_at, updated_at, preferences FROM user_notification_channel
 WHERE user_id = $1 AND channel_type = $2
 `
 
@@ -46,12 +46,13 @@ func (q *Queries) GetUserNotificationChannel(ctx context.Context, arg GetUserNot
 		&i.Enabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Preferences,
 	)
 	return i, err
 }
 
 const listEnabledTelegramChannelsForUsers = `-- name: ListEnabledTelegramChannelsForUsers :many
-SELECT unc.user_id, unc.channel_id
+SELECT unc.user_id, unc.channel_id, unc.preferences
 FROM user_notification_channel unc
 WHERE unc.channel_type = 'telegram'
   AND unc.enabled = TRUE
@@ -59,8 +60,9 @@ WHERE unc.channel_type = 'telegram'
 `
 
 type ListEnabledTelegramChannelsForUsersRow struct {
-	UserID    pgtype.UUID `json:"user_id"`
-	ChannelID string      `json:"channel_id"`
+	UserID      pgtype.UUID `json:"user_id"`
+	ChannelID   string      `json:"channel_id"`
+	Preferences []byte      `json:"preferences"`
 }
 
 func (q *Queries) ListEnabledTelegramChannelsForUsers(ctx context.Context, dollar_1 []pgtype.UUID) ([]ListEnabledTelegramChannelsForUsersRow, error) {
@@ -72,7 +74,7 @@ func (q *Queries) ListEnabledTelegramChannelsForUsers(ctx context.Context, dolla
 	items := []ListEnabledTelegramChannelsForUsersRow{}
 	for rows.Next() {
 		var i ListEnabledTelegramChannelsForUsersRow
-		if err := rows.Scan(&i.UserID, &i.ChannelID); err != nil {
+		if err := rows.Scan(&i.UserID, &i.ChannelID, &i.Preferences); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -84,7 +86,7 @@ func (q *Queries) ListEnabledTelegramChannelsForUsers(ctx context.Context, dolla
 }
 
 const listUserNotificationChannels = `-- name: ListUserNotificationChannels :many
-SELECT user_id, channel_type, channel_id, enabled, created_at, updated_at FROM user_notification_channel
+SELECT user_id, channel_type, channel_id, enabled, created_at, updated_at, preferences FROM user_notification_channel
 WHERE user_id = $1
 ORDER BY channel_type
 `
@@ -105,6 +107,7 @@ func (q *Queries) ListUserNotificationChannels(ctx context.Context, userID pgtyp
 			&i.Enabled,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.Preferences,
 		); err != nil {
 			return nil, err
 		}
@@ -117,13 +120,14 @@ func (q *Queries) ListUserNotificationChannels(ctx context.Context, userID pgtyp
 }
 
 const upsertUserNotificationChannel = `-- name: UpsertUserNotificationChannel :one
-INSERT INTO user_notification_channel (user_id, channel_type, channel_id, enabled)
-VALUES ($1, $2, $3, $4)
+INSERT INTO user_notification_channel (user_id, channel_type, channel_id, enabled, preferences)
+VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (user_id, channel_type) DO UPDATE SET
     channel_id = EXCLUDED.channel_id,
     enabled    = EXCLUDED.enabled,
+    preferences = EXCLUDED.preferences,
     updated_at = now()
-RETURNING user_id, channel_type, channel_id, enabled, created_at, updated_at
+RETURNING user_id, channel_type, channel_id, enabled, created_at, updated_at, preferences
 `
 
 type UpsertUserNotificationChannelParams struct {
@@ -131,6 +135,7 @@ type UpsertUserNotificationChannelParams struct {
 	ChannelType string      `json:"channel_type"`
 	ChannelID   string      `json:"channel_id"`
 	Enabled     bool        `json:"enabled"`
+	Preferences []byte      `json:"preferences"`
 }
 
 func (q *Queries) UpsertUserNotificationChannel(ctx context.Context, arg UpsertUserNotificationChannelParams) (UserNotificationChannel, error) {
@@ -139,6 +144,7 @@ func (q *Queries) UpsertUserNotificationChannel(ctx context.Context, arg UpsertU
 		arg.ChannelType,
 		arg.ChannelID,
 		arg.Enabled,
+		arg.Preferences,
 	)
 	var i UserNotificationChannel
 	err := row.Scan(
@@ -148,6 +154,7 @@ func (q *Queries) UpsertUserNotificationChannel(ctx context.Context, arg UpsertU
 		&i.Enabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Preferences,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/notification_channel.sql
+++ b/server/pkg/db/queries/notification_channel.sql
@@ -8,11 +8,12 @@ WHERE user_id = $1
 ORDER BY channel_type;
 
 -- name: UpsertUserNotificationChannel :one
-INSERT INTO user_notification_channel (user_id, channel_type, channel_id, enabled)
-VALUES ($1, $2, $3, $4)
+INSERT INTO user_notification_channel (user_id, channel_type, channel_id, enabled, preferences)
+VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (user_id, channel_type) DO UPDATE SET
     channel_id = EXCLUDED.channel_id,
     enabled    = EXCLUDED.enabled,
+    preferences = EXCLUDED.preferences,
     updated_at = now()
 RETURNING *;
 
@@ -21,7 +22,7 @@ DELETE FROM user_notification_channel
 WHERE user_id = $1 AND channel_type = $2;
 
 -- name: ListEnabledTelegramChannelsForUsers :many
-SELECT unc.user_id, unc.channel_id
+SELECT unc.user_id, unc.channel_id, unc.preferences
 FROM user_notification_channel unc
 WHERE unc.channel_type = 'telegram'
   AND unc.enabled = TRUE


### PR DESCRIPTION
## Summary
- Add category-based Telegram notification preferences for personal channels and workspace group notifications.
- Persist personal preferences in `user_notification_channel.preferences` and workspace group preferences in `settings.telegram_group.preferences`.
- Filter Telegram delivery by category while preserving default-on behavior for existing configurations.

## Test plan
- `go test ./internal/handler -run 'TestNotificationChannelAPI|TestWorkspaceTelegram'`
- `go test ./cmd/server -run 'TestWorkspaceTelegram|TestPersonalTelegram'`
- `make check`
- `make test`


Made with [Cursor](https://cursor.com)