### PR TITLE
feat(agent): display task execution models

### DIFF
--- a/apps/web/features/issues/components/agent-live-card.test.ts
+++ b/apps/web/features/issues/components/agent-live-card.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { AgentTask } from "@/shared/types/agent";
 import {
+  formatTaskRunModelLabel,
   groupTaskRunsByTrigger,
   isActiveTask,
   partitionTaskRunsByResultComment,
@@ -21,9 +22,22 @@ function makeTask(overrides: Partial<AgentTask>): AgentTask {
     error: null,
     created_at: "2026-05-01T00:00:00Z",
     trigger_comment_id: null,
+    provider: null,
+    model: null,
+    thinking_level: null,
     ...overrides,
   };
 }
+
+describe("formatTaskRunModelLabel", () => {
+  it("joins model and thinking level when both are present", () => {
+    expect(formatTaskRunModelLabel(makeTask({ model: "gpt-5.5", thinking_level: "high" }))).toBe("gpt-5.5 · high");
+  });
+
+  it("omits empty task model metadata", () => {
+    expect(formatTaskRunModelLabel(makeTask({ model: null, thinking_level: null }))).toBeNull();
+  });
+});
 
 describe("groupTaskRunsByTrigger", () => {
   it("places null-trigger runs in the issue bucket", () => {

--- a/apps/web/features/issues/components/agent-live-card.tsx
+++ b/apps/web/features/issues/components/agent-live-card.tsx
@@ -67,6 +67,11 @@ function formatDuration(start: string, end: string): string {
   return `${minutes}m ${secs}s`;
 }
 
+export function formatTaskRunModelLabel(task: Pick<AgentTask, "model" | "thinking_level">): string | null {
+  const parts = [task.model, task.thinking_level].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
 function shortenPath(p: string): string {
   const parts = p.split("/");
   if (parts.length <= 3) return p;
@@ -250,10 +255,11 @@ export function TaskRunCard({ task, fallbackAgentName }: TaskRunCardProps) {
   const taskDaemon = taskRuntime?.daemon_ref ? daemons.find((d) => d.id === taskRuntime.daemon_ref) : null;
   const runtimeLabel = [
     taskDaemon?.device_name || taskDaemon?.daemon_id,
-    taskRuntime?.provider,
+    taskRuntime?.provider ?? task.provider,
   ]
     .filter(Boolean)
     .join(" / ");
+  const modelLabel = formatTaskRunModelLabel(task);
 
   const agentLabel =
     (task.agent_id ? getActorName("agent", task.agent_id) : null) ?? fallbackAgentName ?? "Agent";
@@ -317,6 +323,12 @@ export function TaskRunCard({ task, fallbackAgentName }: TaskRunCardProps) {
               </span>
             )}
           </CollapsibleTrigger>
+
+          {modelLabel && (
+            <span className="text-xs text-muted-foreground shrink-0 truncate max-w-[180px]">
+              {modelLabel}
+            </span>
+          )}
 
           {runtimeLabel && (
             <Link

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -77,6 +77,9 @@ export interface AgentTask {
   agent_id: string;
   runtime_id: string;
   issue_id: string;
+  provider?: string | null;
+  model?: string | null;
+  thinking_level?: string | null;
   status: "queued" | "dispatched" | "running" | "completed" | "failed" | "cancelled";
   priority: number;
   dispatched_at: string | null;

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -112,6 +112,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 
 		r.Get("/tasks/{taskId}/status", h.GetTaskStatus)
 		r.Post("/tasks/{taskId}/start", h.StartTask)
+		r.Post("/tasks/{taskId}/metadata", h.ReportTaskExecutionMetadata)
 		r.Post("/tasks/{taskId}/progress", h.ReportTaskProgress)
 		r.Post("/tasks/{taskId}/complete", h.CompleteTask)
 		r.Post("/tasks/{taskId}/fail", h.FailTask)

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -86,7 +86,21 @@ func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages
 	}, nil)
 }
 
-func (c *Client) CompleteTask(ctx context.Context, taskID, output, prURL, branchName, sessionID, workDir string) error {
+func (c *Client) ReportTaskExecutionMetadata(ctx context.Context, taskID, provider, model, thinkingLevel string) error {
+	body := map[string]any{}
+	if provider != "" {
+		body["provider"] = provider
+	}
+	if model != "" {
+		body["model"] = model
+	}
+	if thinkingLevel != "" {
+		body["thinking_level"] = thinkingLevel
+	}
+	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/tasks/%s/metadata", taskID), body, nil)
+}
+
+func (c *Client) CompleteTask(ctx context.Context, taskID, output, prURL, branchName, sessionID, workDir, model, thinkingLevel string) error {
 	body := map[string]any{"output": output}
 	if prURL != "" {
 		body["pr_url"] = prURL
@@ -99,6 +113,12 @@ func (c *Client) CompleteTask(ctx context.Context, taskID, output, prURL, branch
 	}
 	if workDir != "" {
 		body["work_dir"] = workDir
+	}
+	if model != "" {
+		body["model"] = model
+	}
+	if thinkingLevel != "" {
+		body["thinking_level"] = thinkingLevel
 	}
 	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/tasks/%s/complete", taskID), body, nil)
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1252,7 +1252,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 		}
 	default:
 		taskLog.Info("task completed", "status", result.Status)
-		if err := d.client.CompleteTask(ctx, task.ID, result.Comment, result.PRURL, result.BranchName, result.SessionID, result.WorkDir); err != nil {
+		if err := d.client.CompleteTask(ctx, task.ID, result.Comment, result.PRURL, result.BranchName, result.SessionID, result.WorkDir, result.Model, result.ThinkingLevel); err != nil {
 			taskLog.Error("complete task failed, falling back to fail", "error", err)
 			if failErr := d.client.FailTask(ctx, task.ID, fmt.Sprintf("complete task failed: %s", err.Error())); failErr != nil {
 				taskLog.Error("fail task fallback also failed", "error", failErr)
@@ -1428,6 +1428,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 
 	taskStart := time.Now()
 
+	if err := d.client.ReportTaskExecutionMetadata(ctx, task.ID, provider, model, thinkingLevel); err != nil {
+		taskLog.Warn("report task execution metadata failed", "error", err)
+	}
+
 	session, err := backend.Execute(ctx, prompt, agent.ExecOptions{
 		Cwd:                       env.WorkDir,
 		Model:                     model,
@@ -1572,11 +1576,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	}()
 
 	result := <-session.Result
+	actualModel := model
+	if reportedModel := actualModelFromUsage(result.Usage); reportedModel != "" {
+		actualModel = reportedModel
+	}
 	elapsed := time.Since(taskStart).Round(time.Second)
 	taskLog.Info("agent finished",
 		"status", result.Status,
 		"duration", elapsed.String(),
 		"tools", toolCount.Load(),
+		"model", actualModel,
 	)
 
 	switch result.Status {
@@ -1585,10 +1594,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 			return TaskResult{}, fmt.Errorf("%s returned empty output", provider)
 		}
 		return TaskResult{
-			Status:    "completed",
-			Comment:   result.Output,
-			SessionID: result.SessionID,
-			WorkDir:   env.WorkDir,
+			Status:        "completed",
+			Comment:       result.Output,
+			SessionID:     result.SessionID,
+			WorkDir:       env.WorkDir,
+			Model:         actualModel,
+			ThinkingLevel: thinkingLevel,
 		}, nil
 	case "timeout":
 		return TaskResult{}, fmt.Errorf("%s timed out after %s", provider, d.cfg.AgentTimeout)
@@ -1597,8 +1608,21 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		if errMsg == "" {
 			errMsg = fmt.Sprintf("%s execution %s", provider, result.Status)
 		}
-		return TaskResult{Status: "blocked", Comment: errMsg}, nil
+		return TaskResult{Status: "blocked", Comment: errMsg, Model: actualModel, ThinkingLevel: thinkingLevel}, nil
 	}
+}
+
+func actualModelFromUsage(usage map[string]agent.TokenUsage) string {
+	if len(usage) != 1 {
+		return ""
+	}
+	for model := range usage {
+		if strings.TrimSpace(model) == "" || model == "unknown" {
+			return ""
+		}
+		return model
+	}
+	return ""
 }
 
 func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -67,11 +67,13 @@ type SkillFileData struct {
 
 // TaskResult is the outcome of executing a task.
 type TaskResult struct {
-	Status     string `json:"status"`
-	Comment    string `json:"comment"`
-	PRURL      string `json:"pr_url,omitempty"`
-	BranchName string `json:"branch_name,omitempty"`
-	EnvType    string `json:"env_type,omitempty"`
-	SessionID  string `json:"session_id,omitempty"` // Claude session ID for future resumption
-	WorkDir    string `json:"work_dir,omitempty"`   // working directory used during execution
+	Status        string `json:"status"`
+	Comment       string `json:"comment"`
+	PRURL         string `json:"pr_url,omitempty"`
+	BranchName    string `json:"branch_name,omitempty"`
+	EnvType       string `json:"env_type,omitempty"`
+	SessionID     string `json:"session_id,omitempty"` // Claude session ID for future resumption
+	WorkDir       string `json:"work_dir,omitempty"`   // working directory used during execution
+	Model         string `json:"model,omitempty"`
+	ThinkingLevel string `json:"thinking_level,omitempty"`
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -135,6 +135,9 @@ type AgentTaskResponse struct {
 	RuntimeID        string         `json:"runtime_id"`
 	IssueID          string         `json:"issue_id"`
 	WorkspaceID      string         `json:"workspace_id"`
+	Provider         *string        `json:"provider,omitempty"`
+	Model            *string        `json:"model,omitempty"`
+	ThinkingLevel    *string        `json:"thinking_level,omitempty"`
 	Status           string         `json:"status"`
 	Priority         int32          `json:"priority"`
 	DispatchedAt     *string        `json:"dispatched_at"`
@@ -182,6 +185,9 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		AgentID:          uuidToString(t.AgentID),
 		RuntimeID:        uuidToString(t.RuntimeID),
 		IssueID:          uuidToString(t.IssueID),
+		Provider:         textToPtr(t.Provider),
+		Model:            textToPtr(t.Model),
+		ThinkingLevel:    textToPtr(t.ThinkingLevel),
 		Status:           t.Status,
 		Priority:         t.Priority,
 		DispatchedAt:     timestampToPtr(t.DispatchedAt),

--- a/server/internal/handler/agent_task_model_test.go
+++ b/server/internal/handler/agent_task_model_test.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func seedTaskModelTestRun(t *testing.T, status string) (issueID string, taskID string) {
+	t.Helper()
+	ctx := t.Context()
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load test agent: %v", err)
+	}
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent_runtime WHERE workspace_id = $1 AND provider = 'codex' LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&runtimeID); err != nil {
+		t.Fatalf("load test runtime: %v", err)
+	}
+
+	number := int32(time.Now().UnixNano() % 1_000_000_000)
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		 VALUES ($1, 'task model metadata test', 'todo', 'none', 'member', $2, $3, 0)
+		 RETURNING id`,
+		testWorkspaceID, testUserID, number,
+	).Scan(&issueID); err != nil {
+		t.Fatalf("create test issue: %v", err)
+	}
+
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, provider, model, thinking_level)
+		 VALUES ($1, $2, $3, $4, 0, 'codex', 'configured-model', 'medium')
+		 RETURNING id`,
+		agentID, runtimeID, issueID, status,
+	).Scan(&taskID); err != nil {
+		t.Fatalf("create test task: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		_, _ = testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	return issueID, taskID
+}
+
+func TestReportTaskExecutionMetadataPersistsTaskModelFields(t *testing.T) {
+	_, taskID := seedTaskModelTestRun(t, "running")
+
+	req := withURLParam(newRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/metadata", map[string]any{
+		"provider":       "codex",
+		"model":          "gpt-5.5",
+		"thinking_level": "high",
+	}), "taskId", taskID)
+	w := httptest.NewRecorder()
+
+	testHandler.ReportTaskExecutionMetadata(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var provider, model, thinkingLevel string
+	if err := testPool.QueryRow(t.Context(),
+		`SELECT provider, model, thinking_level FROM agent_task_queue WHERE id = $1`,
+		taskID,
+	).Scan(&provider, &model, &thinkingLevel); err != nil {
+		t.Fatalf("load task metadata: %v", err)
+	}
+	if provider != "codex" || model != "gpt-5.5" || thinkingLevel != "high" {
+		t.Fatalf("unexpected metadata provider=%q model=%q thinking_level=%q", provider, model, thinkingLevel)
+	}
+}
+
+func TestCompleteTaskPersistsActualModelAndTaskRunsReturnMetadata(t *testing.T) {
+	issueID, taskID := seedTaskModelTestRun(t, "running")
+
+	req := withURLParam(newRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/complete", map[string]any{
+		"output":         "done",
+		"model":          "actual-model",
+		"thinking_level": "high",
+	}), "taskId", taskID)
+	w := httptest.NewRecorder()
+
+	testHandler.CompleteTask(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected complete 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req = withURLParam(newRequest(http.MethodGet, "/api/issues/"+issueID+"/task-runs", nil), "id", issueID)
+	w = httptest.NewRecorder()
+	testHandler.ListTasksByIssue(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var runs []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &runs); err != nil {
+		t.Fatalf("decode task runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 task run, got %d", len(runs))
+	}
+	if runs[0]["provider"] != "codex" || runs[0]["model"] != "actual-model" || runs[0]["thinking_level"] != "high" {
+		t.Fatalf("unexpected task run metadata: %#v", runs[0])
+	}
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -592,11 +592,13 @@ func (h *Handler) ReportTaskProgress(w http.ResponseWriter, r *http.Request) {
 
 // CompleteTask marks a running task as completed.
 type TaskCompleteRequest struct {
-	PRURL      string `json:"pr_url"`
-	BranchName string `json:"branch_name"`
-	Output     string `json:"output"`
-	SessionID  string `json:"session_id"` // Claude session ID for future resumption
-	WorkDir    string `json:"work_dir"`   // working directory used during execution
+	PRURL         string `json:"pr_url"`
+	BranchName    string `json:"branch_name"`
+	Output        string `json:"output"`
+	SessionID     string `json:"session_id"` // Claude session ID for future resumption
+	WorkDir       string `json:"work_dir"`   // working directory used during execution
+	Model         string `json:"model"`
+	ThinkingLevel string `json:"thinking_level"`
 }
 
 func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
@@ -609,7 +611,7 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, _ := json.Marshal(req)
-	task, err := h.TaskService.CompleteTask(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir)
+	task, err := h.TaskService.CompleteTask(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir, req.Model, req.ThinkingLevel)
 	if err != nil {
 		slog.Warn("complete task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -618,6 +620,38 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("task completed", "task_id", taskID, "agent_id", uuidToString(task.AgentID))
 	writeJSON(w, http.StatusOK, taskToResponse(*task))
+}
+
+// ReportTaskExecutionMetadata snapshots the model settings the daemon resolved
+// immediately before launching the provider CLI.
+type TaskExecutionMetadataRequest struct {
+	Provider      string `json:"provider"`
+	Model         string `json:"model"`
+	ThinkingLevel string `json:"thinking_level"`
+}
+
+func (h *Handler) ReportTaskExecutionMetadata(w http.ResponseWriter, r *http.Request) {
+	taskID := chi.URLParam(r, "taskId")
+
+	var req TaskExecutionMetadataRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	task, err := h.Queries.SetAgentTaskExecutionMetadata(r.Context(), db.SetAgentTaskExecutionMetadataParams{
+		ID:            parseUUID(taskID),
+		Provider:      pgtype.Text{String: req.Provider, Valid: req.Provider != ""},
+		Model:         pgtype.Text{String: req.Model, Valid: req.Model != ""},
+		ThinkingLevel: pgtype.Text{String: req.ThinkingLevel, Valid: req.ThinkingLevel != ""},
+	})
+	if err != nil {
+		slog.Warn("task execution metadata update failed", "task_id", taskID, "error", err)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, taskToResponse(task))
 }
 
 // GetTaskStatus returns the current status of a task.

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -234,6 +234,7 @@ func (s *TaskService) enqueueTaskToAgent(ctx context.Context, issue db.Issue, ag
 		Priority:         priorityToInt(issue.Priority),
 		TriggerCommentID: triggerCommentID,
 		Context:          contextData,
+		Provider:         pgtype.Text{String: runtime.Provider, Valid: runtime.Provider != ""},
 	})
 	if err != nil {
 		slog.Error("mention task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID), "error", err)
@@ -333,12 +334,14 @@ func (s *TaskService) StartTask(ctx context.Context, taskID pgtype.UUID) (*db.Ag
 
 // CompleteTask marks a task as completed.
 // Issue status is NOT changed here — the agent manages it via the CLI.
-func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, result []byte, sessionID, workDir string) (*db.AgentTaskQueue, error) {
+func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, result []byte, sessionID, workDir, model, thinkingLevel string) (*db.AgentTaskQueue, error) {
 	task, err := s.Queries.CompleteAgentTask(ctx, db.CompleteAgentTaskParams{
-		ID:        taskID,
-		Result:    result,
-		SessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},
-		WorkDir:   pgtype.Text{String: workDir, Valid: workDir != ""},
+		ID:            taskID,
+		Result:        result,
+		SessionID:     pgtype.Text{String: sessionID, Valid: sessionID != ""},
+		WorkDir:       pgtype.Text{String: workDir, Valid: workDir != ""},
+		Model:         pgtype.Text{String: model, Valid: model != ""},
+		ThinkingLevel: pgtype.Text{String: thinkingLevel, Valid: thinkingLevel != ""},
 	})
 	if err != nil {
 		// Log the current task state to help debug why the update matched no rows.

--- a/server/migrations/072_agent_task_model_metadata.down.sql
+++ b/server/migrations/072_agent_task_model_metadata.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE agent_task_queue
+    DROP COLUMN IF EXISTS thinking_level,
+    DROP COLUMN IF EXISTS model,
+    DROP COLUMN IF EXISTS provider;

--- a/server/migrations/072_agent_task_model_metadata.up.sql
+++ b/server/migrations/072_agent_task_model_metadata.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE agent_task_queue
+    ADD COLUMN provider TEXT,
+    ADD COLUMN model TEXT,
+    ADD COLUMN thinking_level TEXT;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -55,7 +55,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -79,6 +79,9 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
@@ -125,7 +128,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 // Claims the next queued task for an agent, enforcing per-issue serialization and
@@ -153,22 +156,33 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (Agen
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
 
 const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
-SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
+SET status = 'completed',
+    completed_at = now(),
+    result = $2,
+    session_id = $3,
+    work_dir = $4,
+    model = COALESCE($5, model),
+    thinking_level = COALESCE($6, thinking_level)
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 type CompleteAgentTaskParams struct {
-	ID        pgtype.UUID `json:"id"`
-	Result    []byte      `json:"result"`
-	SessionID pgtype.Text `json:"session_id"`
-	WorkDir   pgtype.Text `json:"work_dir"`
+	ID            pgtype.UUID `json:"id"`
+	Result        []byte      `json:"result"`
+	SessionID     pgtype.Text `json:"session_id"`
+	WorkDir       pgtype.Text `json:"work_dir"`
+	Model         pgtype.Text `json:"model"`
+	ThinkingLevel pgtype.Text `json:"thinking_level"`
 }
 
 func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskParams) (AgentTaskQueue, error) {
@@ -177,6 +191,8 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		arg.Result,
 		arg.SessionID,
 		arg.WorkDir,
+		arg.Model,
+		arg.ThinkingLevel,
 	)
 	var i AgentTaskQueue
 	err := row.Scan(
@@ -197,6 +213,9 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
@@ -285,9 +304,9 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 }
 
 const createAgentTask = `-- name: CreateAgentTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context)
-VALUES ($1, $2, $3, 'queued', $4, $5, $6)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context, provider)
+VALUES ($1, $2, $3, 'queued', $4, $5, $6, $7)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 type CreateAgentTaskParams struct {
@@ -297,6 +316,7 @@ type CreateAgentTaskParams struct {
 	Priority         int32       `json:"priority"`
 	TriggerCommentID pgtype.UUID `json:"trigger_comment_id"`
 	Context          []byte      `json:"context"`
+	Provider         pgtype.Text `json:"provider"`
 }
 
 func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams) (AgentTaskQueue, error) {
@@ -307,6 +327,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		arg.Priority,
 		arg.TriggerCommentID,
 		arg.Context,
+		arg.Provider,
 	)
 	var i AgentTaskQueue
 	err := row.Scan(
@@ -327,6 +348,9 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
@@ -335,7 +359,7 @@ const failAgentTask = `-- name: FailAgentTask :one
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = $2
 WHERE id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 type FailAgentTaskParams struct {
@@ -364,6 +388,9 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
@@ -484,7 +511,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -509,6 +536,9 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
@@ -588,7 +618,7 @@ func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPen
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('dispatched', 'running')
 ORDER BY created_at DESC
 `
@@ -620,6 +650,9 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ResultCommentID,
+			&i.Provider,
+			&i.Model,
+			&i.ThinkingLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -632,7 +665,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listActiveTasksByWorkspace = `-- name: ListActiveTasksByWorkspace :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.result_comment_id FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.result_comment_id, atq.provider, atq.model, atq.thinking_level FROM agent_task_queue atq
 JOIN issue i ON atq.issue_id = i.id
 WHERE i.workspace_id = $1 AND atq.status IN ('queued', 'dispatched', 'running')
 ORDER BY atq.created_at DESC
@@ -665,6 +698,9 @@ func (q *Queries) ListActiveTasksByWorkspace(ctx context.Context, workspaceID pg
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ResultCommentID,
+			&i.Provider,
+			&i.Model,
+			&i.ThinkingLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -677,7 +713,7 @@ func (q *Queries) ListActiveTasksByWorkspace(ctx context.Context, workspaceID pg
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -709,6 +745,9 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ResultCommentID,
+			&i.Provider,
+			&i.Model,
+			&i.ThinkingLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -817,7 +856,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -849,6 +888,9 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ResultCommentID,
+			&i.Provider,
+			&i.Model,
+			&i.ThinkingLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -861,7 +903,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -893,6 +935,9 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.WorkDir,
 			&i.TriggerCommentID,
 			&i.ResultCommentID,
+			&i.Provider,
+			&i.Model,
+			&i.ThinkingLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -939,11 +984,60 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 	return i, err
 }
 
+const setAgentTaskExecutionMetadata = `-- name: SetAgentTaskExecutionMetadata :one
+UPDATE agent_task_queue
+SET provider = COALESCE($2, provider),
+    model = COALESCE($3, model),
+    thinking_level = COALESCE($4, thinking_level)
+WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
+`
+
+type SetAgentTaskExecutionMetadataParams struct {
+	ID            pgtype.UUID `json:"id"`
+	Provider      pgtype.Text `json:"provider"`
+	Model         pgtype.Text `json:"model"`
+	ThinkingLevel pgtype.Text `json:"thinking_level"`
+}
+
+func (q *Queries) SetAgentTaskExecutionMetadata(ctx context.Context, arg SetAgentTaskExecutionMetadataParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, setAgentTaskExecutionMetadata,
+		arg.ID,
+		arg.Provider,
+		arg.Model,
+		arg.ThinkingLevel,
+	)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
+	)
+	return i, err
+}
+
 const setAgentTaskResultComment = `-- name: SetAgentTaskResultComment :one
 UPDATE agent_task_queue
 SET result_comment_id = $2
 WHERE id = $1 AND result_comment_id IS NULL
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 type SetAgentTaskResultCommentParams struct {
@@ -975,6 +1069,9 @@ func (q *Queries) SetAgentTaskResultComment(ctx context.Context, arg SetAgentTas
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }
@@ -983,7 +1080,7 @@ const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running', started_at = now()
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, result_comment_id, provider, model, thinking_level
 `
 
 func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -1007,6 +1104,9 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.WorkDir,
 		&i.TriggerCommentID,
 		&i.ResultCommentID,
+		&i.Provider,
+		&i.Model,
+		&i.ThinkingLevel,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -84,6 +84,9 @@ type AgentTaskQueue struct {
 	WorkDir          pgtype.Text        `json:"work_dir"`
 	TriggerCommentID pgtype.UUID        `json:"trigger_comment_id"`
 	ResultCommentID  pgtype.UUID        `json:"result_comment_id"`
+	Provider         pgtype.Text        `json:"provider"`
+	Model            pgtype.Text        `json:"model"`
+	ThinkingLevel    pgtype.Text        `json:"thinking_level"`
 }
 
 type Attachment struct {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -59,8 +59,8 @@ WHERE agent_id = $1
 ORDER BY created_at DESC;
 
 -- name: CreateAgentTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context)
-VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id), sqlc.narg(context))
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, context, provider)
+VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id), sqlc.narg(context), sqlc.narg(provider))
 RETURNING *;
 
 -- name: CancelAgentTasksByIssue :exec
@@ -111,8 +111,22 @@ RETURNING *;
 
 -- name: CompleteAgentTask :one
 UPDATE agent_task_queue
-SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
+SET status = 'completed',
+    completed_at = now(),
+    result = $2,
+    session_id = $3,
+    work_dir = $4,
+    model = COALESCE(sqlc.narg(model), model),
+    thinking_level = COALESCE(sqlc.narg(thinking_level), thinking_level)
 WHERE id = $1 AND status = 'running'
+RETURNING *;
+
+-- name: SetAgentTaskExecutionMetadata :one
+UPDATE agent_task_queue
+SET provider = COALESCE(sqlc.narg(provider), provider),
+    model = COALESCE(sqlc.narg(model), model),
+    thinking_level = COALESCE(sqlc.narg(thinking_level), thinking_level)
+WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
 RETURNING *;
 
 -- name: SetAgentTaskResultComment :one


### PR DESCRIPTION
## Summary
- Persist provider/model/thinking_level metadata on each agent task run.
- Have daemons report resolved execution metadata and completion overwrite with actual SDK-reported model when available.
- Surface the recorded model label in issue task run cards.

## Test plan
- `go test ./internal/daemon ./internal/service ./internal/handler`
- `pnpm --filter @multica/web exec vitest run features/issues/components/agent-live-card.test.ts`
- `make test`


Made with [Cursor](https://cursor.com)