### PR TITLE
fix(routines): archive routines instead of deleting them

### DIFF
--- a/apps/web/app/(dashboard)/routines/routine-view-page.tsx
+++ b/apps/web/app/(dashboard)/routines/routine-view-page.tsx
@@ -25,7 +25,7 @@ import { RoutineRunList } from "@/features/routines";
 import { useRoutineStore } from "@/features/routines";
 import { useAuthStore } from "@/features/auth";
 import { useActorName, useWorkspaceStore } from "@/features/workspace";
-import { Loader2, MoreHorizontal, Pencil, Play, Sparkles, Trash2 } from "lucide-react";
+import { Archive, Loader2, MoreHorizontal, Pencil, Play, Sparkles } from "lucide-react";
 import { api } from "@/shared/api";
 import type { Routine, RoutineRun } from "@/shared/types";
 import { toast } from "sonner";
@@ -42,9 +42,9 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
   const [runs, setRuns] = useState<RoutineRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [triggering, setTriggering] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [archiving, setArchiving] = useState(false);
   const [updatingStatus, setUpdatingStatus] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
   const [loadingMoreRuns, setLoadingMoreRuns] = useState(false);
   const [hasMoreRuns, setHasMoreRuns] = useState(true);
   const [nextRunOffset, setNextRunOffset] = useState(0);
@@ -118,17 +118,17 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
     }
   }
 
-  async function handleDelete() {
+  async function handleArchive() {
     if (!routine) return;
-    setDeleting(true);
+    setArchiving(true);
     try {
-      await api.deleteRoutine(routine.id);
+      await api.archiveRoutine(routine.id);
       useRoutineStore.getState().remove(routine.id);
-      toast.success("Routine deleted");
+      toast.success("Routine archived");
       router.push("/routines");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to delete routine");
-      setDeleting(false);
+      toast.error(error instanceof Error ? error.message : "Failed to archive routine");
+      setArchiving(false);
     }
   }
 
@@ -167,7 +167,7 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
             </div>
             {routine && canManageRoutines && (
               <div className="flex flex-wrap items-center justify-end gap-2">
-                <Button variant="outline" onClick={handleTrigger} disabled={!routine.enabled || triggering || deleting}>
+                <Button variant="outline" onClick={handleTrigger} disabled={!routine.enabled || triggering || archiving}>
                   <Play className="size-4" />
                   {triggering ? "Running..." : "Run now"}
                 </Button>
@@ -182,7 +182,7 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
                         variant="outline"
                         size="icon"
                         aria-label="More actions"
-                        disabled={triggering || deleting}
+                        disabled={triggering || archiving}
                       />
                     }
                   >
@@ -191,10 +191,10 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
                       variant="destructive"
-                      onClick={() => setDeleteOpen(true)}
+                      onClick={() => setArchiveOpen(true)}
                     >
-                      <Trash2 className="size-4" />
-                      Delete
+                      <Archive className="size-4" />
+                      Archive
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
@@ -216,7 +216,7 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
                 <div className="rounded-xl border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
                   <span className="font-medium text-foreground">System routine</span>
                   {" · "}
-                  Managed by Multica and provisioned by the GitHub App connection. It cannot be edited or deleted.
+                  Managed by Multica and provisioned by the GitHub App connection. It cannot be edited or archived.
                 </div>
               ) : !canManageRoutines ? (
                 <div className="rounded-xl border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
@@ -296,22 +296,22 @@ export function RoutineViewPage({ routineID }: { routineID: string }) {
           )}
         </div>
       </main>
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+      <AlertDialog open={archiveOpen} onOpenChange={setArchiveOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete routine</AlertDialogTitle>
+            <AlertDialogTitle>Archive routine</AlertDialogTitle>
             <AlertDialogDescription>
-              This will permanently delete {routine?.name ?? "this routine"}. Existing issues created by the routine are kept.
+              This will hide {routine?.name ?? "this routine"} from routine lists and stop its triggers. Existing issues and run history are kept.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={archiving}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleDelete}
-              disabled={deleting}
+              onClick={handleArchive}
+              disabled={archiving}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Delete routine
+              Archive routine
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/features/routines/store.test.ts
+++ b/apps/web/features/routines/store.test.ts
@@ -41,6 +41,7 @@ function makeRoutine(id: string, workspaceId: string): Routine {
     github_auto_fix_enabled: false,
     enabled: true,
     managed: false,
+    archived_at: null,
     created_by_id: "user-1",
     created_by_type: "member",
     subscriber_ids: [],

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -977,7 +977,7 @@ export class ApiClient {
     });
   }
 
