### PR TITLE
feat(web): add running issues quick filter

### DIFF
--- a/apps/web/app/(dashboard)/issues/page.test.tsx
+++ b/apps/web/app/(dashboard)/issues/page.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Issue } from "@/shared/types";
+import type { AgentTask } from "@/shared/types/agent";
+import { useActiveTaskStore } from "@/features/issues/stores/active-task-store";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
@@ -110,9 +112,11 @@ const mockViewState = {
   assigneeFilters: [] as { type: string; id: string }[],
   includeNoAssignee: false,
   creatorFilters: [] as { type: string; id: string }[],
+  labelFilters: [] as string[],
+  runningOnly: false,
   sortBy: "position" as const,
   sortDirection: "asc" as const,
-  cardProperties: { priority: true, description: true, assignee: true, dueDate: true },
+  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, labels: true },
   listCollapsedStatuses: [] as string[],
   setViewMode: vi.fn(),
   toggleStatusFilter: vi.fn(),
@@ -120,6 +124,8 @@ const mockViewState = {
   toggleAssigneeFilter: vi.fn(),
   toggleNoAssignee: vi.fn(),
   toggleCreatorFilter: vi.fn(),
+  toggleLabelFilter: vi.fn(),
+  toggleRunningOnly: vi.fn(),
   hideStatus: vi.fn(),
   showStatus: vi.fn(),
   clearFilters: vi.fn(),
@@ -147,6 +153,7 @@ vi.mock("@/features/issues/stores/view-store", () => ({
     { key: "description", label: "Description" },
     { key: "assignee", label: "Assignee" },
     { key: "dueDate", label: "Due date" },
+    { key: "labels", label: "Labels" },
   ],
 }));
 
@@ -292,6 +299,23 @@ const mockIssues: Issue[] = [
   },
 ];
 
+function activeTaskForIssue(issueId: string): AgentTask {
+  return {
+    id: `task-${issueId}`,
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: issueId,
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: null,
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-01-01T00:00:00Z",
+  };
+}
+
 import IssuesPage from "./page";
 
 describe("IssuesPage", () => {
@@ -309,6 +333,12 @@ describe("IssuesPage", () => {
     mockViewState.viewMode = "board";
     mockViewState.statusFilters = [];
     mockViewState.priorityFilters = [];
+    mockViewState.assigneeFilters = [];
+    mockViewState.includeNoAssignee = false;
+    mockViewState.creatorFilters = [];
+    mockViewState.labelFilters = [];
+    mockViewState.runningOnly = false;
+    useActiveTaskStore.setState({ tasks: new Map() });
   });
 
   it("shows loading state initially", () => {
@@ -371,6 +401,40 @@ describe("IssuesPage", () => {
     // Filter and Display are now icon-only buttons, verify they render as buttons
     const buttons = screen.getAllByRole("button");
     expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it("filters running issues after current filters", () => {
+    mockStoreState.loading = false;
+    mockStoreState.issues = mockIssues;
+    mockViewState.runningOnly = true;
+    mockViewState.statusFilters = ["todo"];
+    useActiveTaskStore.setState({
+      tasks: new Map([
+        ["issue-1", activeTaskForIssue("issue-1")],
+        ["issue-2", activeTaskForIssue("issue-2")],
+      ]),
+    });
+
+    render(<IssuesPage />);
+
+    expect(screen.getByText("Implement auth")).toBeInTheDocument();
+    expect(screen.queryByText("Design landing page")).not.toBeInTheDocument();
+    expect(screen.queryByText("Write tests")).not.toBeInTheDocument();
+  });
+
+  it("toggles the running quick filter from the header", async () => {
+    const user = userEvent.setup();
+    mockStoreState.loading = false;
+    mockStoreState.issues = mockIssues;
+    useActiveTaskStore.setState({
+      tasks: new Map([["issue-2", activeTaskForIssue("issue-2")]]),
+    });
+
+    render(<IssuesPage />);
+
+    await user.click(screen.getByRole("button", { name: /running/i }));
+
+    expect(mockViewState.toggleRunningOnly).toHaveBeenCalledTimes(1);
   });
 
   it("shows empty board view when no issues exist", () => {

--- a/apps/web/features/issues/components/issues-header.tsx
+++ b/apps/web/features/issues/components/issues-header.tsx
@@ -54,6 +54,7 @@ import {
   CARD_PROPERTY_OPTIONS,
   type ActorFilterValue,
 } from "@/features/issues/stores/view-store";
+import { useActiveTaskStore } from "@/features/issues/stores/active-task-store";
 import {
   useIssuesScopeStore,
   type IssuesScope,
@@ -290,9 +291,11 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
   const includeNoAssignee = useIssueViewStore((s) => s.includeNoAssignee);
   const creatorFilters = useIssueViewStore((s) => s.creatorFilters);
   const labelFilters = useIssueViewStore((s) => s.labelFilters ?? []);
+  const runningOnly = useIssueViewStore((s) => s.runningOnly);
   const sortBy = useIssueViewStore((s) => s.sortBy);
   const sortDirection = useIssueViewStore((s) => s.sortDirection);
   const cardProperties = useIssueViewStore((s) => s.cardProperties);
+  const activeTasks = useActiveTaskStore((s) => s.tasks);
   const act = useIssueViewStore.getState();
 
   const allLabels = useLabelStore((s) => s.labels);
@@ -310,6 +313,26 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
 
   const sortLabel =
     SORT_OPTIONS.find((o) => o.value === sortBy)?.label ?? "Manual";
+
+  const runningCount = useMemo(() => {
+    return filterIssues(scopedIssues, {
+      statusFilters,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      labelFilters,
+    }).filter((issue) => activeTasks.has(issue.id)).length;
+  }, [
+    scopedIssues,
+    statusFilters,
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    labelFilters,
+    activeTasks,
+  ]);
 
   return (
     <div className="flex h-12 shrink-0 items-center justify-between px-2 md:px-4 gap-1">
@@ -340,6 +363,23 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
 
       {/* Right: filter + display + view toggle */}
       <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          aria-pressed={runningOnly}
+          className={
+            runningOnly
+              ? "bg-accent text-accent-foreground hover:bg-accent/80"
+              : "text-muted-foreground"
+          }
+          onClick={act.toggleRunningOnly}
+        >
+          Running
+          <span className="text-xs text-muted-foreground">
+            {runningCount}
+          </span>
+        </Button>
+
         {/* Filter */}
         <DropdownMenu>
           <Tooltip>

--- a/apps/web/features/issues/components/issues-page.tsx
+++ b/apps/web/features/issues/components/issues-page.tsx
@@ -7,6 +7,7 @@ import type { IssueStatus } from "@/shared/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useIssueStore } from "@/features/issues/store";
 import { useIssueViewStore, initFilterWorkspaceSync } from "@/features/issues/stores/view-store";
+import { useActiveTaskStore } from "@/features/issues/stores/active-task-store";
 import { useIssuesScopeStore } from "@/features/issues/stores/issues-scope-store";
 import { ViewStoreProvider } from "@/features/issues/stores/view-store-context";
 import { filterIssues } from "@/features/issues/utils/filter";
@@ -37,6 +38,8 @@ export function IssuesPage() {
   const includeNoAssignee = useIssueViewStore((s) => s.includeNoAssignee);
   const creatorFilters = useIssueViewStore((s) => s.creatorFilters);
   const labelFilters = useIssueViewStore((s) => s.labelFilters ?? []);
+  const runningOnly = useIssueViewStore((s) => s.runningOnly);
+  const activeTasks = useActiveTaskStore((s) => s.tasks);
 
   useEffect(() => {
     initFilterWorkspaceSync();
@@ -65,10 +68,28 @@ export function IssuesPage() {
     return allIssues;
   }, [allIssues, scope]);
 
-  const issues = useMemo(
-    () => filterIssues(scopedIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters }),
-    [scopedIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
-  );
+  const issues = useMemo(() => {
+    const filteredIssues = filterIssues(scopedIssues, {
+      statusFilters,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      labelFilters,
+    });
+    if (!runningOnly) return filteredIssues;
+    return filteredIssues.filter((issue) => activeTasks.has(issue.id));
+  }, [
+    scopedIssues,
+    statusFilters,
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    labelFilters,
+    runningOnly,
+    activeTasks,
+  ]);
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)

--- a/apps/web/features/issues/stores/view-store.ts
+++ b/apps/web/features/issues/stores/view-store.ts
@@ -47,6 +47,7 @@ export interface IssueViewState {
   includeNoAssignee: boolean;
   creatorFilters: ActorFilterValue[];
   labelFilters: string[];
+  runningOnly: boolean;
   sortBy: SortField;
   sortDirection: SortDirection;
   cardProperties: CardProperties;
@@ -58,6 +59,7 @@ export interface IssueViewState {
   toggleNoAssignee: () => void;
   toggleCreatorFilter: (value: ActorFilterValue) => void;
   toggleLabelFilter: (labelId: string) => void;
+  toggleRunningOnly: () => void;
   hideStatus: (status: IssueStatus) => void;
   showStatus: (status: IssueStatus) => void;
   clearFilters: () => void;
@@ -75,6 +77,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   includeNoAssignee: false,
   creatorFilters: [],
   labelFilters: [],
+  runningOnly: false,
   sortBy: "position",
   sortDirection: "asc",
   cardProperties: {
@@ -133,6 +136,8 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ? state.labelFilters.filter((id) => id !== labelId)
         : [...state.labelFilters, labelId],
     })),
+  toggleRunningOnly: () =>
+    set((state) => ({ runningOnly: !state.runningOnly })),
   hideStatus: (status) =>
     set((state) => {
       // If no filter active, activate filter with all EXCEPT this one
@@ -157,6 +162,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
       includeNoAssignee: false,
       creatorFilters: [],
       labelFilters: [],
+      runningOnly: false,
     }),
   setSortBy: (field) => set({ sortBy: field }),
   setSortDirection: (dir) => set({ sortDirection: dir }),
@@ -185,6 +191,7 @@ export const viewStorePersistOptions = (name: string) => ({
     includeNoAssignee: state.includeNoAssignee,
     creatorFilters: state.creatorFilters,
     labelFilters: state.labelFilters,
+    runningOnly: state.runningOnly,
     sortBy: state.sortBy,
     sortDirection: state.sortDirection,
     cardProperties: state.cardProperties,


### PR DESCRIPTION
## Summary
- Add a persisted Running quick filter to the issues view state.
- Render a Running button beside issue filters and intersect current filters with active agent-task issues.
- Cover the running-only behavior and header toggle in issues page tests.

## Test plan
- pnpm --filter @multica/web exec vitest run "app/(dashboard)/issues/page.test.tsx"
- make test


Made with [Cursor](https://cursor.com)