-  async deleteRoutine(id: string): Promise<void> {
+  async archiveRoutine(id: string): Promise<void> {
     await this.fetch(`/api/routines/${id}`, { method: "DELETE" });
   }
 

--- a/apps/web/shared/types/routine.ts
+++ b/apps/web/shared/types/routine.ts
@@ -53,6 +53,7 @@ export interface Routine {
   github_auto_fix_enabled: boolean;
   enabled: boolean;
   managed: boolean;
+  archived_at: string | null;
   created_by_id: string;
   created_by_type: string;
   subscriber_ids: string[];

--- a/server/cmd/multica/cmd_routine.go
+++ b/server/cmd/multica/cmd_routine.go
@@ -50,7 +50,7 @@ var routineUpdateCmd = &cobra.Command{
 
 var routineDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
-	Short: "Delete a routine",
+	Short: "Archive a routine",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runRoutineDelete,
 }
@@ -304,9 +304,9 @@ func runRoutineDelete(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	if err := client.DeleteJSON(ctx, "/api/routines/"+args[0]); err != nil {
-		return fmt.Errorf("delete routine: %w", err)
+		return fmt.Errorf("archive routine: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Routine %s deleted.\n", truncateID(args[0]))
+	fmt.Fprintf(os.Stderr, "Routine %s archived.\n", truncateID(args[0]))
 	return nil
 }
 

--- a/server/internal/handler/routine.go
+++ b/server/internal/handler/routine.go
@@ -55,6 +55,7 @@ type RoutineResponse struct {
 	Enabled              bool                     `json:"enabled"`
 	GithubAutoFixEnabled bool                     `json:"github_auto_fix_enabled"`
 	Managed              bool                     `json:"managed"`
+	ArchivedAt           *string                  `json:"archived_at"`
 	CreatedByID          string                   `json:"created_by_id"`
 	CreatedByType        string                   `json:"created_by_type"`
 	CreatedAt            string                   `json:"created_at"`
@@ -202,6 +203,7 @@ func routineToResponse(r db.Routine, subscriberIDs, labelIDs []string, triggers 
 		Enabled:              r.Enabled,
 		GithubAutoFixEnabled: r.GithubAutoFixEnabled,
 		Managed:              r.Managed,
+		ArchivedAt:           timestampToPtr(r.ArchivedAt),
 		CreatedByID:          uuidToString(r.CreatedByID),
 		CreatedByType:        r.CreatedByType,
 		CreatedAt:            timestampToString(r.CreatedAt),
@@ -398,14 +400,14 @@ func (h *Handler) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if existing.Managed {
-		writeError(w, http.StatusForbidden, "managed routines cannot be deleted")
+		writeError(w, http.StatusForbidden, "managed routines cannot be archived")
 		return
 	}
 	if err := h.Queries.DeleteRoutine(r.Context(), db.DeleteRoutineParams{
 		ID:          id,
 		WorkspaceID: parseUUID(workspaceID),
 	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete routine")
+		writeError(w, http.StatusInternalServerError, "failed to archive routine")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/server/internal/handler/routine_test.go
+++ b/server/internal/handler/routine_test.go
@@ -116,6 +116,92 @@ func TestRoutineCRUD_CreateGetAndRunList(t *testing.T) {
 	}
 }
 
+func TestDeleteRoutineArchivesAndPreservesRuns(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("test database not available")
+	}
+
+	ctx := context.Background()
+	var agentID string
+	if err := testPool.QueryRow(ctx, `SELECT id::text FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("find agent: %v", err)
+	}
+	w := httptest.NewRecorder()
+	req := routineRequest(t, "POST", "/api/routines", map[string]any{
+		"name":          "Routine archive test",
+		"instructions":  "Archive instead of delete",
+		"priority":      "medium",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+		"enabled":       true,
+		"triggers": []map[string]any{
+			{
+				"trigger_type": "schedule",
+				"schedule":     "0 9 * * 1",
+				"timezone":     "UTC",
+			},
+		},
+	})
+	testHandler.CreateRoutine(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateRoutine: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var routine RoutineResponse
+	if err := json.NewDecoder(w.Body).Decode(&routine); err != nil {
+		t.Fatalf("decode routine: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM routine WHERE id = $1`, routine.ID)
+	})
+
+	run, err := testHandler.Queries.CreateRoutineRun(ctx, db.CreateRoutineRunParams{
+		RoutineID: parseUUID(routine.ID),
+		TriggerID: parseUUID(routine.Triggers[0].ID),
+		ActionID:  parseUUID(routine.Actions[0].ID),
+		EventType: "routine.archive.test",
+		DedupKey:  "routine-archive-test",
+		Payload:   []byte(`{}`),
+		Status:    "processed",
+	})
+	if err != nil {
+		t.Fatalf("CreateRoutineRun: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = routineRequest(t, "DELETE", "/api/routines/"+routine.ID, nil)
+	req = withURLParam(req, "id", routine.ID)
+	testHandler.DeleteRoutine(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteRoutine: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var archived bool
+	if err := testPool.QueryRow(ctx, `SELECT archived_at IS NOT NULL FROM routine WHERE id = $1`, routine.ID).Scan(&archived); err != nil {
+		t.Fatalf("query archived routine: %v", err)
+	}
+	if !archived {
+		t.Fatal("expected routine to be archived")
+	}
+
+	routines, err := testHandler.Queries.ListRoutines(ctx, parseUUID(testWorkspaceID))
+	if err != nil {
+		t.Fatalf("ListRoutines: %v", err)
+	}
+	for _, listed := range routines {
+		if uuidToString(listed.ID) == routine.ID {
+			t.Fatalf("archived routine %s should not appear in ListRoutines", routine.ID)
+		}
+	}
+
+	var runExists bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM routine_run WHERE id = $1)`, uuidToString(run.ID)).Scan(&runExists); err != nil {
+		t.Fatalf("query routine run: %v", err)
+	}
+	if !runExists {
+		t.Fatal("expected routine run history to be preserved")
+	}
+}
+
 func TestListRoutineEventsPaginatesWorkspaceEventLog(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("test database not available")

--- a/server/migrations/073_routine_archive.down.sql
+++ b/server/migrations/073_routine_archive.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_routine_workspace_active;
+
+ALTER TABLE routine DROP COLUMN IF EXISTS archived_at;

--- a/server/migrations/073_routine_archive.up.sql
+++ b/server/migrations/073_routine_archive.up.sql
@@ -1,0 +1,6 @@
+-- Add archive support to routines (soft-delete replacement).
+-- archived_at IS NOT NULL means the routine is hidden from normal reads and triggers.
+ALTER TABLE routine ADD COLUMN archived_at TIMESTAMPTZ DEFAULT NULL;
+
+CREATE INDEX idx_routine_workspace_active ON routine(workspace_id, created_at DESC)
+    WHERE archived_at IS NULL;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -309,6 +309,7 @@ type Routine struct {
 	UpdatedAt            pgtype.Timestamptz `json:"updated_at"`
 	GithubAutoFixEnabled bool               `json:"github_auto_fix_enabled"`
 	Managed              bool               `json:"managed"`
+	ArchivedAt           pgtype.Timestamptz `json:"archived_at"`
 }
 
 type RoutineAction struct {

--- a/server/pkg/db/generated/routine.sql.go
+++ b/server/pkg/db/generated/routine.sql.go
@@ -48,11 +48,17 @@ UPDATE routine_trigger
 SET last_triggered_at = now(),
     next_run_at       = $3,
     updated_at        = now()
-WHERE id = $1
+WHERE routine_trigger.id = $1
   AND next_run_at = $2
   AND trigger_type = 'schedule'
   AND enabled = TRUE
   AND (max_runs IS NULL OR successful_runs_count < max_runs)
+  AND EXISTS (
+      SELECT 1 FROM routine r
+      WHERE r.id = routine_trigger.routine_id
+        AND r.enabled = TRUE
+        AND r.archived_at IS NULL
+  )
 RETURNING id, routine_id, trigger_type, source_type, token_hash, token_prefix, installation_id, schedule, timezone, run_at, next_run_at, last_triggered_at, dedup_window_seconds, max_runs, successful_runs_count, config, enabled, created_at, updated_at
 `
 
@@ -146,7 +152,7 @@ INSERT INTO routine (
 ) VALUES (
     $1, $2, 'medium', TRUE, TRUE, $3, $4
 )
-RETURNING id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed
+RETURNING id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at
 `
 
 type CreateManagedRoutineParams struct {
@@ -183,6 +189,7 @@ func (q *Queries) CreateManagedRoutine(ctx context.Context, arg CreateManagedRou
 		&i.UpdatedAt,
 		&i.GithubAutoFixEnabled,
 		&i.Managed,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
@@ -196,7 +203,7 @@ INSERT INTO routine (
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
 )
-RETURNING id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed
+RETURNING id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at
 `
 
 type CreateRoutineParams struct {
@@ -253,6 +260,7 @@ func (q *Queries) CreateRoutine(ctx context.Context, arg CreateRoutineParams) (R
 		&i.UpdatedAt,
 		&i.GithubAutoFixEnabled,
 		&i.Managed,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
@@ -589,8 +597,10 @@ func (q *Queries) DeleteManagedRoutineByWorkspace(ctx context.Context, workspace
 }
 
 const deleteRoutine = `-- name: DeleteRoutine :exec
-DELETE FROM routine
-WHERE id = $1 AND workspace_id = $2
+UPDATE routine
+SET archived_at = now(),
+    updated_at = now()
+WHERE id = $1 AND workspace_id = $2 AND archived_at IS NULL
 `
 
 type DeleteRoutineParams struct {
@@ -646,8 +656,8 @@ func (q *Queries) FindRecentRoutineRun(ctx context.Context, arg FindRecentRoutin
 }
 
 const getManagedRoutineByWorkspace = `-- name: GetManagedRoutineByWorkspace :one
-SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed FROM routine
-WHERE workspace_id = $1 AND managed = TRUE
+SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at FROM routine
+WHERE workspace_id = $1 AND managed = TRUE AND archived_at IS NULL
 ORDER BY created_at ASC
 LIMIT 1
 `
@@ -674,13 +684,14 @@ func (q *Queries) GetManagedRoutineByWorkspace(ctx context.Context, workspaceID 
 		&i.UpdatedAt,
 		&i.GithubAutoFixEnabled,
 		&i.Managed,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
 
 const getRoutine = `-- name: GetRoutine :one
-SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed FROM routine
-WHERE id = $1
+SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at FROM routine
+WHERE id = $1 AND archived_at IS NULL
 `
 
 func (q *Queries) GetRoutine(ctx context.Context, id pgtype.UUID) (Routine, error) {
@@ -705,6 +716,7 @@ func (q *Queries) GetRoutine(ctx context.Context, id pgtype.UUID) (Routine, erro
 		&i.UpdatedAt,
 		&i.GithubAutoFixEnabled,
 		&i.Managed,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
@@ -731,8 +743,8 @@ func (q *Queries) GetRoutineAction(ctx context.Context, id pgtype.UUID) (Routine
 }
 
 const getRoutineInWorkspace = `-- name: GetRoutineInWorkspace :one
-SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed FROM routine
-WHERE id = $1 AND workspace_id = $2
+SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at FROM routine
+WHERE id = $1 AND workspace_id = $2 AND archived_at IS NULL
 `
 
 type GetRoutineInWorkspaceParams struct {
@@ -762,6 +774,7 @@ func (q *Queries) GetRoutineInWorkspace(ctx context.Context, arg GetRoutineInWor
 		&i.UpdatedAt,
 		&i.GithubAutoFixEnabled,
 		&i.Managed,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
@@ -951,7 +964,7 @@ const getRoutineTriggerInWorkspace = `-- name: GetRoutineTriggerInWorkspace :one
 SELECT rt.id, rt.routine_id, rt.trigger_type, rt.source_type, rt.token_hash, rt.token_prefix, rt.installation_id, rt.schedule, rt.timezone, rt.run_at, rt.next_run_at, rt.last_triggered_at, rt.dedup_window_seconds, rt.max_runs, rt.successful_runs_count, rt.config, rt.enabled, rt.created_at, rt.updated_at
 FROM routine_trigger rt
 JOIN routine r ON r.id = rt.routine_id
-WHERE rt.id = $1 AND r.workspace_id = $2
+WHERE rt.id = $1 AND r.workspace_id = $2 AND r.archived_at IS NULL
 `
 
 type GetRoutineTriggerInWorkspaceParams struct {
@@ -1030,6 +1043,7 @@ SELECT rt.id, rt.routine_id, rt.trigger_type, rt.source_type, rt.token_hash, rt.
 FROM routine_trigger rt
 JOIN routine r ON r.id = rt.routine_id
 WHERE r.enabled = TRUE
+  AND r.archived_at IS NULL
   AND rt.enabled = TRUE
   AND rt.trigger_type = 'schedule'
   AND rt.next_run_at IS NOT NULL
@@ -1446,6 +1460,7 @@ JOIN routine r ON r.id = rt.routine_id
 WHERE rt.trigger_type = 'github'
   AND rt.installation_id = $1
   AND r.enabled = TRUE
+  AND r.archived_at IS NULL
   AND rt.enabled = TRUE
 ORDER BY rt.created_at
 `
@@ -1497,6 +1512,7 @@ JOIN routine r ON r.id = rt.routine_id
 WHERE r.workspace_id = $1
   AND rt.trigger_type = $2
   AND r.enabled = TRUE
+  AND r.archived_at IS NULL
   AND rt.enabled = TRUE
 ORDER BY rt.created_at
 `
@@ -1547,8 +1563,9 @@ func (q *Queries) ListRoutineTriggersByTypeAndWorkspace(ctx context.Context, arg
 }
 
 const listRoutines = `-- name: ListRoutines :many
-SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed FROM routine
+SELECT id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at FROM routine
 WHERE workspace_id = $1
+  AND archived_at IS NULL
 ORDER BY created_at DESC
 `
 
@@ -1580,6 +1597,7 @@ func (q *Queries) ListRoutines(ctx context.Context, workspaceID pgtype.UUID) ([]
 			&i.UpdatedAt,
 			&i.GithubAutoFixEnabled,
 			&i.Managed,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1605,8 +1623,8 @@ UPDATE routine SET
     enabled               = $11,
     github_auto_fix_enabled = $12,
     updated_at            = now()
-WHERE id = $1 AND workspace_id = $13
-RETURNING id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed
+WHERE id = $1 AND workspace_id = $13 AND archived_at IS NULL
+RETURNING id, workspace_id, name, instructions, priority, assignee_type, assignee_id, due_date_offset_hours, dispatch_provider, dispatch_daemon_id, dispatch_daemon_label, enabled, created_by_id, created_by_type, created_at, updated_at, github_auto_fix_enabled, managed, archived_at
 `
 
 type UpdateRoutineParams struct {
@@ -1661,6 +1679,7 @@ func (q *Queries) UpdateRoutine(ctx context.Context, arg UpdateRoutineParams) (R
 		&i.UpdatedAt,
 		&i.GithubAutoFixEnabled,
 		&i.Managed,
+		&i.ArchivedAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/routine.sql
+++ b/server/pkg/db/queries/routine.sql
@@ -19,7 +19,7 @@ RETURNING *;
 
 -- name: GetManagedRoutineByWorkspace :one
 SELECT * FROM routine
-WHERE workspace_id = $1 AND managed = TRUE
+WHERE workspace_id = $1 AND managed = TRUE AND archived_at IS NULL
 ORDER BY created_at ASC
 LIMIT 1;
 
@@ -29,15 +29,16 @@ WHERE workspace_id = $1 AND managed = TRUE;
 
 -- name: GetRoutineInWorkspace :one
 SELECT * FROM routine
-WHERE id = $1 AND workspace_id = $2;
+WHERE id = $1 AND workspace_id = $2 AND archived_at IS NULL;
 
 -- name: GetRoutine :one
 SELECT * FROM routine
-WHERE id = $1;
+WHERE id = $1 AND archived_at IS NULL;
 
 -- name: ListRoutines :many
 SELECT * FROM routine
 WHERE workspace_id = $1
+  AND archived_at IS NULL
 ORDER BY created_at DESC;
 
 -- name: UpdateRoutine :one
@@ -54,12 +55,14 @@ UPDATE routine SET
     enabled               = $11,
     github_auto_fix_enabled = $12,
     updated_at            = now()
-WHERE id = $1 AND workspace_id = $13
+WHERE id = $1 AND workspace_id = $13 AND archived_at IS NULL
 RETURNING *;
 
 -- name: DeleteRoutine :exec
-DELETE FROM routine
-WHERE id = $1 AND workspace_id = $2;
+UPDATE routine
+SET archived_at = now(),
+    updated_at = now()
+WHERE id = $1 AND workspace_id = $2 AND archived_at IS NULL;
 
 -- name: CreateRoutineTrigger :one
 INSERT INTO routine_trigger (
@@ -89,7 +92,7 @@ WHERE id = $1;
 SELECT rt.*
 FROM routine_trigger rt
 JOIN routine r ON r.id = rt.routine_id
-WHERE rt.id = $1 AND r.workspace_id = $2;
+WHERE rt.id = $1 AND r.workspace_id = $2 AND r.archived_at IS NULL;
 
 -- name: GetRoutineTriggerByTokenHash :one
 SELECT * FROM routine_trigger
@@ -107,6 +110,7 @@ JOIN routine r ON r.id = rt.routine_id
 WHERE r.workspace_id = $1
   AND rt.trigger_type = $2
   AND r.enabled = TRUE
+  AND r.archived_at IS NULL
   AND rt.enabled = TRUE
 ORDER BY rt.created_at;
 
@@ -117,6 +121,7 @@ JOIN routine r ON r.id = rt.routine_id
 WHERE rt.trigger_type = 'github'
   AND rt.installation_id = $1
   AND r.enabled = TRUE
+  AND r.archived_at IS NULL
   AND rt.enabled = TRUE
 ORDER BY rt.created_at;
 
@@ -147,6 +152,7 @@ SELECT rt.*
 FROM routine_trigger rt
 JOIN routine r ON r.id = rt.routine_id
 WHERE r.enabled = TRUE
+  AND r.archived_at IS NULL
   AND rt.enabled = TRUE
   AND rt.trigger_type = 'schedule'
   AND rt.next_run_at IS NOT NULL
@@ -160,11 +166,17 @@ UPDATE routine_trigger
 SET last_triggered_at = now(),
     next_run_at       = $3,
     updated_at        = now()
-WHERE id = $1
+WHERE routine_trigger.id = $1
   AND next_run_at = $2
   AND trigger_type = 'schedule'
   AND enabled = TRUE
   AND (max_runs IS NULL OR successful_runs_count < max_runs)
+  AND EXISTS (
+      SELECT 1 FROM routine r
+      WHERE r.id = routine_trigger.routine_id
+        AND r.enabled = TRUE
+        AND r.archived_at IS NULL
+  )
 RETURNING *;
 
 -- name: IncrementRoutineTriggerSuccess :one


### PR DESCRIPTION
## Summary
- Change routine deletion to archive routines by setting `archived_at`, preserving routine rows and run history.
- Hide archived routines from normal list/read/update/trigger paths so they stop running after archive.
- Update web and CLI wording from delete to archive.

## Test plan
- `make test`


Made with [Cursor](https://cursor.com)